### PR TITLE
feat(cli): make every GUI hint reachable from the Web CLI, and guard it

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "lint": "biome lint .",
     "lint:tokens": "bun scripts/check-design-tokens.mjs",
     "format": "biome format --write .",
-    "check": "biome check . && bun scripts/check-guard-floors.mjs && bun scripts/check-design-tokens.mjs && bun scripts/check-modal-focus-trap.mjs && bun scripts/check-discover-blurbs.mjs && bun scripts/check-discover-axes.mjs && bun scripts/check-message-codes.mjs && bun scripts/check-move-zone-fields.mjs && bun scripts/check-hint-coverage.mjs && bun scripts/check-hint-reasons.mjs && bun scripts/check-markdown-tables.mjs && bun scripts/check-hint-gate.mjs && bun scripts/check-dependency-licenses.mjs && bun scripts/check-trademark-terms.mjs && bun scripts/check-asset-provenance.mjs && bun scripts/check-codecov-uploads.mjs && bun scripts/check-mermaid.mjs && bun scripts/check-design-doc-identifiers.mjs",
+    "check": "biome check . && bun scripts/check-guard-floors.mjs && bun scripts/check-design-tokens.mjs && bun scripts/check-modal-focus-trap.mjs && bun scripts/check-discover-blurbs.mjs && bun scripts/check-discover-axes.mjs && bun scripts/check-message-codes.mjs && bun scripts/check-move-zone-fields.mjs && bun scripts/check-hint-coverage.mjs && bun scripts/check-hint-reasons.mjs && bun scripts/check-markdown-tables.mjs && bun scripts/check-hint-gate.mjs && bun scripts/check-cli-hint-reachable.mjs && bun scripts/check-dependency-licenses.mjs && bun scripts/check-trademark-terms.mjs && bun scripts/check-asset-provenance.mjs && bun scripts/check-codecov-uploads.mjs && bun scripts/check-mermaid.mjs && bun scripts/check-design-doc-identifiers.mjs",
     "check:write": "biome check --write .",
     "preview": "vite preview",
     "test": "vitest run",

--- a/frontend/scripts/check-cli-hint-reachable.mjs
+++ b/frontend/scripts/check-cli-hint-reachable.mjs
@@ -38,11 +38,11 @@ const FIXTURE = process.env.CLI_HINT_GUARD_ROOT !== undefined;
  * An entry is a claim that the page has no CLI hint to expose, not a to-do.
  */
 const ALLOWED = new Map([
-  [
-    'Memory',
-    'useGameHint を hintEnabled/setHintEnabled のためだけに使い、hint 自体を' +
-      ' 受け取らない。出すヒントが存在しない。',
-  ],
+  // Empty on purpose. The first version exempted Memory on the claim that it
+  // never receives a hint -- wrong: it computes `frontendHint` from
+  // getMemoryHint() instead of taking it from useGameHint, so the exemption was
+  // hiding a real gap rather than describing one. An entry here must be a claim
+  // that the page has no hint at all, verified against how it renders one.
 ]);
 
 /** Reads a directory, returning [] when it does not exist. */
@@ -78,16 +78,28 @@ for (const f of pageFiles) {
   const name = f.replace(/Page\.tsx$/, '');
 
   // Only pages that actually have a hint to show, and a CLI to show it in.
-  if (!src.includes('useGameHint') || !src.includes('parseCommand:')) continue;
-  if (!/\bhint\b\s*[,:}]/.test(src.split('useGameHint')[0].slice(-400))) {
-    // `hint` is not among the destructured names -- nothing to expose.
-    if (!/const\s*\{[^}]*\bhint\b/.test(src)) continue;
-  }
+  if (!src.includes('parseCommand:')) continue;
+
+  // "Has a hint" is not the same as "destructures `hint` from useGameHint".
+  // MemoryPage computes its own via getMemoryHint() and renders it through
+  // FrontendHintTooltip; keying on the destructure skipped it silently, so the
+  // guard reported every page reachable while never looking at it.
+  const hasHint =
+    /const\s*\{[^}]*\bhint\b[^}]*\}\s*=\s*useGameHint/.test(src) ||
+    /\bhint:\s*\w+[^}]*\}\s*=\s*useGameHint/.test(src) ||
+    /FrontendHintTooltip/.test(src) ||
+    /\bget\w+Hint\(/.test(src);
+  if (!hasHint) continue;
   if (ALLOWED.has(name)) continue;
   checked += 1;
 
-  // (a) the page answers locally
-  if (src.includes('hintCliText')) continue;
+  // (a) the page answers locally.
+  //
+  // Both halves are required: an `import { hintCliText }` on its own satisfied
+  // the first version of this check, so deleting the localCommand line left the
+  // guard green with a dangling import. Verified by removing that line from
+  // MemoryPage -- the guard has to notice.
+  if (/localCommand:/.test(src) && /hintCliText\(/.test(src)) continue;
 
   // (b) the page defines its parser inline and handles hint there. Several
   // solitaire pages keep `parseXCommand` in the page file rather than in a

--- a/frontend/scripts/check-cli-hint-reachable.mjs
+++ b/frontend/scripts/check-cli-hint-reachable.mjs
@@ -95,11 +95,11 @@ for (const f of pageFiles) {
 
   // (a) the page answers locally.
   //
-  // Both halves are required: an `import { hintCliText }` on its own satisfied
-  // the first version of this check, so deleting the localCommand line left the
-  // guard green with a dangling import. Verified by removing that line from
-  // MemoryPage -- the guard has to notice.
-  if (/localCommand:/.test(src) && /hintCliText\(/.test(src)) continue;
+  // Matched as one expression on purpose. An earlier version accepted an
+  // `import { hintCliText }` on its own, so deleting the localCommand line left
+  // a dangling import and the guard stayed green. Requiring the wiring itself
+  // means a page cannot satisfy this by importing something it never uses.
+  if (/localCommand:\s*hintLocalCommand\(/.test(src)) continue;
 
   // (b) the page defines its parser inline and handles hint there. Several
   // solitaire pages keep `parseXCommand` in the page file rather than in a

--- a/frontend/scripts/check-cli-hint-reachable.mjs
+++ b/frontend/scripts/check-cli-hint-reachable.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env bun
+// Guard that a page offering hints in the GUI also offers them in the CLI.
+//
+// Switching a game to CLI mode used to lose the feature silently: the page
+// wires `useGameHint` and shows a HintToggle, but the CLI had no `hint`
+// command, so typing it answered "Unknown command". 121 games were in that
+// state (#5473).
+//
+// There are two legitimate ways to answer, and a page needs exactly one:
+//
+//   - the game's parser module handles `hint` and forwards it to the backend
+//     (#5791, #5792) -- available when the Web controller dispatches hint;
+//   - the page passes `localCommand` using `hintCliText`, answering from the
+//     client-side `useGameHint` result (#5793) -- for games whose backend has
+//     no hint action at all.
+//
+// Neither half is visible to the other: a page can wire `localCommand` while
+// its parser rejects the word, and a parser can accept `hint` while the page
+// never renders one. This checks the property the player actually experiences
+// -- that *some* path exists -- rather than either mechanism.
+
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { assertFloor } from './lib/floor.mjs';
+
+// CLI_HINT_GUARD_ROOT lets the guard's own test point it at a fixture tree.
+// Without it the guard could only be tested against the real repo, where every
+// case passes and a broken detector would look identical to a clean codebase.
+const FRONTEND = process.env.CLI_HINT_GUARD_ROOT ?? fileURLToPath(new URL('..', import.meta.url));
+const PAGES = join(FRONTEND, 'src/pages');
+const COMMANDS = join(FRONTEND, 'src/utils/cli/commands');
+const FIXTURE = process.env.CLI_HINT_GUARD_ROOT !== undefined;
+
+/**
+ * Pages exempt from the rule, each with the reason it cannot apply.
+ *
+ * An entry is a claim that the page has no CLI hint to expose, not a to-do.
+ */
+const ALLOWED = new Map([
+  [
+    'Memory',
+    'useGameHint を hintEnabled/setHintEnabled のためだけに使い、hint 自体を' +
+      ' 受け取らない。出すヒントが存在しない。',
+  ],
+]);
+
+/** Reads a directory, returning [] when it does not exist. */
+async function listFiles(dir) {
+  try {
+    return await readdir(dir);
+  } catch {
+    return [];
+  }
+}
+
+const pageFiles = (await listFiles(PAGES)).filter((f) => f.endsWith('Page.tsx'));
+if (!FIXTURE) assertFloor('cli-hint-reachable', pageFiles.length, 200, 'game pages scanned');
+
+const commandFiles = (await listFiles(COMMANDS)).filter((f) => f.endsWith('Commands.ts') && !f.endsWith('.test.ts'));
+if (!FIXTURE) assertFloor('cli-hint-reachable', commandFiles.length, 180, 'CLI command modules scanned');
+
+// Modules that answer `hint` themselves, plus the ones they re-export it through.
+const answersHint = new Set();
+const shared = new Set();
+for (const f of commandFiles) {
+  const src = await readFile(join(COMMANDS, f), 'utf8');
+  if (src.includes("'hint'")) {
+    answersHint.add(f.replace(/Commands\.ts$/, ''));
+    if (f.startsWith('shared')) shared.add(f.replace(/\.ts$/, ''));
+  }
+}
+
+let checked = 0;
+const missing = [];
+for (const f of pageFiles) {
+  const src = await readFile(join(PAGES, f), 'utf8');
+  const name = f.replace(/Page\.tsx$/, '');
+
+  // Only pages that actually have a hint to show, and a CLI to show it in.
+  if (!src.includes('useGameHint') || !src.includes('parseCommand:')) continue;
+  if (!/\bhint\b\s*[,:}]/.test(src.split('useGameHint')[0].slice(-400))) {
+    // `hint` is not among the destructured names -- nothing to expose.
+    if (!/const\s*\{[^}]*\bhint\b/.test(src)) continue;
+  }
+  if (ALLOWED.has(name)) continue;
+  checked += 1;
+
+  // (a) the page answers locally
+  if (src.includes('hintCliText')) continue;
+
+  // (b) the page defines its parser inline and handles hint there. Several
+  // solitaire pages keep `parseXCommand` in the page file rather than in a
+  // commands module, so looking only at src/utils/cli/commands/ reports them
+  // as missing when they have handled hint all along.
+  if (/function parse\w+Command/.test(src) && /case 'hint':/.test(src)) continue;
+
+  // (c) its parser module answers, directly or via a shared module it imports
+  const mod = src.match(/from '\.\.\/utils\/cli\/commands\/(\w+)Commands'/);
+  if (mod && answersHint.has(mod[1])) continue;
+  if (mod) {
+    const modSrc = await readFile(join(COMMANDS, `${mod[1]}Commands.ts`), 'utf8').catch(() => '');
+    if ([...shared].some((s) => modSrc.includes(`./${s}`))) continue;
+  }
+
+  missing.push(name);
+}
+
+if (!FIXTURE) assertFloor('cli-hint-reachable', checked, 150, 'pages with both a hint and a CLI');
+
+if (missing.length > 0) {
+  console.error(
+    `cli-hint-reachable: ${missing.length} page(s) show hints in the GUI but expose no way to ask ` +
+      "for one in CLI mode. Either add a `hint` case to the game's *Commands.ts (when its Web " +
+      'controller dispatches hint) or pass `localCommand` with `hintCliText` (when it does not):\n' +
+      missing.map((m) => `  - ${m}Page.tsx`).join('\n'),
+  );
+  process.exit(1);
+}
+
+console.log(
+  `cli-hint-reachable: OK (${checked} of ${pageFiles.length} pages have both a hint and a CLI; ` +
+    `all reachable, ${ALLOWED.size} documented exemption(s)).`,
+);

--- a/frontend/scripts/check-cli-hint-reachable.test.mjs
+++ b/frontend/scripts/check-cli-hint-reachable.test.mjs
@@ -59,12 +59,24 @@ describe('check-cli-hint-reachable', () => {
     expect(r.status).toBe(0);
   });
 
-  it('passes when the page answers locally with hintCliText', () => {
+  it('passes when the page answers locally via hintLocalCommand', () => {
     const r = run({
-      pages: { 'XPage.tsx': page('x', 'localCommand: (i) => hintCliText(hint),') },
+      pages: { 'XPage.tsx': page('x', 'localCommand: hintLocalCommand(hint),') },
       commands: { 'xCommands.ts': "case 'play': return { args: ['play'] };" },
     });
     expect(r.status).toBe(0);
+  });
+
+  it('rejects a page that imports the helper but never wires it', () => {
+    // The dangling-import case: an earlier version accepted the import alone.
+    const r = run({
+      pages: {
+        'XPage.tsx': page('x', "// import { hintLocalCommand } from '../utils/cli/hintText';"),
+      },
+      commands: { 'xCommands.ts': "case 'play': return { args: ['play'] };" },
+    });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('XPage.tsx');
   });
 
   it('passes when the page parses inline and handles hint there', () => {

--- a/frontend/scripts/check-cli-hint-reachable.test.mjs
+++ b/frontend/scripts/check-cli-hint-reachable.test.mjs
@@ -1,0 +1,108 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+
+// vitest の root は `frontend/` なので cwd から解決する。パスを誤ると全ケースが
+// 「無いファイルを spawn した」になり、落ちてほしいケースが落ちて見えるだけになる。
+const SCRIPTS = join(process.cwd(), 'scripts');
+const GUARD = join(SCRIPTS, 'check-cli-hint-reachable.mjs');
+if (!existsSync(GUARD)) throw new Error(`guard not found at ${GUARD} (cwd: ${process.cwd()})`);
+
+const dirs = [];
+afterAll(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+});
+
+/** Builds a fixture tree and runs the guard against it. */
+function run({ pages = {}, commands = {} }) {
+  const root = mkdtempSync(join(tmpdir(), 'cli-hint-guard-'));
+  dirs.push(root);
+  mkdirSync(join(root, 'src/pages'), { recursive: true });
+  mkdirSync(join(root, 'src/utils/cli/commands'), { recursive: true });
+  for (const [name, body] of Object.entries(pages)) {
+    writeFileSync(join(root, 'src/pages', name), body);
+  }
+  for (const [name, body] of Object.entries(commands)) {
+    writeFileSync(join(root, 'src/utils/cli/commands', name), body);
+  }
+  return spawnSync('bun', [GUARD], {
+    encoding: 'utf8',
+    env: { ...process.env, CLI_HINT_GUARD_ROOT: root },
+  });
+}
+
+/** A page with a hint and a CLI, importing the named command module. */
+const page = (mod, extra = '') => `
+  import { parseXCommand } from '../utils/cli/commands/${mod}Commands';
+  const { hint, hintEnabled } = useGameHint('x', state);
+  const cfg = { parseCommand: parseXCommand, helpText: [] };
+  ${extra}
+`;
+
+describe('check-cli-hint-reachable', () => {
+  it('fails when a page has a hint but no way to ask for one', () => {
+    const r = run({
+      pages: { 'XPage.tsx': page('x') },
+      commands: { 'xCommands.ts': "case 'play': return { args: ['play'] };" },
+    });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('XPage.tsx');
+  });
+
+  it('passes when the command module answers hint', () => {
+    const r = run({
+      pages: { 'XPage.tsx': page('x') },
+      commands: { 'xCommands.ts': "case 'hint': return { args: ['hint'] };" },
+    });
+    expect(r.status).toBe(0);
+  });
+
+  it('passes when the page answers locally with hintCliText', () => {
+    const r = run({
+      pages: { 'XPage.tsx': page('x', 'localCommand: (i) => hintCliText(hint),') },
+      commands: { 'xCommands.ts': "case 'play': return { args: ['play'] };" },
+    });
+    expect(r.status).toBe(0);
+  });
+
+  it('passes when the page parses inline and handles hint there', () => {
+    const r = run({
+      pages: {
+        'XPage.tsx': `
+          function parseXCommand(input) { switch (input) { case 'hint': return 1; } }
+          const { hint } = useGameHint('x', state);
+          const cfg = { parseCommand: parseXCommand, helpText: [] };
+        `,
+      },
+    });
+    expect(r.status).toBe(0);
+  });
+
+  it('passes when the module delegates to a shared parser that answers hint', () => {
+    const r = run({
+      pages: { 'XPage.tsx': page('x') },
+      commands: {
+        'sharedTrickCommands.ts': "case 'hint': return { command: 'hint' };",
+        'xCommands.ts': "export * from './sharedTrickCommands';",
+      },
+    });
+    expect(r.status).toBe(0);
+  });
+
+  it('ignores a page with no hint to expose', () => {
+    const r = run({
+      pages: { 'XPage.tsx': 'const cfg = { parseCommand: p, helpText: [] };' },
+      commands: { 'xCommands.ts': "case 'play': return 1;" },
+    });
+    expect(r.status).toBe(0);
+  });
+
+  it('ignores a page with a hint but no CLI at all', () => {
+    const r = run({
+      pages: { 'XPage.tsx': "const { hint } = useGameHint('x', state);" },
+    });
+    expect(r.status).toBe(0);
+  });
+});

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -2192,7 +2192,14 @@
     "unknownCommand": "Unknown command: {{cmd}}",
     "unknownCommandWithSuggestion": "Unknown command: {{cmd}}. Did you mean: {{suggestion}}",
     "emptyInput": "Please enter a command. Type 'help' for help.",
-    "helpCommon": "Common commands: r/reset (reset), help/? (help), clear (clear log)"
+    "helpCommon": "Common commands: r/reset (reset), help/? (help), clear (clear log)",
+    "hintNone": "No hint available",
+    "hintTarget": "(position {{pos}})",
+    "hintTargets": "(positions {{positions}})",
+    "hintConfidence": {
+      "strong": "[confidence: high]",
+      "moderate": "[confidence: medium]"
+    }
   },
   "notFound": {
     "eyebrow": "PAGE NOT FOUND",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -2192,7 +2192,14 @@
     "unknownCommand": "不明なコマンド: {{cmd}}",
     "unknownCommandWithSuggestion": "不明なコマンド: {{cmd}}。もしかして: {{suggestion}}",
     "emptyInput": "コマンドを入力してください。'help' でヘルプを表示",
-    "helpCommon": "共通コマンド: r/reset (リセット), help/? (ヘルプ), clear (ログクリア)"
+    "helpCommon": "共通コマンド: r/reset (リセット), help/? (ヘルプ), clear (ログクリア)",
+    "hintNone": "ヒントはありません",
+    "hintTarget": "(位置 {{pos}})",
+    "hintTargets": "(位置 {{positions}})",
+    "hintConfidence": {
+      "strong": "[確度: 高]",
+      "moderate": "[確度: 中]"
+    }
   },
   "notFound": {
     "eyebrow": "PAGE NOT FOUND",

--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -33,6 +33,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { computeBaccaratShoeStats } from '../utils/baccaratStats';
 import { BACCARAT_HELP, parseBaccaratCommand } from '../utils/cli/commands/baccaratCommands';
 import { formatBaccaratState } from '../utils/cli/formatters/baccaratFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 const BET_TYPE_LABELS: Record<number, string> = {
@@ -278,8 +279,9 @@ function BaccaratPageContent() {
       parseCommand: parseBaccaratCommand,
       formatResponse: formatBaccaratState,
       helpText: BACCARAT_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
     }),
-    [],
+    [hint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/BaccaratPage.tsx
+++ b/frontend/src/pages/BaccaratPage.tsx
@@ -33,7 +33,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { computeBaccaratShoeStats } from '../utils/baccaratStats';
 import { BACCARAT_HELP, parseBaccaratCommand } from '../utils/cli/commands/baccaratCommands';
 import { formatBaccaratState } from '../utils/cli/formatters/baccaratFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 const BET_TYPE_LABELS: Record<number, string> = {
@@ -279,7 +279,7 @@ function BaccaratPageContent() {
       parseCommand: parseBaccaratCommand,
       formatResponse: formatBaccaratState,
       helpText: BACCARAT_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
+      localCommand: hintLocalCommand(hint),
     }),
     [hint],
   );

--- a/frontend/src/pages/BeggarMyNeighbourPage.tsx
+++ b/frontend/src/pages/BeggarMyNeighbourPage.tsx
@@ -27,6 +27,7 @@ import { BeggarMyNeighbourPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { BEGGARMYNEIGHBOUR_HELP, parseBeggarMyNeighbourCommand } from '../utils/cli/commands/beggarmyneighbourCommands';
 import { formatBeggarMyNeighbourState } from '../utils/cli/formatters/beggarmyneighbourFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -190,8 +191,9 @@ function BeggarMyNeighbourPageContent() {
       parseCommand: parseBeggarMyNeighbourCommand,
       formatResponse: formatBeggarMyNeighbourState,
       helpText: BEGGARMYNEIGHBOUR_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/BeggarMyNeighbourPage.tsx
+++ b/frontend/src/pages/BeggarMyNeighbourPage.tsx
@@ -27,7 +27,7 @@ import { BeggarMyNeighbourPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { BEGGARMYNEIGHBOUR_HELP, parseBeggarMyNeighbourCommand } from '../utils/cli/commands/beggarmyneighbourCommands';
 import { formatBeggarMyNeighbourState } from '../utils/cli/formatters/beggarmyneighbourFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -191,7 +191,7 @@ function BeggarMyNeighbourPageContent() {
       parseCommand: parseBeggarMyNeighbourCommand,
       formatResponse: formatBeggarMyNeighbourState,
       helpText: BEGGARMYNEIGHBOUR_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/BidEuchrePage.tsx
+++ b/frontend/src/pages/BidEuchrePage.tsx
@@ -28,6 +28,7 @@ import { BidEuchrePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { BIDEUCHRE_HELP, parseBidEuchreCommand } from '../utils/cli/commands/bideuchreCommands';
 import { formatBidEuchreState } from '../utils/cli/formatters/bideuchreFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 /** Declarations, in menu order. **Two of them are no-trump forms.** */
@@ -99,19 +100,6 @@ function BidEuchrePageContent() {
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('bideuchre');
-  const cliConfig: CliGameConfig<BidEuchreResponse, Parameters<typeof bidEuchreApi.exec>> = useMemo(
-    () => ({
-      gameName: 'bideuchre',
-      parseCommand: parseBidEuchreCommand,
-      formatResponse: formatBidEuchreState,
-      helpText: BIDEUCHRE_HELP,
-    }),
-    [],
-  );
-  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
-
-  const { cardWidth } = useCardDimensions();
-  const phaseNames = usePhaseNames('bideuchre', BIDEUCHRE_PHASE_KEYS);
 
   // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
   // だけフック数が変わってページが骨組みのまま固まる (#4561)。
@@ -120,6 +108,20 @@ function BidEuchrePageContent() {
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('bideuchre', state);
+  const cliConfig: CliGameConfig<BidEuchreResponse, Parameters<typeof bidEuchreApi.exec>> = useMemo(
+    () => ({
+      gameName: 'bideuchre',
+      parseCommand: parseBidEuchreCommand,
+      formatResponse: formatBidEuchreState,
+      helpText: BIDEUCHRE_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+    }),
+    [frontendHint],
+  );
+  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
+
+  const { cardWidth } = useCardDimensions();
+  const phaseNames = usePhaseNames('bideuchre', BIDEUCHRE_PHASE_KEYS);
 
   if (!state)
     return <GameSkeleton gameKey="bideuchre" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 6 }} />;

--- a/frontend/src/pages/BidEuchrePage.tsx
+++ b/frontend/src/pages/BidEuchrePage.tsx
@@ -28,7 +28,7 @@ import { BidEuchrePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { BIDEUCHRE_HELP, parseBidEuchreCommand } from '../utils/cli/commands/bideuchreCommands';
 import { formatBidEuchreState } from '../utils/cli/formatters/bideuchreFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 /** Declarations, in menu order. **Two of them are no-trump forms.** */
@@ -114,7 +114,7 @@ function BidEuchrePageContent() {
       parseCommand: parseBidEuchreCommand,
       formatResponse: formatBidEuchreState,
       helpText: BIDEUCHRE_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/BigTwoPage.tsx
+++ b/frontend/src/pages/BigTwoPage.tsx
@@ -32,7 +32,7 @@ import {
   formatBigTwoState,
   parseBigTwoCommand,
 } from '../utils/cli/commands/bigtwoCommands';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -113,7 +113,7 @@ function BigTwoPageContent() {
       parseCommand: parseBigTwoCommand,
       formatResponse: formatBigTwoState,
       helpText: [...BIGTWO_HELP],
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/BigTwoPage.tsx
+++ b/frontend/src/pages/BigTwoPage.tsx
@@ -32,6 +32,7 @@ import {
   formatBigTwoState,
   parseBigTwoCommand,
 } from '../utils/cli/commands/bigtwoCommands';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -112,8 +113,9 @@ function BigTwoPageContent() {
       parseCommand: parseBigTwoCommand,
       formatResponse: formatBigTwoState,
       helpText: [...BIGTWO_HELP],
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(callApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/BlackJackSwitchPage.tsx
+++ b/frontend/src/pages/BlackJackSwitchPage.tsx
@@ -33,6 +33,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { blackjackSwitchPreviewScores } from '../utils/blackjackSwitchPreview';
 import { BLACKJACKSWITCH_HELP, parseBlackjackSwitchCommand } from '../utils/cli/commands/blackjackswitchCommands';
 import { formatBlackjackSwitchState } from '../utils/cli/formatters/blackjackswitchFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 const BJSWITCH_TUTORIAL_STEPS: TutorialStep[] = [];
@@ -63,8 +64,9 @@ function BlackJackSwitchPageContent() {
       parseCommand: parseBlackjackSwitchCommand,
       formatResponse: formatBlackjackSwitchState,
       helpText: BLACKJACKSWITCH_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
     }),
-    [],
+    [hint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/BlackJackSwitchPage.tsx
+++ b/frontend/src/pages/BlackJackSwitchPage.tsx
@@ -33,7 +33,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { blackjackSwitchPreviewScores } from '../utils/blackjackSwitchPreview';
 import { BLACKJACKSWITCH_HELP, parseBlackjackSwitchCommand } from '../utils/cli/commands/blackjackswitchCommands';
 import { formatBlackjackSwitchState } from '../utils/cli/formatters/blackjackswitchFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 const BJSWITCH_TUTORIAL_STEPS: TutorialStep[] = [];
@@ -64,7 +64,7 @@ function BlackJackSwitchPageContent() {
       parseCommand: parseBlackjackSwitchCommand,
       formatResponse: formatBlackjackSwitchState,
       helpText: BLACKJACKSWITCH_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
+      localCommand: hintLocalCommand(hint),
     }),
     [hint],
   );

--- a/frontend/src/pages/BostonPage.tsx
+++ b/frontend/src/pages/BostonPage.tsx
@@ -28,6 +28,7 @@ import { BostonPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { BOSTON_HELP, parseBostonCommand } from '../utils/cli/commands/bostonCommands';
 import { formatBostonState } from '../utils/cli/formatters/bostonFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 /** Suit glyphs by design value (1=Spade … 4=Diamond). */
@@ -100,19 +101,6 @@ function BostonPageContent() {
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('boston');
-  const cliConfig: CliGameConfig<BostonResponse, Parameters<typeof bostonApi.exec>> = useMemo(
-    () => ({
-      gameName: 'boston',
-      parseCommand: parseBostonCommand,
-      formatResponse: formatBostonState,
-      helpText: BOSTON_HELP,
-    }),
-    [],
-  );
-  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
-
-  const { cardWidth } = useCardDimensions();
-  const phaseNames = usePhaseNames('boston', BOSTON_PHASE_KEYS);
 
   // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
   // だけフック数が変わってページが骨組みのまま固まる (#4561)。
@@ -121,6 +109,20 @@ function BostonPageContent() {
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('boston', state);
+  const cliConfig: CliGameConfig<BostonResponse, Parameters<typeof bostonApi.exec>> = useMemo(
+    () => ({
+      gameName: 'boston',
+      parseCommand: parseBostonCommand,
+      formatResponse: formatBostonState,
+      helpText: BOSTON_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+    }),
+    [frontendHint],
+  );
+  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
+
+  const { cardWidth } = useCardDimensions();
+  const phaseNames = usePhaseNames('boston', BOSTON_PHASE_KEYS);
 
   if (!state)
     return <GameSkeleton gameKey="boston" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 13 }} />;

--- a/frontend/src/pages/BostonPage.tsx
+++ b/frontend/src/pages/BostonPage.tsx
@@ -28,7 +28,7 @@ import { BostonPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { BOSTON_HELP, parseBostonCommand } from '../utils/cli/commands/bostonCommands';
 import { formatBostonState } from '../utils/cli/formatters/bostonFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 /** Suit glyphs by design value (1=Spade … 4=Diamond). */
@@ -115,7 +115,7 @@ function BostonPageContent() {
       parseCommand: parseBostonCommand,
       formatResponse: formatBostonState,
       helpText: BOSTON_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/BourrePage.tsx
+++ b/frontend/src/pages/BourrePage.tsx
@@ -135,6 +135,8 @@ function BourrePageContent() {
     retry,
   } = useGameApi<BourreResponse, [ApiArgs]>((...args) => bourreApi.exec(...args));
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('bourre');
+  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
+  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
   const {
     hint: frontendHint,
     hintEnabled: frontendHintEnabled,
@@ -239,9 +241,6 @@ function BourrePageContent() {
     if (p.bourreed) return t('label.bourreed');
     return `${p.tricks} ${t('label.tricks')}`;
   };
-
-  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
-  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
 
   if (!state) return <GameSkeleton gameKey="bourre" layout={{ kind: 'card-grid', count: 5, cols: 'grid-cols-5' }} />;
 

--- a/frontend/src/pages/BourrePage.tsx
+++ b/frontend/src/pages/BourrePage.tsx
@@ -25,7 +25,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { BourreResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
 import { isRedSuitDesign, isSuitDesign, suitSymbol } from '../utils/cardAlt';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -145,7 +145,7 @@ function BourrePageContent() {
   const cliConfigWithHint = useMemo(
     () => ({
       ...cliConfig,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/BourrePage.tsx
+++ b/frontend/src/pages/BourrePage.tsx
@@ -25,6 +25,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { BourreResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
 import { isRedSuitDesign, isSuitDesign, suitSymbol } from '../utils/cardAlt';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -134,7 +135,21 @@ function BourrePageContent() {
     retry,
   } = useGameApi<BourreResponse, [ApiArgs]>((...args) => bourreApi.exec(...args));
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('bourre');
-  const { handleCommand } = useCliGame<BourreResponse, [ApiArgs]>(apiCall, cliConfig, state, {
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('bourre', state);
+  // The module-level config cannot see `frontendHint`: hints are computed per render.
+  // Layer the local answer on here rather than restructuring the shared const.
+  const cliConfigWithHint = useMemo(
+    () => ({
+      ...cliConfig,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+    }),
+    [frontendHint],
+  );
+  const { handleCommand } = useCliGame<BourreResponse, [ApiArgs]>(apiCall, cliConfigWithHint, state, {
     addInput,
     addOutput,
     addError,
@@ -227,11 +242,6 @@ function BourrePageContent() {
 
   // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
   // だけフック数が変わってページが骨組みのまま固まる (#4561)。
-  const {
-    hint: frontendHint,
-    hintEnabled: frontendHintEnabled,
-    setHintEnabled: setFrontendHintEnabled,
-  } = useGameHint('bourre', state);
 
   if (!state) return <GameSkeleton gameKey="bourre" layout={{ kind: 'card-grid', count: 5, cols: 'grid-cols-5' }} />;
 

--- a/frontend/src/pages/CanastaPage.tsx
+++ b/frontend/src/pages/CanastaPage.tsx
@@ -34,6 +34,7 @@ import { canastaMinMeld, canastaSelectionPoints } from '../utils/canastaScore';
 import { cardAlt } from '../utils/cardAlt';
 import { CANASTA_HELP, parseCanastaCommand } from '../utils/cli/commands/canastaCommands';
 import { formatCanastaState } from '../utils/cli/formatters/canastaFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -106,8 +107,9 @@ function CanastaPageContent() {
       parseCommand: parseCanastaCommand,
       formatResponse: formatCanastaState,
       helpText: CANASTA_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(gameExec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/CanastaPage.tsx
+++ b/frontend/src/pages/CanastaPage.tsx
@@ -34,7 +34,7 @@ import { canastaMinMeld, canastaSelectionPoints } from '../utils/canastaScore';
 import { cardAlt } from '../utils/cardAlt';
 import { CANASTA_HELP, parseCanastaCommand } from '../utils/cli/commands/canastaCommands';
 import { formatCanastaState } from '../utils/cli/formatters/canastaFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -107,7 +107,7 @@ function CanastaPageContent() {
       parseCommand: parseCanastaCommand,
       formatResponse: formatCanastaState,
       helpText: CANASTA_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/CariocaPage.tsx
+++ b/frontend/src/pages/CariocaPage.tsx
@@ -28,6 +28,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { canLayoffCariocaMeld, describeCariocaSlotShortfall, evaluateCariocaContractSlot } from '../utils/cariocaUtils';
 import { CARIOCA_HELP, parseCariocaCommand } from '../utils/cli/commands/cariocaCommands';
 import { formatCariocaState } from '../utils/cli/formatters/cariocaFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 /** Phase identifiers for Carioca. */
@@ -91,14 +92,23 @@ function CariocaPageContent() {
   // CLI mode. Carioca は CUI プレゼンターがあるのに Web からその表現へ行けなかった
   // (#4849)。他の extra worker のゲームと同じ配線。
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('carioca');
+
+  // **フックは `if (!state)` より前。**後ろに置くとスケルトン中だけフック数が
+  // 変わり、StrictMode でも本番ビルドでも検出できない形で壊れる (#4561)。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('carioca', state);
   const cliConfig: CliGameConfig<CariocaResponse, Parameters<typeof cariocaApi.exec>> = useMemo(
     () => ({
       gameName: 'carioca',
       parseCommand: parseCariocaCommand,
       formatResponse: formatCariocaState,
       helpText: CARIOCA_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
@@ -221,14 +231,6 @@ function CariocaPageContent() {
       return { ev: evaluateCariocaContractSlot(slot, cards), shortfall: describeCariocaSlotShortfall(slot, cards) };
     });
   }, [state, humanPlayer, contractSlots]);
-
-  // **フックは `if (!state)` より前。**後ろに置くとスケルトン中だけフック数が
-  // 変わり、StrictMode でも本番ビルドでも検出できない形で壊れる (#4561)。
-  const {
-    hint: frontendHint,
-    hintEnabled: frontendHintEnabled,
-    setHintEnabled: setFrontendHintEnabled,
-  } = useGameHint('carioca', state);
 
   // humanPlayer gates slotEvaluations population, so checking it here keeps the
   // intent obvious; the length>0 guard prevents `[].every(...)` from vacuously

--- a/frontend/src/pages/CariocaPage.tsx
+++ b/frontend/src/pages/CariocaPage.tsx
@@ -28,7 +28,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { canLayoffCariocaMeld, describeCariocaSlotShortfall, evaluateCariocaContractSlot } from '../utils/cariocaUtils';
 import { CARIOCA_HELP, parseCariocaCommand } from '../utils/cli/commands/cariocaCommands';
 import { formatCariocaState } from '../utils/cli/formatters/cariocaFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 /** Phase identifiers for Carioca. */
@@ -106,7 +106,7 @@ function CariocaPageContent() {
       parseCommand: parseCariocaCommand,
       formatResponse: formatCariocaState,
       helpText: CARIOCA_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/CasinoWarPage.tsx
+++ b/frontend/src/pages/CasinoWarPage.tsx
@@ -34,6 +34,7 @@ import { CasinoWarPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { CASINOWAR_HELP, parseCasinowarCommand } from '../utils/cli/commands/casinowarCommands';
 import { formatCasinowarState } from '../utils/cli/formatters/casinowarFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 const CW_TUTORIAL_STEPS: TutorialStep[] = [
@@ -71,8 +72,9 @@ function CasinoWarPageContent() {
       parseCommand: parseCasinowarCommand,
       formatResponse: formatCasinowarState,
       helpText: CASINOWAR_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
     }),
-    [],
+    [hint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/CasinoWarPage.tsx
+++ b/frontend/src/pages/CasinoWarPage.tsx
@@ -34,7 +34,7 @@ import { CasinoWarPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { CASINOWAR_HELP, parseCasinowarCommand } from '../utils/cli/commands/casinowarCommands';
 import { formatCasinowarState } from '../utils/cli/formatters/casinowarFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 const CW_TUTORIAL_STEPS: TutorialStep[] = [
@@ -72,7 +72,7 @@ function CasinoWarPageContent() {
       parseCommand: parseCasinowarCommand,
       formatResponse: formatCasinowarState,
       helpText: CASINOWAR_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
+      localCommand: hintLocalCommand(hint),
     }),
     [hint],
   );

--- a/frontend/src/pages/ChinchonPage.tsx
+++ b/frontend/src/pages/ChinchonPage.tsx
@@ -44,7 +44,7 @@ import {
 } from '../utils/chinchonDeadwood';
 import { CHINCHON_HELP, parseChinchonCommand } from '../utils/cli/commands/chinchonCommands';
 import { formatChinchonState } from '../utils/cli/formatters/chinchonFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -134,7 +134,7 @@ function ChinchonPageContent() {
       parseCommand: parseChinchonCommand,
       formatResponse: formatChinchonState,
       helpText: CHINCHON_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/ChinchonPage.tsx
+++ b/frontend/src/pages/ChinchonPage.tsx
@@ -44,6 +44,7 @@ import {
 } from '../utils/chinchonDeadwood';
 import { CHINCHON_HELP, parseChinchonCommand } from '../utils/cli/commands/chinchonCommands';
 import { formatChinchonState } from '../utils/cli/formatters/chinchonFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -119,14 +120,23 @@ function ChinchonPageContent() {
   const { cardWidth } = useCardDimensions();
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('chinchon');
+
+  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
+  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('chinchon', state);
   const cliConfig: CliGameConfig<ChinchonResponse, Parameters<typeof chinchonApi.exec>> = useMemo(
     () => ({
       gameName: 'chinchon',
       parseCommand: parseChinchonCommand,
       formatResponse: formatChinchonState,
       helpText: CHINCHON_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(gameExec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
@@ -221,14 +231,6 @@ function ChinchonPageContent() {
     }
     return result;
   }, [state, selectedCardIndices]);
-
-  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
-  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
-  const {
-    hint: frontendHint,
-    hintEnabled: frontendHintEnabled,
-    setHintEnabled: setFrontendHintEnabled,
-  } = useGameHint('chinchon', state);
 
   if (!state)
     return (

--- a/frontend/src/pages/ClockSolitairePage.tsx
+++ b/frontend/src/pages/ClockSolitairePage.tsx
@@ -27,6 +27,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { ClockSolitaireResponse } from '../types/card';
 import { ClockSolitairePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -201,8 +202,9 @@ function ClockSolitairePageContent() {
         'l/log      - Show action log',
         'r/reset    - Reset game',
       ],
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
     }),
-    [],
+    [hint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, {
     addInput,

--- a/frontend/src/pages/ClockSolitairePage.tsx
+++ b/frontend/src/pages/ClockSolitairePage.tsx
@@ -27,7 +27,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { ClockSolitaireResponse } from '../types/card';
 import { ClockSolitairePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -202,7 +202,7 @@ function ClockSolitairePageContent() {
         'l/log      - Show action log',
         'r/reset    - Reset game',
       ],
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
+      localCommand: hintLocalCommand(hint),
     }),
     [hint],
   );

--- a/frontend/src/pages/ConquianPage.tsx
+++ b/frontend/src/pages/ConquianPage.tsx
@@ -33,7 +33,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { CONQUIAN_HELP, parseConquianCommand } from '../utils/cli/commands/conquianCommands';
 import { formatConquianState } from '../utils/cli/formatters/conquianFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -159,7 +159,7 @@ function ConquianPageContent() {
       parseCommand: parseConquianCommand,
       formatResponse: formatConquianState,
       helpText: CONQUIAN_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/ConquianPage.tsx
+++ b/frontend/src/pages/ConquianPage.tsx
@@ -33,6 +33,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { CONQUIAN_HELP, parseConquianCommand } from '../utils/cli/commands/conquianCommands';
 import { formatConquianState } from '../utils/cli/formatters/conquianFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -144,14 +145,23 @@ function ConquianPageContent() {
   };
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('conquian');
+
+  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
+  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('conquian', state);
   const cliConfig: CliGameConfig<ConquianResponse, Parameters<typeof conquianApi.exec>> = useMemo(
     () => ({
       gameName: 'conquian',
       parseCommand: parseConquianCommand,
       formatResponse: formatConquianState,
       helpText: CONQUIAN_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(gameExec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
@@ -193,14 +203,6 @@ function ConquianPageContent() {
     [handleDrawStock, handleDrawDiscard, canDrawForKbd, state?.discardTop],
   );
   useActionKeyboardNav({ bindings: drawBindings, enabled: canDrawForKbd });
-
-  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
-  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
-  const {
-    hint: frontendHint,
-    hintEnabled: frontendHintEnabled,
-    setHintEnabled: setFrontendHintEnabled,
-  } = useGameHint('conquian', state);
 
   if (!state) {
     return (

--- a/frontend/src/pages/ContractRummyPage.tsx
+++ b/frontend/src/pages/ContractRummyPage.tsx
@@ -28,7 +28,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { CONTRACTRUMMY_HELP, parseContractRummyCommand } from '../utils/cli/commands/contractrummyCommands';
 import { formatContractRummyState } from '../utils/cli/formatters/contractrummyFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { evaluateContractSlot, isContractRummyMeld } from '../utils/contractRummyUtils';
 
@@ -108,7 +108,7 @@ function ContractRummyPageContent() {
       parseCommand: parseContractRummyCommand,
       formatResponse: formatContractRummyState,
       helpText: CONTRACTRUMMY_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/ContractRummyPage.tsx
+++ b/frontend/src/pages/ContractRummyPage.tsx
@@ -28,6 +28,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { CONTRACTRUMMY_HELP, parseContractRummyCommand } from '../utils/cli/commands/contractrummyCommands';
 import { formatContractRummyState } from '../utils/cli/formatters/contractrummyFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { evaluateContractSlot, isContractRummyMeld } from '../utils/contractRummyUtils';
 
@@ -93,14 +94,23 @@ function ContractRummyPageContent() {
   const phaseNames = usePhaseNames('contractrummy', CR_PHASE_KEYS);
 
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('contractrummy');
+
+  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
+  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('contractrummy', state);
   const cliConfig: CliGameConfig<ContractRummyResponse, Parameters<typeof execApi>> = useMemo(
     () => ({
       gameName: 'contractrummy',
       parseCommand: parseContractRummyCommand,
       formatResponse: formatContractRummyState,
       helpText: CONTRACTRUMMY_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
@@ -231,14 +241,6 @@ function ContractRummyPageContent() {
   // enabling submit on a contract with zero slots.
   const allSlotsSatisfied =
     humanPlayer != null && slotEvaluations.length > 0 && slotEvaluations.every((ev) => ev.satisfied);
-
-  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
-  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
-  const {
-    hint: frontendHint,
-    hintEnabled: frontendHintEnabled,
-    setHintEnabled: setFrontendHintEnabled,
-  } = useGameHint('contractrummy', state);
 
   if (!state) {
     return (

--- a/frontend/src/pages/CuarentaPage.tsx
+++ b/frontend/src/pages/CuarentaPage.tsx
@@ -30,7 +30,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { CUARENTA_HELP, parseCuarentaCommand } from '../utils/cli/commands/cuarentaCommands';
 import { formatCuarentaState } from '../utils/cli/formatters/cuarentaFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { cuarentaCaptureIndices } from '../utils/cuarentaCapture';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -137,7 +137,7 @@ function CuarentaPageContent() {
       parseCommand: parseCuarentaCommand,
       formatResponse: formatCuarentaState,
       helpText: CUARENTA_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/CuarentaPage.tsx
+++ b/frontend/src/pages/CuarentaPage.tsx
@@ -30,6 +30,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { CUARENTA_HELP, parseCuarentaCommand } from '../utils/cli/commands/cuarentaCommands';
 import { formatCuarentaState } from '../utils/cli/formatters/cuarentaFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { cuarentaCaptureIndices } from '../utils/cuarentaCapture';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -122,14 +123,23 @@ function CuarentaPageContent() {
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('cuarenta');
+
+  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
+  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('cuarenta', state);
   const cliConfig: CliGameConfig<CuarentaResponse, Parameters<typeof cuarentaApi.exec>> = useMemo(
     () => ({
       gameName: 'cuarenta',
       parseCommand: parseCuarentaCommand,
       formatResponse: formatCuarentaState,
       helpText: CUARENTA_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
@@ -158,14 +168,6 @@ function CuarentaPageContent() {
       }
     }
   }, [humanActionSig, humanBonus, playSound]);
-
-  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
-  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
-  const {
-    hint: frontendHint,
-    hintEnabled: frontendHintEnabled,
-    setHintEnabled: setFrontendHintEnabled,
-  } = useGameHint('cuarenta', state);
 
   if (!state)
     return <GameSkeleton gameKey="cuarenta" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 5 }} />;

--- a/frontend/src/pages/CuckooPage.tsx
+++ b/frontend/src/pages/CuckooPage.tsx
@@ -32,7 +32,7 @@ import { CuckooPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { CUCKOO_HELP, parseCuckooCommand } from '../utils/cli/commands/cuckooCommands';
 import { formatCuckooState } from '../utils/cli/formatters/cuckooFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -127,7 +127,7 @@ function CuckooPageContent() {
       parseCommand: parseCuckooCommand,
       formatResponse: formatCuckooState,
       helpText: CUCKOO_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/CuckooPage.tsx
+++ b/frontend/src/pages/CuckooPage.tsx
@@ -32,6 +32,7 @@ import { CuckooPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { CUCKOO_HELP, parseCuckooCommand } from '../utils/cli/commands/cuckooCommands';
 import { formatCuckooState } from '../utils/cli/formatters/cuckooFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -112,14 +113,23 @@ function CuckooPageContent() {
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('cuckoo');
+
+  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
+  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('cuckoo', state);
   const cliConfig: CliGameConfig<CuckooResponse, Parameters<typeof cuckooApi.exec>> = useMemo(
     () => ({
       gameName: 'cuckoo',
       parseCommand: parseCuckooCommand,
       formatResponse: formatCuckooState,
       helpText: CUCKOO_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
@@ -143,14 +153,6 @@ function CuckooPageContent() {
     [exec, kbIsHumanTurn, kbIsRefuseTarget, kbHumanHasKing],
   );
   useActionKeyboardNav({ bindings: actionBindings, enabled: !!state && !loading });
-
-  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
-  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
-  const {
-    hint: frontendHint,
-    hintEnabled: frontendHintEnabled,
-    setHintEnabled: setFrontendHintEnabled,
-  } = useGameHint('cuckoo', state);
 
   // **山場が全部無音だった。**CPU の手番が自動で進むテンポの速いゲームなので、
   // バッジだけだとライフ喪失やキング公開を見落とす (#4891)。

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -38,6 +38,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardLabel } from '../utils/cardUtils';
 import { DAIFUGO_HELP, parseDaifugoCommand } from '../utils/cli/commands/daifugoCommands';
 import { formatDaifugoState } from '../utils/cli/formatters/daifugoFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { findPlayerName, playerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -111,22 +112,23 @@ function DaifugoPageContent() {
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('daifugo');
-  const daifugoCliConfig: CliGameConfig<DaifugoResponse, Parameters<typeof daifugoApi.exec>> = useMemo(
-    () => ({
-      gameName: 'daifugo',
-      parseCommand: parseDaifugoCommand,
-      formatResponse: formatDaifugoState,
-      helpText: DAIFUGO_HELP,
-    }),
-    [],
-  );
-  const { handleCommand } = useCliGame(exec, daifugoCliConfig, state, { addInput, addOutput, addError, clearLog });
 
   const {
     hint: frontendHint,
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('daifugo', state);
+  const daifugoCliConfig: CliGameConfig<DaifugoResponse, Parameters<typeof daifugoApi.exec>> = useMemo(
+    () => ({
+      gameName: 'daifugo',
+      parseCommand: parseDaifugoCommand,
+      formatResponse: formatDaifugoState,
+      helpText: DAIFUGO_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+    }),
+    [frontendHint],
+  );
+  const { handleCommand } = useCliGame(exec, daifugoCliConfig, state, { addInput, addOutput, addError, clearLog });
 
   const { cardWidth } = useCardDimensions();
   const isMobile = useIsMobile();

--- a/frontend/src/pages/DaifugoPage.tsx
+++ b/frontend/src/pages/DaifugoPage.tsx
@@ -38,7 +38,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardLabel } from '../utils/cardUtils';
 import { DAIFUGO_HELP, parseDaifugoCommand } from '../utils/cli/commands/daifugoCommands';
 import { formatDaifugoState } from '../utils/cli/formatters/daifugoFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { findPlayerName, playerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -124,7 +124,7 @@ function DaifugoPageContent() {
       parseCommand: parseDaifugoCommand,
       formatResponse: formatDaifugoState,
       helpText: DAIFUGO_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/DoubtPage.tsx
+++ b/frontend/src/pages/DoubtPage.tsx
@@ -40,6 +40,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { valueName } from '../utils/cardUtils';
 import { DOUBT_HELP, parseDoubtCommand } from '../utils/cli/commands/doubtCommands';
 import { formatDoubtState } from '../utils/cli/formatters/doubtFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -126,8 +127,9 @@ function DoubtPageContent() {
       parseCommand: parseDoubtCommand,
       formatResponse: formatDoubtState,
       helpText: DOUBT_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/DoubtPage.tsx
+++ b/frontend/src/pages/DoubtPage.tsx
@@ -40,7 +40,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { valueName } from '../utils/cardUtils';
 import { DOUBT_HELP, parseDoubtCommand } from '../utils/cli/commands/doubtCommands';
 import { formatDoubtState } from '../utils/cli/formatters/doubtFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -127,7 +127,7 @@ function DoubtPageContent() {
       parseCommand: parseDoubtCommand,
       formatResponse: formatDoubtState,
       helpText: DOUBT_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/DoudizhuPage.tsx
+++ b/frontend/src/pages/DoudizhuPage.tsx
@@ -24,7 +24,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { DoudizhuResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { classifyDoudizhuCombo, doudizhuInvalidReason } from '../utils/doudizhuComboValidator';
 
@@ -123,7 +123,7 @@ function DoudizhuPageContent() {
   const cliConfigWithHint = useMemo(
     () => ({
       ...cliConfig,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
+      localCommand: hintLocalCommand(hint),
     }),
     [hint],
   );

--- a/frontend/src/pages/DoudizhuPage.tsx
+++ b/frontend/src/pages/DoudizhuPage.tsx
@@ -24,6 +24,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { DoudizhuResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { classifyDoudizhuCombo, doudizhuInvalidReason } from '../utils/doudizhuComboValidator';
 
@@ -117,7 +118,16 @@ function DoudizhuPageContent() {
   } = useGameApi<DoudizhuResponse, [ApiArgs]>((...args) => doudizhuApi.exec(...args));
   const { hint, hintEnabled, setHintEnabled } = useGameHint('doudizhu', state);
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('doudizhu');
-  const { handleCommand } = useCliGame<DoudizhuResponse, [ApiArgs]>(apiCall, cliConfig, state, {
+  // The module-level config cannot see `hint`: hints are computed per render.
+  // Layer the local answer on here rather than restructuring the shared const.
+  const cliConfigWithHint = useMemo(
+    () => ({
+      ...cliConfig,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
+    }),
+    [hint],
+  );
+  const { handleCommand } = useCliGame<DoudizhuResponse, [ApiArgs]>(apiCall, cliConfigWithHint, state, {
     addInput,
     addOutput,
     addError,

--- a/frontend/src/pages/DragonTigerPage.tsx
+++ b/frontend/src/pages/DragonTigerPage.tsx
@@ -32,7 +32,7 @@ import { DragonTigerBetType, DragonTigerHistoryResult, DragonTigerPhase } from '
 import type { TutorialStep } from '../types/tutorial';
 import { DRAGONTIGER_CLI_HELP, parseDragonTigerCommand } from '../utils/cli/commands/dragontigerCommands';
 import { formatDragonTigerState } from '../utils/cli/formatters/dragontigerFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -76,7 +76,7 @@ function DragonTigerPageContent() {
       parseCommand: parseDragonTigerCommand,
       formatResponse: formatDragonTigerState,
       helpText: DRAGONTIGER_CLI_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/DragonTigerPage.tsx
+++ b/frontend/src/pages/DragonTigerPage.tsx
@@ -32,6 +32,7 @@ import { DragonTigerBetType, DragonTigerHistoryResult, DragonTigerPhase } from '
 import type { TutorialStep } from '../types/tutorial';
 import { DRAGONTIGER_CLI_HELP, parseDragonTigerCommand } from '../utils/cli/commands/dragontigerCommands';
 import { formatDragonTigerState } from '../utils/cli/formatters/dragontigerFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -61,14 +62,23 @@ function DragonTigerPageContent() {
   const { state, loading, error, exec: execApi, retry } = useGameApi(dragontigerApi.exec);
 
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('dragontiger');
+
+  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
+  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('dragontiger', state);
   const cliConfig: CliGameConfig<DragonTigerResponse, Parameters<typeof dragontigerApi.exec>> = useMemo(
     () => ({
       gameName: 'dragontiger',
       parseCommand: parseDragonTigerCommand,
       formatResponse: formatDragonTigerState,
       helpText: DRAGONTIGER_CLI_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
@@ -108,14 +118,6 @@ function DragonTigerPageContent() {
     [execApi, handleBet, handleRebet, isBetPhase, isEndPhase, canRebet],
   );
   useActionKeyboardNav({ bindings: actionBindings, enabled: !!state && !loading });
-
-  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
-  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
-  const {
-    hint: frontendHint,
-    hintEnabled: frontendHintEnabled,
-    setHintEnabled: setFrontendHintEnabled,
-  } = useGameHint('dragontiger', state);
 
   if (!state) return <GameSkeleton gameKey="dragontiger" layout={{ kind: 'casino-table', sections: [1, 1] }} />;
 

--- a/frontend/src/pages/EgyptianRatscrewPage.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.tsx
@@ -34,7 +34,7 @@ import {
 } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { formatEgyptianRatscrewState } from '../utils/cli/formatters/egyptianratscrewFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -175,7 +175,7 @@ function EgyptianRatscrewPageContent() {
         'r/reset - Reset game',
         'l/log   - Show action log',
       ],
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/EgyptianRatscrewPage.tsx
+++ b/frontend/src/pages/EgyptianRatscrewPage.tsx
@@ -34,6 +34,7 @@ import {
 } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { formatEgyptianRatscrewState } from '../utils/cli/formatters/egyptianratscrewFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -174,8 +175,9 @@ function EgyptianRatscrewPageContent() {
         'r/reset - Reset game',
         'l/log   - Show action log',
       ],
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/FaroPage.tsx
+++ b/frontend/src/pages/FaroPage.tsx
@@ -28,7 +28,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { valueName } from '../utils/cardUtils';
 import { FARO_HELP, parseFaroCommand } from '../utils/cli/commands/faroCommands';
 import { formatFaroState } from '../utils/cli/formatters/faroFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { FARO_RANK_COUNT, mergeSeenCards, remainingByRank } from '../utils/faroCaseKeeper';
 
@@ -143,7 +143,7 @@ function FaroPageContent() {
       parseCommand: parseFaroCommand,
       formatResponse: formatFaroState,
       helpText: FARO_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/FaroPage.tsx
+++ b/frontend/src/pages/FaroPage.tsx
@@ -28,6 +28,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { valueName } from '../utils/cardUtils';
 import { FARO_HELP, parseFaroCommand } from '../utils/cli/commands/faroCommands';
 import { formatFaroState } from '../utils/cli/formatters/faroFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { FARO_RANK_COUNT, mergeSeenCards, remainingByRank } from '../utils/faroCaseKeeper';
 
@@ -128,18 +129,6 @@ function FaroPageContent() {
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('faro');
-  const cliConfig: CliGameConfig<FaroResponse, Parameters<typeof faroApi.exec>> = useMemo(
-    () => ({
-      gameName: 'faro',
-      parseCommand: parseFaroCommand,
-      formatResponse: formatFaroState,
-      helpText: FARO_HELP,
-    }),
-    [],
-  );
-  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
-
-  const { cardWidth } = useCardDimensions();
 
   // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
   // だけフック数が変わってページが骨組みのまま固まる (#4561)。
@@ -148,6 +137,19 @@ function FaroPageContent() {
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('faro', state);
+  const cliConfig: CliGameConfig<FaroResponse, Parameters<typeof faroApi.exec>> = useMemo(
+    () => ({
+      gameName: 'faro',
+      parseCommand: parseFaroCommand,
+      formatResponse: formatFaroState,
+      helpText: FARO_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+    }),
+    [frontendHint],
+  );
+  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
+
+  const { cardWidth } = useCardDimensions();
 
   if (!state)
     return <GameSkeleton gameKey="faro" layout={{ kind: 'casino-table', sections: [2], footerStyle: 'bet' }} />;

--- a/frontend/src/pages/FiftyOnePage.tsx
+++ b/frontend/src/pages/FiftyOnePage.tsx
@@ -26,6 +26,7 @@ import type { FiftyOneResponse } from '../types/card';
 import { FiftyOnePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { fiftyOneBestSuit, fiftyOneSuitScores } from '../utils/fiftyOneSuitScores';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -155,8 +156,9 @@ function FiftyOnePageContent() {
         'r/reset               - Reset game',
         'l/log                 - Show action log',
       ],
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/FiftyOnePage.tsx
+++ b/frontend/src/pages/FiftyOnePage.tsx
@@ -26,7 +26,7 @@ import type { FiftyOneResponse } from '../types/card';
 import { FiftyOnePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { fiftyOneBestSuit, fiftyOneSuitScores } from '../utils/fiftyOneSuitScores';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -156,7 +156,7 @@ function FiftyOnePageContent() {
         'r/reset               - Reset game',
         'l/log                 - Show action log',
       ],
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/FiveCardStudPage.tsx
+++ b/frontend/src/pages/FiveCardStudPage.tsx
@@ -40,6 +40,7 @@ import { FiveCardStudPhase, FiveCardStudRebuyPhaseType } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { FIVECARDSTUD_HELP, parseFiveCardStudCommand } from '../utils/cli/commands/fiveCardStudCommands';
 import { formatFiveCardStudState } from '../utils/cli/formatters/fiveCardStudFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { findPlayerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -118,14 +119,23 @@ export function FiveCardStudPageContent({ gameKey }: { gameKey: FcsPageGameKey }
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode(gameKey);
   type FcsArgs = Parameters<typeof fiveCardStudApi.exec>;
+
+  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
+  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint(gameKey, state);
   const cliConfig: CliGameConfig<FiveCardStudResponse, FcsArgs> = useMemo(
     () => ({
       gameName: gameKey,
       parseCommand: parseFiveCardStudCommand,
       formatResponse: (s: FiveCardStudResponse) => formatFiveCardStudState(s, phaseNames),
       helpText: FIVECARDSTUD_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [gameKey, phaseNames],
+    [gameKey, phaseNames, frontendHint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
@@ -217,14 +227,6 @@ export function FiveCardStudPageContent({ gameKey }: { gameKey: FcsPageGameKey }
     bindings: actionBindings,
     enabled: canAct && !loading,
   });
-
-  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
-  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
-  const {
-    hint: frontendHint,
-    hintEnabled: frontendHintEnabled,
-    setHintEnabled: setFrontendHintEnabled,
-  } = useGameHint(gameKey, state);
 
   if (!state)
     return (

--- a/frontend/src/pages/FiveCardStudPage.tsx
+++ b/frontend/src/pages/FiveCardStudPage.tsx
@@ -40,7 +40,7 @@ import { FiveCardStudPhase, FiveCardStudRebuyPhaseType } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { FIVECARDSTUD_HELP, parseFiveCardStudCommand } from '../utils/cli/commands/fiveCardStudCommands';
 import { formatFiveCardStudState } from '../utils/cli/formatters/fiveCardStudFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { findPlayerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -133,7 +133,7 @@ export function FiveCardStudPageContent({ gameKey }: { gameKey: FcsPageGameKey }
       parseCommand: parseFiveCardStudCommand,
       formatResponse: (s: FiveCardStudResponse) => formatFiveCardStudState(s, phaseNames),
       helpText: FIVECARDSTUD_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [gameKey, phaseNames, frontendHint],
   );

--- a/frontend/src/pages/FourCardPokerPage.tsx
+++ b/frontend/src/pages/FourCardPokerPage.tsx
@@ -32,7 +32,7 @@ import { FourCardPokerPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { FOURCARDPOKER_HELP, parseFourCardPokerCommand } from '../utils/cli/commands/fourcardpokerCommands';
 import { formatFourCardPokerState } from '../utils/cli/formatters/fourcardpokerFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -104,7 +104,7 @@ function FourCardPokerPageContent() {
       parseCommand: parseFourCardPokerCommand,
       formatResponse: formatFourCardPokerState,
       helpText: FOURCARDPOKER_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/FourCardPokerPage.tsx
+++ b/frontend/src/pages/FourCardPokerPage.tsx
@@ -32,6 +32,7 @@ import { FourCardPokerPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { FOURCARDPOKER_HELP, parseFourCardPokerCommand } from '../utils/cli/commands/fourcardpokerCommands';
 import { formatFourCardPokerState } from '../utils/cli/formatters/fourcardpokerFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -103,8 +104,9 @@ function FourCardPokerPageContent() {
       parseCommand: parseFourCardPokerCommand,
       formatResponse: formatFourCardPokerState,
       helpText: FOURCARDPOKER_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/GinRummyPage.tsx
+++ b/frontend/src/pages/GinRummyPage.tsx
@@ -32,7 +32,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { GINRUMMY_HELP, parseGinrummyCommand } from '../utils/cli/commands/ginrummyCommands';
 import { formatGinrummyState } from '../utils/cli/formatters/ginrummyFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import {
   bestDeadwoodValue,
@@ -126,7 +126,7 @@ function GinRummyPageContent() {
       parseCommand: parseGinrummyCommand,
       formatResponse: formatGinrummyState,
       helpText: GINRUMMY_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/GinRummyPage.tsx
+++ b/frontend/src/pages/GinRummyPage.tsx
@@ -32,6 +32,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { GINRUMMY_HELP, parseGinrummyCommand } from '../utils/cli/commands/ginrummyCommands';
 import { formatGinrummyState } from '../utils/cli/formatters/ginrummyFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import {
   bestDeadwoodValue,
@@ -125,8 +126,9 @@ function GinRummyPageContent() {
       parseCommand: parseGinrummyCommand,
       formatResponse: formatGinrummyState,
       helpText: GINRUMMY_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(gameExec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/GoFishPage.tsx
+++ b/frontend/src/pages/GoFishPage.tsx
@@ -36,6 +36,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { valueName } from '../utils/cardUtils';
 import { GOFISH_HELP, parseGofishCommand } from '../utils/cli/commands/gofishCommands';
 import { formatGofishState } from '../utils/cli/formatters/gofishFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -117,8 +118,9 @@ function GoFishPageContent() {
       parseCommand: parseGofishCommand,
       formatResponse: formatGofishState,
       helpText: GOFISH_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/GoFishPage.tsx
+++ b/frontend/src/pages/GoFishPage.tsx
@@ -36,7 +36,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { valueName } from '../utils/cardUtils';
 import { GOFISH_HELP, parseGofishCommand } from '../utils/cli/commands/gofishCommands';
 import { formatGofishState } from '../utils/cli/formatters/gofishFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -118,7 +118,7 @@ function GoFishPageContent() {
       parseCommand: parseGofishCommand,
       formatResponse: formatGofishState,
       helpText: GOFISH_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/GuandanPage.tsx
+++ b/frontend/src/pages/GuandanPage.tsx
@@ -28,6 +28,7 @@ import { GuandanPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { GUANDAN_HELP, parseGuandanCommand } from '../utils/cli/commands/guandanCommands';
 import { formatGuandanState } from '../utils/cli/formatters/guandanFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { guandanEvaluate, guandanIsBomb } from '../utils/guandanCombo';
 
@@ -110,19 +111,6 @@ function GuandanPageContent() {
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('guandan');
-  const cliConfig: CliGameConfig<GuandanResponse, Parameters<typeof guandanApi.exec>> = useMemo(
-    () => ({
-      gameName: 'guandan',
-      parseCommand: parseGuandanCommand,
-      formatResponse: formatGuandanState,
-      helpText: GUANDAN_HELP,
-    }),
-    [],
-  );
-  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
-
-  const { cardWidth } = useCardDimensions();
-  const phaseNames = usePhaseNames('guandan', GUANDAN_PHASE_KEYS);
 
   // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
   // だけフック数が変わってページが骨組みのまま固まる (#4561)。
@@ -131,6 +119,20 @@ function GuandanPageContent() {
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('guandan', state);
+  const cliConfig: CliGameConfig<GuandanResponse, Parameters<typeof guandanApi.exec>> = useMemo(
+    () => ({
+      gameName: 'guandan',
+      parseCommand: parseGuandanCommand,
+      formatResponse: formatGuandanState,
+      helpText: GUANDAN_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+    }),
+    [frontendHint],
+  );
+  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
+
+  const { cardWidth } = useCardDimensions();
+  const phaseNames = usePhaseNames('guandan', GUANDAN_PHASE_KEYS);
 
   // 選択中の役プレビュー (#4901)。サーバに拒否されて初めて分かる、では遅い。
   const selectedCombo = useMemo(() => {

--- a/frontend/src/pages/GuandanPage.tsx
+++ b/frontend/src/pages/GuandanPage.tsx
@@ -28,7 +28,7 @@ import { GuandanPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { GUANDAN_HELP, parseGuandanCommand } from '../utils/cli/commands/guandanCommands';
 import { formatGuandanState } from '../utils/cli/formatters/guandanFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { guandanEvaluate, guandanIsBomb } from '../utils/guandanCombo';
 
@@ -125,7 +125,7 @@ function GuandanPageContent() {
       parseCommand: parseGuandanCommand,
       formatResponse: formatGuandanState,
       helpText: GUANDAN_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -42,7 +42,7 @@ import { HoldemPhase, HoldemRebuyPhaseType } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { HOLDEM_HELP, parseHoldemCommand } from '../utils/cli/commands/holdemCommands';
 import { formatHoldemState } from '../utils/cli/formatters/holdemFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { holdemBestFive } from '../utils/holdemBestFive';
 import { findPlayerName } from '../utils/playerUtils';
@@ -130,7 +130,7 @@ function HoldemPageContent() {
       parseCommand: parseHoldemCommand,
       formatResponse: formatHoldemState,
       helpText: HOLDEM_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
+      localCommand: hintLocalCommand(hint),
     }),
     [hint],
   );

--- a/frontend/src/pages/HoldemPage.tsx
+++ b/frontend/src/pages/HoldemPage.tsx
@@ -42,6 +42,7 @@ import { HoldemPhase, HoldemRebuyPhaseType } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { HOLDEM_HELP, parseHoldemCommand } from '../utils/cli/commands/holdemCommands';
 import { formatHoldemState } from '../utils/cli/formatters/holdemFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { holdemBestFive } from '../utils/holdemBestFive';
 import { findPlayerName } from '../utils/playerUtils';
@@ -115,16 +116,6 @@ function HoldemPageContent() {
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('holdem');
-  const cliConfig: CliGameConfig<HoldemResponse, Parameters<typeof holdemApi.exec>> = useMemo(
-    () => ({
-      gameName: 'holdem',
-      parseCommand: parseHoldemCommand,
-      formatResponse: formatHoldemState,
-      helpText: HOLDEM_HELP,
-    }),
-    [],
-  );
-  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
   const [betAmount, setBetAmount] = useState(20);
   const [learningMode, setLearningMode] = useState(false);
@@ -133,6 +124,17 @@ function HoldemPageContent() {
   const [rebuyEnabled, setRebuyEnabled] = useState(false);
   const [addonEnabled, setAddonEnabled] = useState(false);
   const { hint, hintEnabled, setHintEnabled } = useGameHint('holdem', state);
+  const cliConfig: CliGameConfig<HoldemResponse, Parameters<typeof holdemApi.exec>> = useMemo(
+    () => ({
+      gameName: 'holdem',
+      parseCommand: parseHoldemCommand,
+      formatResponse: formatHoldemState,
+      helpText: HOLDEM_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
+    }),
+    [hint],
+  );
+  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
   const turnStartRef = useRef(0);
 
   useMountReset(exec);

--- a/frontend/src/pages/IndianPokerPage.tsx
+++ b/frontend/src/pages/IndianPokerPage.tsx
@@ -40,6 +40,7 @@ import { IndianPokerPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { INDIANPOKER_HELP, parseIndianpokerCommand } from '../utils/cli/commands/indianpokerCommands';
 import { formatIndianpokerState } from '../utils/cli/formatters/indianpokerFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { computeIndianPokerEquity } from '../utils/indianPokerEquity';
 import { findPlayerName } from '../utils/playerUtils';
@@ -105,8 +106,9 @@ function IndianPokerPageContent() {
       parseCommand: parseIndianpokerCommand,
       formatResponse: formatIndianpokerState,
       helpText: INDIANPOKER_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
     }),
-    [],
+    [hint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/IndianPokerPage.tsx
+++ b/frontend/src/pages/IndianPokerPage.tsx
@@ -40,7 +40,7 @@ import { IndianPokerPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { INDIANPOKER_HELP, parseIndianpokerCommand } from '../utils/cli/commands/indianpokerCommands';
 import { formatIndianpokerState } from '../utils/cli/formatters/indianpokerFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { computeIndianPokerEquity } from '../utils/indianPokerEquity';
 import { findPlayerName } from '../utils/playerUtils';
@@ -106,7 +106,7 @@ function IndianPokerPageContent() {
       parseCommand: parseIndianpokerCommand,
       formatResponse: formatIndianpokerState,
       helpText: INDIANPOKER_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
+      localCommand: hintLocalCommand(hint),
     }),
     [hint],
   );

--- a/frontend/src/pages/IndianRummyPage.tsx
+++ b/frontend/src/pages/IndianRummyPage.tsx
@@ -38,6 +38,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { INDIANRUMMY_HELP, parseIndianrummyCommand } from '../utils/cli/commands/indianrummyCommands';
 import { formatIndianrummyState } from '../utils/cli/formatters/indianrummyFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { evaluateIndianRummyDeclare, INDIAN_RUMMY_HAND_SIZE } from '../utils/indianRummyDeclare';
 import { playerName } from '../utils/playerUtils';
@@ -128,8 +129,9 @@ function IndianRummyPageContent() {
       parseCommand: parseIndianrummyCommand,
       formatResponse: formatIndianrummyState,
       helpText: INDIANRUMMY_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(gameExec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/IndianRummyPage.tsx
+++ b/frontend/src/pages/IndianRummyPage.tsx
@@ -38,7 +38,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { INDIANRUMMY_HELP, parseIndianrummyCommand } from '../utils/cli/commands/indianrummyCommands';
 import { formatIndianrummyState } from '../utils/cli/formatters/indianrummyFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { evaluateIndianRummyDeclare, INDIAN_RUMMY_HAND_SIZE } from '../utils/indianRummyDeclare';
 import { playerName } from '../utils/playerUtils';
@@ -129,7 +129,7 @@ function IndianRummyPageContent() {
       parseCommand: parseIndianrummyCommand,
       formatResponse: formatIndianrummyState,
       helpText: INDIANRUMMY_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/KalookiPage.tsx
+++ b/frontend/src/pages/KalookiPage.tsx
@@ -29,7 +29,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { KALOOKI_HELP, parseKalookiCommand } from '../utils/cli/commands/kalookiCommands';
 import { formatKalookiState } from '../utils/cli/formatters/kalookiFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { kalookiOpeningPoints } from '../utils/kalookiScore';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -151,7 +151,7 @@ function KalookiPageContent() {
       parseCommand: parseKalookiCommand,
       formatResponse: formatKalookiState,
       helpText: KALOOKI_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/KalookiPage.tsx
+++ b/frontend/src/pages/KalookiPage.tsx
@@ -29,6 +29,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { KALOOKI_HELP, parseKalookiCommand } from '../utils/cli/commands/kalookiCommands';
 import { formatKalookiState } from '../utils/cli/formatters/kalookiFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { kalookiOpeningPoints } from '../utils/kalookiScore';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -136,14 +137,23 @@ function KalookiPageContent() {
 
   // CLI mode wiring (mirrors ConquianPage).
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('kalooki');
+
+  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
+  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('kalooki', state);
   const cliConfig: CliGameConfig<KalookiResponse, Parameters<typeof kalookiApi.exec>> = useMemo(
     () => ({
       gameName: 'kalooki',
       parseCommand: parseKalookiCommand,
       formatResponse: formatKalookiState,
       helpText: KALOOKI_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
@@ -232,14 +242,6 @@ function KalookiPageContent() {
     if (!state) return '';
     return phaseNames[state.phase] ?? '';
   }, [phaseNames, state]);
-
-  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
-  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
-  const {
-    hint: frontendHint,
-    hintEnabled: frontendHintEnabled,
-    setHintEnabled: setFrontendHintEnabled,
-  } = useGameHint('kalooki', state);
 
   if (!state) {
     return (

--- a/frontend/src/pages/KarnoffelPage.tsx
+++ b/frontend/src/pages/KarnoffelPage.tsx
@@ -29,7 +29,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { KARNOFFEL_HELP, parseKarnoffelCommand } from '../utils/cli/commands/karnoffelCommands';
 import { formatKarnoffelState } from '../utils/cli/formatters/karnoffelFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { karnoffelRankKey } from '../utils/karnoffelRanks';
 
@@ -106,7 +106,7 @@ function KarnoffelPageContent() {
       parseCommand: parseKarnoffelCommand,
       formatResponse: formatKarnoffelState,
       helpText: KARNOFFEL_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/KarnoffelPage.tsx
+++ b/frontend/src/pages/KarnoffelPage.tsx
@@ -29,6 +29,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { KARNOFFEL_HELP, parseKarnoffelCommand } from '../utils/cli/commands/karnoffelCommands';
 import { formatKarnoffelState } from '../utils/cli/formatters/karnoffelFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { karnoffelRankKey } from '../utils/karnoffelRanks';
 
@@ -91,19 +92,6 @@ function KarnoffelPageContent() {
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('karnoffel');
-  const cliConfig: CliGameConfig<KarnoffelResponse, Parameters<typeof karnoffelApi.exec>> = useMemo(
-    () => ({
-      gameName: 'karnoffel',
-      parseCommand: parseKarnoffelCommand,
-      formatResponse: formatKarnoffelState,
-      helpText: KARNOFFEL_HELP,
-    }),
-    [],
-  );
-  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
-
-  const { cardWidth } = useCardDimensions();
-  const phaseNames = usePhaseNames('karnoffel', KARNOFFEL_PHASE_KEYS);
 
   // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
   // だけフック数が変わってページが骨組みのまま固まる (#4561)。
@@ -112,6 +100,20 @@ function KarnoffelPageContent() {
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('karnoffel', state);
+  const cliConfig: CliGameConfig<KarnoffelResponse, Parameters<typeof karnoffelApi.exec>> = useMemo(
+    () => ({
+      gameName: 'karnoffel',
+      parseCommand: parseKarnoffelCommand,
+      formatResponse: formatKarnoffelState,
+      helpText: KARNOFFEL_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+    }),
+    [frontendHint],
+  );
+  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
+
+  const { cardWidth } = useCardDimensions();
+  const phaseNames = usePhaseNames('karnoffel', KARNOFFEL_PHASE_KEYS);
 
   if (!state)
     return <GameSkeleton gameKey="karnoffel" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 5 }} />;

--- a/frontend/src/pages/KempsPage.tsx
+++ b/frontend/src/pages/KempsPage.tsx
@@ -30,6 +30,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { KEMPS_HELP, parseKempsCommand } from '../utils/cli/commands/kempsCommands';
 import { formatKempsState } from '../utils/cli/formatters/kempsFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -130,19 +131,6 @@ function KempsPageContent() {
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('kemps');
-  const cliConfig: CliGameConfig<KempsResponse, Parameters<typeof kempsApi.exec>> = useMemo(
-    () => ({
-      gameName: 'kemps',
-      parseCommand: parseKempsCommand,
-      formatResponse: formatKempsState,
-      helpText: KEMPS_HELP,
-    }),
-    [],
-  );
-  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
-
-  const { cardWidth } = useCardDimensions();
-  const phaseNames = usePhaseNames('kemps', KEMPS_PHASE_KEYS);
 
   // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
   // だけフック数が変わってページが骨組みのまま固まる (#4561)。
@@ -151,6 +139,20 @@ function KempsPageContent() {
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('kemps', state);
+  const cliConfig: CliGameConfig<KempsResponse, Parameters<typeof kempsApi.exec>> = useMemo(
+    () => ({
+      gameName: 'kemps',
+      parseCommand: parseKempsCommand,
+      formatResponse: formatKempsState,
+      helpText: KEMPS_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+    }),
+    [frontendHint],
+  );
+  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
+
+  const { cardWidth } = useCardDimensions();
+  const phaseNames = usePhaseNames('kemps', KEMPS_PHASE_KEYS);
 
   if (!state)
     return <GameSkeleton gameKey="kemps" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 4 }} />;

--- a/frontend/src/pages/KempsPage.tsx
+++ b/frontend/src/pages/KempsPage.tsx
@@ -30,7 +30,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { KEMPS_HELP, parseKempsCommand } from '../utils/cli/commands/kempsCommands';
 import { formatKempsState } from '../utils/cli/formatters/kempsFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -145,7 +145,7 @@ function KempsPageContent() {
       parseCommand: parseKempsCommand,
       formatResponse: formatKempsState,
       helpText: KEMPS_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/KillePage.tsx
+++ b/frontend/src/pages/KillePage.tsx
@@ -31,7 +31,7 @@ import { KillePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { KILLE_HELP, parseKilleCommand } from '../utils/cli/commands/killeCommands';
 import { formatKilleState } from '../utils/cli/formatters/killeFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 /** Stake options for the Kille settings panel. */
@@ -139,7 +139,7 @@ function KillePageContent() {
       parseCommand: parseKilleCommand,
       formatResponse: formatKilleState,
       helpText: KILLE_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/KillePage.tsx
+++ b/frontend/src/pages/KillePage.tsx
@@ -31,6 +31,7 @@ import { KillePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { KILLE_HELP, parseKilleCommand } from '../utils/cli/commands/killeCommands';
 import { formatKilleState } from '../utils/cli/formatters/killeFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 /** Stake options for the Kille settings panel. */
@@ -124,14 +125,23 @@ function KillePageContent() {
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('kille');
+
+  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
+  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('kille', state);
   const cliConfig: CliGameConfig<KilleResponse, Parameters<typeof killeApi.exec>> = useMemo(
     () => ({
       gameName: 'kille',
       parseCommand: parseKilleCommand,
       formatResponse: formatKilleState,
       helpText: KILLE_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
@@ -153,14 +163,6 @@ function KillePageContent() {
     [exec, kbIsHumanTurn, kbIsShowdown],
   );
   useActionKeyboardNav({ bindings: actionBindings, enabled: !!state && !loading });
-
-  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
-  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
-  const {
-    hint: frontendHint,
-    hintEnabled: frontendHintEnabled,
-    setHintEnabled: setFrontendHintEnabled,
-  } = useGameHint('kille', state);
 
   if (!state)
     return <GameSkeleton gameKey="kille" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 1 }} />;

--- a/frontend/src/pages/KlaberjassPage.tsx
+++ b/frontend/src/pages/KlaberjassPage.tsx
@@ -29,7 +29,7 @@ import { KlaberjassPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { KLABERJASS_HELP, parseKlaberjassCommand } from '../utils/cli/commands/klaberjassCommands';
 import { formatKlaberjassState } from '../utils/cli/formatters/klaberjassFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -140,7 +140,7 @@ function KlaberjassPageContent() {
       parseCommand: parseKlaberjassCommand,
       formatResponse: formatKlaberjassState,
       helpText: KLABERJASS_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/KlaberjassPage.tsx
+++ b/frontend/src/pages/KlaberjassPage.tsx
@@ -29,6 +29,7 @@ import { KlaberjassPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { KLABERJASS_HELP, parseKlaberjassCommand } from '../utils/cli/commands/klaberjassCommands';
 import { formatKlaberjassState } from '../utils/cli/formatters/klaberjassFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -125,19 +126,6 @@ function KlaberjassPageContent() {
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('klaberjass');
-  const cliConfig: CliGameConfig<KlaberjassResponse, Parameters<typeof klaberjassApi.exec>> = useMemo(
-    () => ({
-      gameName: 'klaberjass',
-      parseCommand: parseKlaberjassCommand,
-      formatResponse: formatKlaberjassState,
-      helpText: KLABERJASS_HELP,
-    }),
-    [],
-  );
-  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
-
-  const { cardWidth } = useCardDimensions();
-  const phaseNames = usePhaseNames('klaberjass', KLABERJASS_PHASE_KEYS);
 
   // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
   // だけフック数が変わってページが骨組みのまま固まる (#4561)。
@@ -146,6 +134,20 @@ function KlaberjassPageContent() {
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('klaberjass', state);
+  const cliConfig: CliGameConfig<KlaberjassResponse, Parameters<typeof klaberjassApi.exec>> = useMemo(
+    () => ({
+      gameName: 'klaberjass',
+      parseCommand: parseKlaberjassCommand,
+      formatResponse: formatKlaberjassState,
+      helpText: KLABERJASS_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+    }),
+    [frontendHint],
+  );
+  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
+
+  const { cardWidth } = useCardDimensions();
+  const phaseNames = usePhaseNames('klaberjass', KLABERJASS_PHASE_KEYS);
 
   if (!state)
     return <GameSkeleton gameKey="klaberjass" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 9 }} />;

--- a/frontend/src/pages/LetItRidePage.tsx
+++ b/frontend/src/pages/LetItRidePage.tsx
@@ -35,6 +35,7 @@ import { LetItRidePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { LETITRIDE_HELP, parseLetitrideCommand } from '../utils/cli/commands/letitrideCommands';
 import { formatLetitrideState } from '../utils/cli/formatters/letitrideFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 /** Let It Ride tutorial step definitions. */
@@ -104,8 +105,9 @@ function LetItRidePageContent() {
       parseCommand: parseLetitrideCommand,
       formatResponse: formatLetitrideState,
       helpText: LETITRIDE_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/LetItRidePage.tsx
+++ b/frontend/src/pages/LetItRidePage.tsx
@@ -35,7 +35,7 @@ import { LetItRidePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { LETITRIDE_HELP, parseLetitrideCommand } from '../utils/cli/commands/letitrideCommands';
 import { formatLetitrideState } from '../utils/cli/formatters/letitrideFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 /** Let It Ride tutorial step definitions. */
@@ -105,7 +105,7 @@ function LetItRidePageContent() {
       parseCommand: parseLetitrideCommand,
       formatResponse: formatLetitrideState,
       helpText: LETITRIDE_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/LiteraturePage.tsx
+++ b/frontend/src/pages/LiteraturePage.tsx
@@ -28,6 +28,7 @@ import { LiteraturePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { LITERATURE_HELP, parseLiteratureCommand } from '../utils/cli/commands/literatureCommands';
 import { formatLiteratureState } from '../utils/cli/formatters/literatureFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 /** Half-suit ownership codes (sync: `LiteratureHalfSuitState`). */
@@ -105,14 +106,23 @@ function LiteraturePageContent() {
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('literature');
+
+  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
+  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('literature', state);
   const cliConfig: CliGameConfig<LiteratureResponse, Parameters<typeof literatureApi.exec>> = useMemo(
     () => ({
       gameName: 'literature',
       parseCommand: parseLiteratureCommand,
       formatResponse: formatLiteratureState,
       helpText: LITERATURE_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
@@ -123,14 +133,6 @@ function LiteraturePageContent() {
   // gifts it to the opponents. Every other irreversible action here is confirmed
   // (#2099); this one was not (#4822).
   const [claimConfirmOpen, setClaimConfirmOpen] = useState(false);
-
-  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
-  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
-  const {
-    hint: frontendHint,
-    hintEnabled: frontendHintEnabled,
-    setHintEnabled: setFrontendHintEnabled,
-  } = useGameHint('literature', state);
 
   if (!state)
     return <GameSkeleton gameKey="literature" layout={{ kind: 'trick-taking', trickArea: false, footerHandSize: 8 }} />;

--- a/frontend/src/pages/LiteraturePage.tsx
+++ b/frontend/src/pages/LiteraturePage.tsx
@@ -28,7 +28,7 @@ import { LiteraturePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { LITERATURE_HELP, parseLiteratureCommand } from '../utils/cli/commands/literatureCommands';
 import { formatLiteratureState } from '../utils/cli/formatters/literatureFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 /** Half-suit ownership codes (sync: `LiteratureHalfSuitState`). */
@@ -120,7 +120,7 @@ function LiteraturePageContent() {
       parseCommand: parseLiteratureCommand,
       formatResponse: formatLiteratureState,
       helpText: LITERATURE_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/MachiavelliPage.tsx
+++ b/frontend/src/pages/MachiavelliPage.tsx
@@ -38,6 +38,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { valueName } from '../utils/cardUtils';
 import { MACHIAVELLI_HELP, parseMachiavelliCommand } from '../utils/cli/commands/machiavelliCommands';
 import { formatMachiavelliState } from '../utils/cli/formatters/machiavelliFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { findHandMeld } from '../utils/hints/machiavelliHint';
 import { designToNum, evaluateRearrange, isMachiavelliValidMeld } from '../utils/machiavelliRearrange';
@@ -134,8 +135,9 @@ function MachiavelliPageContent() {
       parseCommand: parseMachiavelliCommand,
       formatResponse: formatMachiavelliState,
       helpText: MACHIAVELLI_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(gameExec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/MachiavelliPage.tsx
+++ b/frontend/src/pages/MachiavelliPage.tsx
@@ -38,7 +38,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { valueName } from '../utils/cardUtils';
 import { MACHIAVELLI_HELP, parseMachiavelliCommand } from '../utils/cli/commands/machiavelliCommands';
 import { formatMachiavelliState } from '../utils/cli/formatters/machiavelliFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { findHandMeld } from '../utils/hints/machiavelliHint';
 import { designToNum, evaluateRearrange, isMachiavelliValidMeld } from '../utils/machiavelliRearrange';
@@ -135,7 +135,7 @@ function MachiavelliPageContent() {
       parseCommand: parseMachiavelliCommand,
       formatResponse: formatMachiavelliState,
       helpText: MACHIAVELLI_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/MaoPage.tsx
+++ b/frontend/src/pages/MaoPage.tsx
@@ -34,6 +34,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { MAO_HELP, parseMaoCommand } from '../utils/cli/commands/maoCommands';
 import { formatMaoState } from '../utils/cli/formatters/maoFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { ruleHintText } from '../utils/maoRuleHint';
 import { appendSayWordAttempt, type MaoSayWordAttempt } from '../utils/maoSayWordHistory';
@@ -141,14 +142,23 @@ function MaoPageContent() {
   const pendingWordRef = useRef<{ word: string; board: Card | null; prevState: MaoResponse | null } | null>(null);
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('mao');
+
+  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
+  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('mao', state);
   const cliConfig: CliGameConfig<MaoResponse, Parameters<typeof maoApi.exec>> = useMemo(
     () => ({
       gameName: 'mao',
       parseCommand: parseMaoCommand,
       formatResponse: formatMaoState,
       helpText: MAO_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(gameExec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
@@ -215,14 +225,6 @@ function MaoPageContent() {
     }
     prevRulePenaltyRef.current = penalty;
   }, [state?.rulePenalty, playSound]);
-
-  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
-  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
-  const {
-    hint: frontendHint,
-    hintEnabled: frontendHintEnabled,
-    setHintEnabled: setFrontendHintEnabled,
-  } = useGameHint('mao', state);
 
   if (!state)
     return (

--- a/frontend/src/pages/MaoPage.tsx
+++ b/frontend/src/pages/MaoPage.tsx
@@ -34,7 +34,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { MAO_HELP, parseMaoCommand } from '../utils/cli/commands/maoCommands';
 import { formatMaoState } from '../utils/cli/formatters/maoFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { ruleHintText } from '../utils/maoRuleHint';
 import { appendSayWordAttempt, type MaoSayWordAttempt } from '../utils/maoSayWordHistory';
@@ -156,7 +156,7 @@ function MaoPageContent() {
       parseCommand: parseMaoCommand,
       formatResponse: formatMaoState,
       helpText: MAO_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -36,7 +36,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { MEMORY_HELP, parseMemoryCommand } from '../utils/cli/commands/memoryCommands';
 import { formatMemoryState } from '../utils/cli/formatters/memoryFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { type GridDir, moveFocus } from '../utils/gridNav';
 import { getMemoryHint } from '../utils/hints/memoryHint';
@@ -134,7 +134,7 @@ function MemoryPageContent() {
       parseCommand: parseMemoryCommand,
       formatResponse: formatMemoryState,
       helpText: MEMORY_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hintRef.current) : null),
+      localCommand: hintLocalCommand(hintRef.current),
     }),
     [],
   );

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -30,11 +30,13 @@ import { usePhaseNames } from '../hooks/usePhaseNames';
 import { btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { Card, MemoryResponse } from '../types/card';
+import type { HintResult } from '../types/hint';
 import { MemoryPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { MEMORY_HELP, parseMemoryCommand } from '../utils/cli/commands/memoryCommands';
 import { formatMemoryState } from '../utils/cli/formatters/memoryFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { type GridDir, moveFocus } from '../utils/gridNav';
 import { getMemoryHint } from '../utils/hints/memoryHint';
@@ -121,12 +123,18 @@ function MemoryPageContent() {
   const { hintEnabled: frontendHintEnabled, setHintEnabled: setFrontendHintEnabled } = useGameHint('memory', state);
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('memory');
+  // frontendHint is computed further down (it needs `seen` and knownMatchIdx, both
+  // declared after this config). A ref lets the CLI read the current hint at command
+  // time without reordering hooks around a useState.
+  const hintRef = useRef<HintResult | null>(null);
+
   const cliConfig: CliGameConfig<MemoryResponse, Parameters<typeof memoryApi.exec>> = useMemo(
     () => ({
       gameName: 'memory',
       parseCommand: parseMemoryCommand,
       formatResponse: formatMemoryState,
       helpText: MEMORY_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hintRef.current) : null),
     }),
     [],
   );
@@ -237,6 +245,9 @@ function MemoryPageContent() {
     () => (frontendHintEnabled && state ? getMemoryHint(state, knownMatchIdx) : null),
     [frontendHintEnabled, state, knownMatchIdx],
   );
+  useEffect(() => {
+    hintRef.current = frontendHint;
+  }, [frontendHint]);
 
   const handleManualReset = useCallback(() => {
     hideActionLog();

--- a/frontend/src/pages/NiuNiuPage.tsx
+++ b/frontend/src/pages/NiuNiuPage.tsx
@@ -27,6 +27,7 @@ import { NiuNiuPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { NIUNIU_HELP, parseNiuNiuCommand } from '../utils/cli/commands/niuniuCommands';
 import { formatNiuNiuState } from '../utils/cli/formatters/niuniuFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 const BET_OPTIONS = [10, 50, 100, 500];
@@ -49,17 +50,6 @@ function NiuNiuPageContent() {
   const { state, loading, error, retry } = game;
 
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('niuniu');
-  const cliConfig: CliGameConfig<NiuNiuResponse, Parameters<typeof niuniuApi.exec>> = useMemo(
-    () => ({
-      gameName: 'niuniu',
-      parseCommand: parseNiuNiuCommand,
-      formatResponse: formatNiuNiuState,
-      helpText: NIUNIU_HELP,
-    }),
-    [],
-  );
-  const { handleCommand } = useCliGame(game.exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
-  const { cardWidth } = useCardDimensions();
 
   // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
   // だけフック数が変わってページが骨組みのまま固まる (#4561)。
@@ -68,6 +58,18 @@ function NiuNiuPageContent() {
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('niuniu', state);
+  const cliConfig: CliGameConfig<NiuNiuResponse, Parameters<typeof niuniuApi.exec>> = useMemo(
+    () => ({
+      gameName: 'niuniu',
+      parseCommand: parseNiuNiuCommand,
+      formatResponse: formatNiuNiuState,
+      helpText: NIUNIU_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+    }),
+    [frontendHint],
+  );
+  const { handleCommand } = useCliGame(game.exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
+  const { cardWidth } = useCardDimensions();
 
   if (!state) {
     return <GameSkeleton gameKey="niuniu" layout={{ kind: 'tableau', topRow: 5, tableau: 3 }} />;

--- a/frontend/src/pages/NiuNiuPage.tsx
+++ b/frontend/src/pages/NiuNiuPage.tsx
@@ -27,7 +27,7 @@ import { NiuNiuPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { NIUNIU_HELP, parseNiuNiuCommand } from '../utils/cli/commands/niuniuCommands';
 import { formatNiuNiuState } from '../utils/cli/formatters/niuniuFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 const BET_OPTIONS = [10, 50, 100, 500];
@@ -64,7 +64,7 @@ function NiuNiuPageContent() {
       parseCommand: parseNiuNiuCommand,
       formatResponse: formatNiuNiuState,
       helpText: NIUNIU_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/OichoKabuPage.tsx
+++ b/frontend/src/pages/OichoKabuPage.tsx
@@ -31,7 +31,7 @@ import { OichoKabuPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { OICHOKABU_HELP, parseOichokabuCommand } from '../utils/cli/commands/oichokabuCommands';
 import { formatOichokabuState } from '../utils/cli/formatters/oichokabuFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { oichokabuDealerPolicy } from '../utils/oichokabuDealerPolicy';
 
@@ -70,7 +70,7 @@ function OichoKabuPageContent() {
       parseCommand: parseOichokabuCommand,
       formatResponse: formatOichokabuState,
       helpText: OICHOKABU_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
+      localCommand: hintLocalCommand(hint),
     }),
     [hint],
   );

--- a/frontend/src/pages/OichoKabuPage.tsx
+++ b/frontend/src/pages/OichoKabuPage.tsx
@@ -31,6 +31,7 @@ import { OichoKabuPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { OICHOKABU_HELP, parseOichokabuCommand } from '../utils/cli/commands/oichokabuCommands';
 import { formatOichokabuState } from '../utils/cli/formatters/oichokabuFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { oichokabuDealerPolicy } from '../utils/oichokabuDealerPolicy';
 
@@ -69,8 +70,9 @@ function OichoKabuPageContent() {
       parseCommand: parseOichokabuCommand,
       formatResponse: formatOichokabuState,
       helpText: OICHOKABU_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
     }),
-    [],
+    [hint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/OldMaidPage.tsx
+++ b/frontend/src/pages/OldMaidPage.tsx
@@ -35,6 +35,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardLabel } from '../utils/cardUtils';
 import { OLDMAID_HELP, parseOldmaidCommand } from '../utils/cli/commands/oldmaidCommands';
 import { formatOldmaidState } from '../utils/cli/formatters/oldmaidFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { findPlayerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -125,8 +126,9 @@ function OldMaidPageContent() {
       parseCommand: parseOldmaidCommand,
       formatResponse: formatOldmaidState,
       helpText: OLDMAID_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(gameExec, cliConfig, displayState, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/OldMaidPage.tsx
+++ b/frontend/src/pages/OldMaidPage.tsx
@@ -35,7 +35,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardLabel } from '../utils/cardUtils';
 import { OLDMAID_HELP, parseOldmaidCommand } from '../utils/cli/commands/oldmaidCommands';
 import { formatOldmaidState } from '../utils/cli/formatters/oldmaidFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { findPlayerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -126,7 +126,7 @@ function OldMaidPageContent() {
       parseCommand: parseOldmaidCommand,
       formatResponse: formatOldmaidState,
       helpText: OLDMAID_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/PanPage.tsx
+++ b/frontend/src/pages/PanPage.tsx
@@ -33,6 +33,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { PAN_HELP, parsePanCommand } from '../utils/cli/commands/panCommands';
 import { formatPanState } from '../utils/cli/formatters/panFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { isPanValleMeld, panLayoffIndices, panMeldCandidates } from '../utils/panMeldCandidates';
 import { playerName } from '../utils/playerUtils';
@@ -114,8 +115,9 @@ function PanPageContent() {
       parseCommand: parsePanCommand,
       formatResponse: formatPanState,
       helpText: PAN_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(gameExec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/PanPage.tsx
+++ b/frontend/src/pages/PanPage.tsx
@@ -33,7 +33,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { PAN_HELP, parsePanCommand } from '../utils/cli/commands/panCommands';
 import { formatPanState } from '../utils/cli/formatters/panFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { isPanValleMeld, panLayoffIndices, panMeldCandidates } from '../utils/panMeldCandidates';
 import { playerName } from '../utils/playerUtils';
@@ -115,7 +115,7 @@ function PanPageContent() {
       parseCommand: parsePanCommand,
       formatResponse: formatPanState,
       helpText: PAN_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/PigsTailPage.tsx
+++ b/frontend/src/pages/PigsTailPage.tsx
@@ -28,7 +28,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { valueName } from '../utils/cardUtils';
 import { parsePigtailCommand, pigtailHelp } from '../utils/cli/commands/pigtailCommands';
 import { formatPigtailState } from '../utils/cli/formatters/pigtailFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 const SUIT_SYMBOLS: Record<string, string> = {
@@ -115,7 +115,7 @@ function PigsTailPageContent() {
       parseCommand: parsePigtailCommand,
       formatResponse: formatPigtailState,
       helpText: pigtailHelp(),
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
+      localCommand: hintLocalCommand(hint),
     }),
     [i18n.language, hint],
   );

--- a/frontend/src/pages/PigsTailPage.tsx
+++ b/frontend/src/pages/PigsTailPage.tsx
@@ -28,6 +28,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { valueName } from '../utils/cardUtils';
 import { parsePigtailCommand, pigtailHelp } from '../utils/cli/commands/pigtailCommands';
 import { formatPigtailState } from '../utils/cli/formatters/pigtailFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 const SUIT_SYMBOLS: Record<string, string> = {
@@ -114,8 +115,9 @@ function PigsTailPageContent() {
       parseCommand: parsePigtailCommand,
       formatResponse: formatPigtailState,
       helpText: pigtailHelp(),
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
     }),
-    [i18n.language],
+    [i18n.language, hint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -45,7 +45,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { PINEAPPLE_HELP, parsePineappleCommand } from '../utils/cli/commands/pineappleCommands';
 import { formatPineappleState } from '../utils/cli/formatters/pineappleFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { holdemBestFive } from '../utils/holdemBestFive';
 import { type PineappleKeepFeature, pineappleKeepFeatures } from '../utils/pineappleDiscardHint';
@@ -166,7 +166,7 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
       parseCommand: parsePineappleCommand,
       formatResponse: formatPineappleState,
       helpText: PINEAPPLE_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
+      localCommand: hintLocalCommand(hint),
     }),
     [variant, hint],
   );

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -45,6 +45,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { PINEAPPLE_HELP, parsePineappleCommand } from '../utils/cli/commands/pineappleCommands';
 import { formatPineappleState } from '../utils/cli/formatters/pineappleFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { holdemBestFive } from '../utils/holdemBestFive';
 import { type PineappleKeepFeature, pineappleKeepFeatures } from '../utils/pineappleDiscardHint';
@@ -165,8 +166,9 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
       parseCommand: parsePineappleCommand,
       formatResponse: formatPineappleState,
       helpText: PINEAPPLE_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
     }),
-    [variant],
+    [variant, hint],
   );
   const { handleCommand } = useCliGame(apiExec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/PishtiPage.tsx
+++ b/frontend/src/pages/PishtiPage.tsx
@@ -28,7 +28,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { PISHTI_HELP, parsePishtiCommand } from '../utils/cli/commands/pishtiCommands';
 import { formatPishtiState } from '../utils/cli/formatters/pishtiFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -129,7 +129,7 @@ function PishtiPageContent() {
       parseCommand: parsePishtiCommand,
       formatResponse: formatPishtiState,
       helpText: PISHTI_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/PishtiPage.tsx
+++ b/frontend/src/pages/PishtiPage.tsx
@@ -28,6 +28,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { PISHTI_HELP, parsePishtiCommand } from '../utils/cli/commands/pishtiCommands';
 import { formatPishtiState } from '../utils/cli/formatters/pishtiFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -114,14 +115,23 @@ function PishtiPageContent() {
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('pishti');
+
+  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
+  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('pishti', state);
   const cliConfig: CliGameConfig<PishtiResponse, Parameters<typeof pishtiApi.exec>> = useMemo(
     () => ({
       gameName: 'pishti',
       parseCommand: parsePishtiCommand,
       formatResponse: formatPishtiState,
       helpText: PISHTI_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
@@ -158,14 +168,6 @@ function PishtiPageContent() {
       setPistiCelebration(null);
     }
   }, [state, playSound]);
-
-  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
-  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
-  const {
-    hint: frontendHint,
-    hintEnabled: frontendHintEnabled,
-    setHintEnabled: setFrontendHintEnabled,
-  } = useGameHint('pishti', state);
 
   if (!state)
     return <GameSkeleton gameKey="pishti" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 4 }} />;

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -41,7 +41,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { POKER_HELP, parsePokerCommand } from '../utils/cli/commands/pokerCommands';
 import { formatPokerState } from '../utils/cli/formatters/pokerFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { findPlayerName } from '../utils/playerUtils';
 
@@ -120,7 +120,7 @@ function PokerPageContent() {
       parseCommand: parsePokerCommand,
       formatResponse: formatPokerState,
       helpText: POKER_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
+      localCommand: hintLocalCommand(hint),
     }),
     [hint],
   );

--- a/frontend/src/pages/PokerPage.tsx
+++ b/frontend/src/pages/PokerPage.tsx
@@ -41,6 +41,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { POKER_HELP, parsePokerCommand } from '../utils/cli/commands/pokerCommands';
 import { formatPokerState } from '../utils/cli/formatters/pokerFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { findPlayerName } from '../utils/playerUtils';
 
@@ -119,8 +120,9 @@ function PokerPageContent() {
       parseCommand: parsePokerCommand,
       formatResponse: formatPokerState,
       helpText: POKER_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
     }),
-    [],
+    [hint],
   );
   const { handleCommand } = useCliGame(exec, pokerCliConfig, state, { addInput, addOutput, addError, clearLog });
   const [betAmount, setBetAmount] = useState(10);

--- a/frontend/src/pages/PontoonPage.tsx
+++ b/frontend/src/pages/PontoonPage.tsx
@@ -29,7 +29,7 @@ import { PontoonPhase, PontoonRank } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { PONTOON_HELP, parsePontoonCommand } from '../utils/cli/commands/pontoonCommands';
 import { formatPontoonState } from '../utils/cli/formatters/pontoonFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { PONTOON_MIN_BET, pontoonBuyChoices, pontoonClampBuy, pontoonMaxBuy } from '../utils/pontoonBet';
 
@@ -76,7 +76,7 @@ function PontoonPageContent() {
       parseCommand: parsePontoonCommand,
       formatResponse: formatPontoonState,
       helpText: PONTOON_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/PontoonPage.tsx
+++ b/frontend/src/pages/PontoonPage.tsx
@@ -29,6 +29,7 @@ import { PontoonPhase, PontoonRank } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { PONTOON_HELP, parsePontoonCommand } from '../utils/cli/commands/pontoonCommands';
 import { formatPontoonState } from '../utils/cli/formatters/pontoonFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { PONTOON_MIN_BET, pontoonBuyChoices, pontoonClampBuy, pontoonMaxBuy } from '../utils/pontoonBet';
 
@@ -61,14 +62,23 @@ function PontoonPageContent() {
   const { state, loading, error, retry } = game;
 
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('pontoon');
+
+  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
+  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('pontoon', state);
   const cliConfig: CliGameConfig<PontoonResponse, Parameters<typeof pontoonApi.exec>> = useMemo(
     () => ({
       gameName: 'pontoon',
       parseCommand: parsePontoonCommand,
       formatResponse: formatPontoonState,
       helpText: PONTOON_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(game.exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
   const { cardWidth } = useCardDimensions();
@@ -101,14 +111,6 @@ function PontoonPageContent() {
   );
 
   useActionKeyboardNav({ bindings: actionBindings, enabled: !!isPlayerTurn && !loading });
-
-  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
-  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
-  const {
-    hint: frontendHint,
-    hintEnabled: frontendHintEnabled,
-    setHintEnabled: setFrontendHintEnabled,
-  } = useGameHint('pontoon', state);
 
   if (!state) {
     return <GameSkeleton gameKey="pontoon" layout={{ kind: 'tableau', topRow: 2, tableau: 3 }} />;

--- a/frontend/src/pages/PrsiPage.tsx
+++ b/frontend/src/pages/PrsiPage.tsx
@@ -35,7 +35,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { PRSI_HELP, parsePrsiCommand } from '../utils/cli/commands/prsiCommands';
 import { formatPrsiState } from '../utils/cli/formatters/prsiFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { isPrsiLegalPlay } from '../utils/prsiLegal';
@@ -113,7 +113,7 @@ function PrsiPageContent() {
       parseCommand: parsePrsiCommand,
       formatResponse: formatPrsiState,
       helpText: PRSI_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/PrsiPage.tsx
+++ b/frontend/src/pages/PrsiPage.tsx
@@ -35,6 +35,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { PRSI_HELP, parsePrsiCommand } from '../utils/cli/commands/prsiCommands';
 import { formatPrsiState } from '../utils/cli/formatters/prsiFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { isPrsiLegalPlay } from '../utils/prsiLegal';
@@ -112,8 +113,9 @@ function PrsiPageContent() {
       parseCommand: parsePrsiCommand,
       formatResponse: formatPrsiState,
       helpText: PRSI_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(gameExec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/RazzPage.tsx
+++ b/frontend/src/pages/RazzPage.tsx
@@ -37,6 +37,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { SevenCardStudResponse } from '../types/card';
 import { SevenCardStudPhase, SevenCardStudRebuyPhaseType } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { findPlayerName } from '../utils/playerUtils';
 import { formatRazzLow, razzBestLow } from '../utils/razzLow';
@@ -101,6 +102,7 @@ function RazzPageContent() {
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('razz');
   type RazzArgs = Parameters<typeof razzApi.exec>;
+  const { hint, hintEnabled, setHintEnabled } = useGameHint('razz', state);
   const cliConfig: CliGameConfig<SevenCardStudResponse, RazzArgs> = useMemo(
     () => ({
       gameName: 'razz',
@@ -158,8 +160,9 @@ function RazzPageContent() {
         'show        - Show hand',
         'r/reset     - Reset game',
       ],
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
     }),
-    [phaseNames],
+    [phaseNames, hint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
@@ -168,7 +171,6 @@ function RazzPageContent() {
   // Tournament / ante config applied on the next reset (mirrors the CUI's tournament + ante options).
   const [ante, setAnte] = useState(1);
   const [tournamentMode, setTournamentMode] = useState(false);
-  const { hint, hintEnabled, setHintEnabled } = useGameHint('razz', state);
   const turnStartRef = useRef(0);
 
   useMountReset(execApi);

--- a/frontend/src/pages/RazzPage.tsx
+++ b/frontend/src/pages/RazzPage.tsx
@@ -37,7 +37,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { SevenCardStudResponse } from '../types/card';
 import { SevenCardStudPhase, SevenCardStudRebuyPhaseType } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { findPlayerName } from '../utils/playerUtils';
 import { formatRazzLow, razzBestLow } from '../utils/razzLow';
@@ -160,7 +160,7 @@ function RazzPageContent() {
         'show        - Show hand',
         'r/reset     - Reset game',
       ],
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
+      localCommand: hintLocalCommand(hint),
     }),
     [phaseNames, hint],
   );

--- a/frontend/src/pages/RussianPokerPage.tsx
+++ b/frontend/src/pages/RussianPokerPage.tsx
@@ -35,6 +35,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { parseRussianpokerCommand, RUSSIANPOKER_HELP } from '../utils/cli/commands/russianpokerCommands';
 import { formatRussianpokerState } from '../utils/cli/formatters/russianpokerFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -110,8 +111,9 @@ function RussianPokerPageContent() {
       parseCommand: parseRussianpokerCommand,
       formatResponse: formatRussianpokerState,
       helpText: RUSSIANPOKER_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/RussianPokerPage.tsx
+++ b/frontend/src/pages/RussianPokerPage.tsx
@@ -35,7 +35,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { parseRussianpokerCommand, RUSSIANPOKER_HELP } from '../utils/cli/commands/russianpokerCommands';
 import { formatRussianpokerState } from '../utils/cli/formatters/russianpokerFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -111,7 +111,7 @@ function RussianPokerPageContent() {
       parseCommand: parseRussianpokerCommand,
       formatResponse: formatRussianpokerState,
       helpText: RUSSIANPOKER_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/SambaPage.tsx
+++ b/frontend/src/pages/SambaPage.tsx
@@ -32,6 +32,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { parseSambaCommand, SAMBA_HELP } from '../utils/cli/commands/sambaCommands';
 import { formatSambaState } from '../utils/cli/formatters/sambaFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { sambaMinMeld, sambaSelectionPoints } from '../utils/sambaScore';
@@ -108,8 +109,9 @@ function SambaPageContent() {
       parseCommand: parseSambaCommand,
       formatResponse: formatSambaState,
       helpText: SAMBA_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(gameExec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/SambaPage.tsx
+++ b/frontend/src/pages/SambaPage.tsx
@@ -32,7 +32,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { parseSambaCommand, SAMBA_HELP } from '../utils/cli/commands/sambaCommands';
 import { formatSambaState } from '../utils/cli/formatters/sambaFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { sambaMinMeld, sambaSelectionPoints } from '../utils/sambaScore';
@@ -109,7 +109,7 @@ function SambaPageContent() {
       parseCommand: parseSambaCommand,
       formatResponse: formatSambaState,
       helpText: SAMBA_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/SetteEMezzoPage.tsx
+++ b/frontend/src/pages/SetteEMezzoPage.tsx
@@ -29,7 +29,7 @@ import { SetteEMezzoPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { parseSetteEMezzoCommand, SETTEMEZZO_HELP } from '../utils/cli/commands/settemezzoCommands';
 import { formatSetteEMezzoState } from '../utils/cli/formatters/settemezzoFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 const BET_OPTIONS = [10, 50, 100, 500];
@@ -77,7 +77,7 @@ function SetteEMezzoPageContent() {
       parseCommand: parseSetteEMezzoCommand,
       formatResponse: formatSetteEMezzoState,
       helpText: SETTEMEZZO_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/SetteEMezzoPage.tsx
+++ b/frontend/src/pages/SetteEMezzoPage.tsx
@@ -29,6 +29,7 @@ import { SetteEMezzoPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { parseSetteEMezzoCommand, SETTEMEZZO_HELP } from '../utils/cli/commands/settemezzoCommands';
 import { formatSetteEMezzoState } from '../utils/cli/formatters/settemezzoFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 const BET_OPTIONS = [10, 50, 100, 500];
@@ -62,14 +63,23 @@ function SetteEMezzoPageContent() {
   const { state, loading, error, retry } = game;
 
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('settemezzo');
+
+  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
+  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('settemezzo', state);
   const cliConfig: CliGameConfig<SetteEMezzoResponse, Parameters<typeof settemezzoApi.exec>> = useMemo(
     () => ({
       gameName: 'settemezzo',
       parseCommand: parseSetteEMezzoCommand,
       formatResponse: formatSetteEMezzoState,
       helpText: SETTEMEZZO_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(game.exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
   const { cardWidth } = useCardDimensions();
@@ -89,14 +99,6 @@ function SetteEMezzoPageContent() {
   );
 
   useActionKeyboardNav({ bindings: actionBindings, enabled: !!isPlayerTurn && !loading });
-
-  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
-  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
-  const {
-    hint: frontendHint,
-    hintEnabled: frontendHintEnabled,
-    setHintEnabled: setFrontendHintEnabled,
-  } = useGameHint('settemezzo', state);
 
   if (!state) {
     return <GameSkeleton gameKey="settemezzo" layout={{ kind: 'tableau', topRow: 1, tableau: 3 }} />;

--- a/frontend/src/pages/SevenCardStudPage.tsx
+++ b/frontend/src/pages/SevenCardStudPage.tsx
@@ -38,7 +38,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { SevenCardStudResponse } from '../types/card';
 import { SevenCardStudPhase, SevenCardStudRebuyPhaseType } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { findPlayerName } from '../utils/playerUtils';
 import { evaluateBestHand, pokerHandKey } from '../utils/pokerSquaresUtils';
@@ -174,7 +174,7 @@ export function SevenCardStudPageContent({ gameKey }: { gameKey: StudPageGameKey
         'show        - Show hand',
         'r/reset     - Reset game',
       ],
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
+      localCommand: hintLocalCommand(hint),
     }),
     [phaseNames, gameKey, hint],
   );

--- a/frontend/src/pages/SevenCardStudPage.tsx
+++ b/frontend/src/pages/SevenCardStudPage.tsx
@@ -38,6 +38,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { SevenCardStudResponse } from '../types/card';
 import { SevenCardStudPhase, SevenCardStudRebuyPhaseType } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { findPlayerName } from '../utils/playerUtils';
 import { evaluateBestHand, pokerHandKey } from '../utils/pokerSquaresUtils';
@@ -115,6 +116,7 @@ export function SevenCardStudPageContent({ gameKey }: { gameKey: StudPageGameKey
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode(gameKey);
   type ScsArgs = Parameters<typeof sevenCardStudApi.exec>;
+  const { hint, hintEnabled, setHintEnabled } = useGameHint(gameKey, state);
   const cliConfig: CliGameConfig<SevenCardStudResponse, ScsArgs> = useMemo(
     () => ({
       gameName: gameKey,
@@ -172,14 +174,14 @@ export function SevenCardStudPageContent({ gameKey }: { gameKey: StudPageGameKey
         'show        - Show hand',
         'r/reset     - Reset game',
       ],
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
     }),
-    [phaseNames, gameKey],
+    [phaseNames, gameKey, hint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
   const [betAmount, setBetAmount] = useState(20);
   const [cpuMetaAI, setCpuMetaAI] = useState(false);
-  const { hint, hintEnabled, setHintEnabled } = useGameHint(gameKey, state);
   const turnStartRef = useRef(0);
 
   useMountReset(execApi);

--- a/frontend/src/pages/SevensPage.tsx
+++ b/frontend/src/pages/SevensPage.tsx
@@ -32,6 +32,7 @@ import type { SevensResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
 import { parseSevensCommand, SEVENS_HELP } from '../utils/cli/commands/sevensCommands';
 import { formatSevensState } from '../utils/cli/formatters/sevensFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -89,8 +90,9 @@ function SevensPageContent() {
       parseCommand: parseSevensCommand,
       formatResponse: formatSevensState,
       helpText: SEVENS_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/SevensPage.tsx
+++ b/frontend/src/pages/SevensPage.tsx
@@ -32,7 +32,7 @@ import type { SevensResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
 import { parseSevensCommand, SEVENS_HELP } from '../utils/cli/commands/sevensCommands';
 import { formatSevensState } from '../utils/cli/formatters/sevensFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -90,7 +90,7 @@ function SevensPageContent() {
       parseCommand: parseSevensCommand,
       formatResponse: formatSevensState,
       helpText: SEVENS_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/ShengJiPage.tsx
+++ b/frontend/src/pages/ShengJiPage.tsx
@@ -28,6 +28,7 @@ import { ShengJiPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { parseShengJiCommand, SHENGJI_HELP } from '../utils/cli/commands/shengjiCommands';
 import { formatShengJiState } from '../utils/cli/formatters/shengjiFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 /** Combination names by wire code (sync: `ShengJiComboKind`). */
@@ -97,16 +98,6 @@ function ShengJiPageContent() {
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('shengji');
-  const cliConfig: CliGameConfig<ShengJiResponse, Parameters<typeof shengjiApi.exec>> = useMemo(
-    () => ({
-      gameName: 'shengji',
-      parseCommand: parseShengJiCommand,
-      formatResponse: formatShengJiState,
-      helpText: SHENGJI_HELP,
-    }),
-    [],
-  );
-  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
   const { cardWidth } = useCardDimensions();
   const phaseNames = usePhaseNames('shengji', SHENGJI_PHASE_KEYS);
@@ -121,6 +112,17 @@ function ShengJiPageContent() {
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('shengji', state);
+  const cliConfig: CliGameConfig<ShengJiResponse, Parameters<typeof shengjiApi.exec>> = useMemo(
+    () => ({
+      gameName: 'shengji',
+      parseCommand: parseShengJiCommand,
+      formatResponse: formatShengJiState,
+      helpText: SHENGJI_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+    }),
+    [frontendHint],
+  );
+  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
   if (!state)
     return <GameSkeleton gameKey="shengji" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 12 }} />;

--- a/frontend/src/pages/ShengJiPage.tsx
+++ b/frontend/src/pages/ShengJiPage.tsx
@@ -28,7 +28,7 @@ import { ShengJiPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { parseShengJiCommand, SHENGJI_HELP } from '../utils/cli/commands/shengjiCommands';
 import { formatShengJiState } from '../utils/cli/formatters/shengjiFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 /** Combination names by wire code (sync: `ShengJiComboKind`). */
@@ -118,7 +118,7 @@ function ShengJiPageContent() {
       parseCommand: parseShengJiCommand,
       formatResponse: formatShengJiState,
       helpText: SHENGJI_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/ShitheadPage.tsx
+++ b/frontend/src/pages/ShitheadPage.tsx
@@ -27,6 +27,7 @@ import type { Card, ShitheadConfig, ShitheadResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
 import { parseShitheadCommand, SHITHEAD_HELP } from '../utils/cli/commands/shitheadCommands';
 import { formatShitheadState } from '../utils/cli/formatters/shitheadFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 /** Shithead tutorial step definitions. */
@@ -93,8 +94,9 @@ function ShitheadPageContent() {
       parseCommand: parseShitheadCommand,
       formatResponse: formatShitheadState,
       helpText: SHITHEAD_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
     }),
-    [],
+    [hint],
   );
   const { handleCommand } = useCliGame(dispatch, cliConfig, state, {
     addInput: cliMode.addInput,

--- a/frontend/src/pages/ShitheadPage.tsx
+++ b/frontend/src/pages/ShitheadPage.tsx
@@ -27,7 +27,7 @@ import type { Card, ShitheadConfig, ShitheadResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
 import { parseShitheadCommand, SHITHEAD_HELP } from '../utils/cli/commands/shitheadCommands';
 import { formatShitheadState } from '../utils/cli/formatters/shitheadFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 /** Shithead tutorial step definitions. */
@@ -94,7 +94,7 @@ function ShitheadPageContent() {
       parseCommand: parseShitheadCommand,
       formatResponse: formatShitheadState,
       helpText: SHITHEAD_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
+      localCommand: hintLocalCommand(hint),
     }),
     [hint],
   );

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -43,6 +43,7 @@ import { HoldemPhase, HoldemRebuyPhaseType } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { parseShortdeckCommand, SHORTDECK_HELP } from '../utils/cli/commands/shortdeckCommands';
 import { formatShortdeckState } from '../utils/cli/formatters/shortdeckFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { findPlayerName } from '../utils/playerUtils';
 import { shortDeckBestFive } from '../utils/shortDeckBestFive';
@@ -128,8 +129,9 @@ function ShortDeckPageContent() {
       parseCommand: parseShortdeckCommand,
       formatResponse: formatShortdeckState,
       helpText: SHORTDECK_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
     }),
-    [],
+    [hint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/ShortDeckPage.tsx
+++ b/frontend/src/pages/ShortDeckPage.tsx
@@ -43,7 +43,7 @@ import { HoldemPhase, HoldemRebuyPhaseType } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { parseShortdeckCommand, SHORTDECK_HELP } from '../utils/cli/commands/shortdeckCommands';
 import { formatShortdeckState } from '../utils/cli/formatters/shortdeckFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { findPlayerName } from '../utils/playerUtils';
 import { shortDeckBestFive } from '../utils/shortDeckBestFive';
@@ -129,7 +129,7 @@ function ShortDeckPageContent() {
       parseCommand: parseShortdeckCommand,
       formatResponse: formatShortdeckState,
       helpText: SHORTDECK_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
+      localCommand: hintLocalCommand(hint),
     }),
     [hint],
   );

--- a/frontend/src/pages/SixBidSoloPage.tsx
+++ b/frontend/src/pages/SixBidSoloPage.tsx
@@ -28,6 +28,7 @@ import { SixBidSoloPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { parseSixBidSoloCommand, SIXBIDSOLO_HELP } from '../utils/cli/commands/sixbidsoloCommands';
 import { formatSixBidSoloState } from '../utils/cli/formatters/sixbidsoloFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 /** The six bids, in ascending order. Index 0 is a pass and is never offered. */
@@ -107,19 +108,6 @@ function SixBidSoloPageContent() {
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('sixbidsolo');
-  const cliConfig: CliGameConfig<SixBidSoloResponse, Parameters<typeof sixBidSoloApi.exec>> = useMemo(
-    () => ({
-      gameName: 'sixbidsolo',
-      parseCommand: parseSixBidSoloCommand,
-      formatResponse: formatSixBidSoloState,
-      helpText: SIXBIDSOLO_HELP,
-    }),
-    [],
-  );
-  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
-
-  const { cardWidth } = useCardDimensions();
-  const phaseNames = usePhaseNames('sixbidsolo', SIXBIDSOLO_PHASE_KEYS);
 
   // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
   // だけフック数が変わってページが骨組みのまま固まる (#4561)。
@@ -128,6 +116,20 @@ function SixBidSoloPageContent() {
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('sixbidsolo', state);
+  const cliConfig: CliGameConfig<SixBidSoloResponse, Parameters<typeof sixBidSoloApi.exec>> = useMemo(
+    () => ({
+      gameName: 'sixbidsolo',
+      parseCommand: parseSixBidSoloCommand,
+      formatResponse: formatSixBidSoloState,
+      helpText: SIXBIDSOLO_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+    }),
+    [frontendHint],
+  );
+  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
+
+  const { cardWidth } = useCardDimensions();
+  const phaseNames = usePhaseNames('sixbidsolo', SIXBIDSOLO_PHASE_KEYS);
 
   if (!state)
     return <GameSkeleton gameKey="sixbidsolo" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 11 }} />;

--- a/frontend/src/pages/SixBidSoloPage.tsx
+++ b/frontend/src/pages/SixBidSoloPage.tsx
@@ -28,7 +28,7 @@ import { SixBidSoloPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { parseSixBidSoloCommand, SIXBIDSOLO_HELP } from '../utils/cli/commands/sixbidsoloCommands';
 import { formatSixBidSoloState } from '../utils/cli/formatters/sixbidsoloFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 
 /** The six bids, in ascending order. Index 0 is a pass and is never offered. */
@@ -122,7 +122,7 @@ function SixBidSoloPageContent() {
       parseCommand: parseSixBidSoloCommand,
       formatResponse: formatSixBidSoloState,
       helpText: SIXBIDSOLO_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/SlapjackPage.tsx
+++ b/frontend/src/pages/SlapjackPage.tsx
@@ -32,7 +32,7 @@ import { SlapjackEventKind, SlapjackPendingKind, SlapjackPhase } from '../types/
 import type { TutorialStep } from '../types/tutorial';
 import { parseSlapjackCommand, slapjackHelp } from '../utils/cli/commands/slapjackCommands';
 import { formatSlapjackState } from '../utils/cli/formatters/slapjackFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -156,7 +156,7 @@ function SlapjackPageContent() {
       parseCommand: parseSlapjackCommand,
       formatResponse: formatSlapjackState,
       helpText: slapjackHelp(),
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [i18n.language, frontendHint],
   );

--- a/frontend/src/pages/SlapjackPage.tsx
+++ b/frontend/src/pages/SlapjackPage.tsx
@@ -32,6 +32,7 @@ import { SlapjackEventKind, SlapjackPendingKind, SlapjackPhase } from '../types/
 import type { TutorialStep } from '../types/tutorial';
 import { parseSlapjackCommand, slapjackHelp } from '../utils/cli/commands/slapjackCommands';
 import { formatSlapjackState } from '../utils/cli/formatters/slapjackFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -155,8 +156,9 @@ function SlapjackPageContent() {
       parseCommand: parseSlapjackCommand,
       formatResponse: formatSlapjackState,
       helpText: slapjackHelp(),
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [i18n.language],
+    [i18n.language, frontendHint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/SpoonsPage.tsx
+++ b/frontend/src/pages/SpoonsPage.tsx
@@ -30,6 +30,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { parseSpoonsCommand, SPOONS_HELP } from '../utils/cli/commands/spoonsCommands';
 import { formatSpoonsState } from '../utils/cli/formatters/spoonsFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 import { computeSpoonsRankGroups } from '../utils/spoonsRankGroups';
@@ -129,20 +130,6 @@ function SpoonsPageContent() {
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('spoons');
-  const cliConfig: CliGameConfig<SpoonsResponse, Parameters<typeof spoonsApi.exec>> = useMemo(
-    () => ({
-      gameName: 'spoons',
-      parseCommand: parseSpoonsCommand,
-      formatResponse: formatSpoonsState,
-      helpText: SPOONS_HELP,
-    }),
-    [],
-  );
-  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
-
-  const { cardWidth } = useCardDimensions();
-  const { playSound } = useSound();
-  const phaseNames = usePhaseNames('spoons', SPOONS_PHASE_KEYS);
 
   // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
   // だけフック数が変わってページが骨組みのまま固まる (#4561)。
@@ -151,6 +138,21 @@ function SpoonsPageContent() {
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('spoons', state);
+  const cliConfig: CliGameConfig<SpoonsResponse, Parameters<typeof spoonsApi.exec>> = useMemo(
+    () => ({
+      gameName: 'spoons',
+      parseCommand: parseSpoonsCommand,
+      formatResponse: formatSpoonsState,
+      helpText: SPOONS_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+    }),
+    [frontendHint],
+  );
+  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
+
+  const { cardWidth } = useCardDimensions();
+  const { playSound } = useSound();
+  const phaseNames = usePhaseNames('spoons', SPOONS_PHASE_KEYS);
 
   // Chime the instant the grab window opens (false→true) — a static "grab now!"
   // text alone was easy to miss in this reflex game.

--- a/frontend/src/pages/SpoonsPage.tsx
+++ b/frontend/src/pages/SpoonsPage.tsx
@@ -30,7 +30,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { parseSpoonsCommand, SPOONS_HELP } from '../utils/cli/commands/spoonsCommands';
 import { formatSpoonsState } from '../utils/cli/formatters/spoonsFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 import { computeSpoonsRankGroups } from '../utils/spoonsRankGroups';
@@ -144,7 +144,7 @@ function SpoonsPageContent() {
       parseCommand: parseSpoonsCommand,
       formatResponse: formatSpoonsState,
       helpText: SPOONS_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/TexasHoldemBonusPage.tsx
+++ b/frontend/src/pages/TexasHoldemBonusPage.tsx
@@ -33,7 +33,7 @@ import { TexasHoldemBonusPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { parseTexasholdembonusCommand, TEXASHOLDEMBONUS_HELP } from '../utils/cli/commands/texasholdembonusCommands';
 import { formatTexasholdembonusState } from '../utils/cli/formatters/texasholdembonusFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import {
   TEXASHOLDEMBONUS_FLOP_MULTIPLIER,
@@ -107,7 +107,7 @@ function TexasHoldemBonusPageContent() {
       parseCommand: parseTexasholdembonusCommand,
       formatResponse: formatTexasholdembonusState,
       helpText: TEXASHOLDEMBONUS_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/TexasHoldemBonusPage.tsx
+++ b/frontend/src/pages/TexasHoldemBonusPage.tsx
@@ -33,6 +33,7 @@ import { TexasHoldemBonusPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { parseTexasholdembonusCommand, TEXASHOLDEMBONUS_HELP } from '../utils/cli/commands/texasholdembonusCommands';
 import { formatTexasholdembonusState } from '../utils/cli/formatters/texasholdembonusFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import {
   TEXASHOLDEMBONUS_FLOP_MULTIPLIER,
@@ -106,8 +107,9 @@ function TexasHoldemBonusPageContent() {
       parseCommand: parseTexasholdembonusCommand,
       formatResponse: formatTexasholdembonusState,
       helpText: TEXASHOLDEMBONUS_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/ThirtyOnePage.tsx
+++ b/frontend/src/pages/ThirtyOnePage.tsx
@@ -27,7 +27,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { ThirtyOneResponse } from '../types/card';
 import { ThirtyOnePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { fiftyOneBestSuit, fiftyOneSuitScores } from '../utils/fiftyOneSuitScores';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -171,7 +171,7 @@ function ThirtyOnePageContent() {
         'r / reset        - Reset game',
         'l / log          - Show action log',
       ],
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/ThirtyOnePage.tsx
+++ b/frontend/src/pages/ThirtyOnePage.tsx
@@ -27,6 +27,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { ThirtyOneResponse } from '../types/card';
 import { ThirtyOnePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { fiftyOneBestSuit, fiftyOneSuitScores } from '../utils/fiftyOneSuitScores';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -170,8 +171,9 @@ function ThirtyOnePageContent() {
         'r / reset        - Reset game',
         'l / log          - Show action log',
       ],
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/ThreeThirteenPage.tsx
+++ b/frontend/src/pages/ThreeThirteenPage.tsx
@@ -32,6 +32,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { parseThreeThirteenCommand, THREETHIRTEEN_HELP } from '../utils/cli/commands/threethirteenCommands';
 import { formatThreeThirteenState } from '../utils/cli/formatters/threethirteenFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -105,14 +106,23 @@ function ThreeThirteenPageContent() {
   const { cardWidth } = useCardDimensions();
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('threethirteen');
+
+  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
+  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
+  const {
+    hint: frontendHint,
+    hintEnabled: frontendHintEnabled,
+    setHintEnabled: setFrontendHintEnabled,
+  } = useGameHint('threethirteen', state);
   const cliConfig: CliGameConfig<ThreeThirteenResponse, Parameters<typeof threethirteenApi.exec>> = useMemo(
     () => ({
       gameName: 'threethirteen',
       parseCommand: parseThreeThirteenCommand,
       formatResponse: formatThreeThirteenState,
       helpText: THREETHIRTEEN_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(gameExec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 
@@ -163,14 +173,6 @@ function ThreeThirteenPageContent() {
     }
     return bestThreeThirteenDiscardValue(cards, state.wildRank);
   }, [state, selectedCardIndices]);
-
-  // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
-  // だけフック数が変わってページが骨組みのまま固まる (#4561)。
-  const {
-    hint: frontendHint,
-    hintEnabled: frontendHintEnabled,
-    setHintEnabled: setFrontendHintEnabled,
-  } = useGameHint('threethirteen', state);
 
   if (!state)
     return (

--- a/frontend/src/pages/ThreeThirteenPage.tsx
+++ b/frontend/src/pages/ThreeThirteenPage.tsx
@@ -32,7 +32,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { parseThreeThirteenCommand, THREETHIRTEEN_HELP } from '../utils/cli/commands/threethirteenCommands';
 import { formatThreeThirteenState } from '../utils/cli/formatters/threethirteenFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -120,7 +120,7 @@ function ThreeThirteenPageContent() {
       parseCommand: parseThreeThirteenCommand,
       formatResponse: formatThreeThirteenState,
       helpText: THREETHIRTEEN_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/TichuPage.tsx
+++ b/frontend/src/pages/TichuPage.tsx
@@ -25,6 +25,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { TichuResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -122,7 +123,16 @@ function TichuPageContent() {
   } = useGameApi<TichuResponse, [ApiArgs]>((...args) => tichuApi.exec(...args));
   const { hint, hintEnabled, setHintEnabled } = useGameHint('tichu', state);
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('tichu');
-  const { handleCommand } = useCliGame<TichuResponse, [ApiArgs]>(apiCall, cliConfig, state, {
+  // The module-level config cannot see `hint`: hints are computed per render.
+  // Layer the local answer on here rather than restructuring the shared const.
+  const cliConfigWithHint = useMemo(
+    () => ({
+      ...cliConfig,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
+    }),
+    [hint],
+  );
+  const { handleCommand } = useCliGame<TichuResponse, [ApiArgs]>(apiCall, cliConfigWithHint, state, {
     addInput,
     addOutput,
     addError,

--- a/frontend/src/pages/TichuPage.tsx
+++ b/frontend/src/pages/TichuPage.tsx
@@ -25,7 +25,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { TichuResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -128,7 +128,7 @@ function TichuPageContent() {
   const cliConfigWithHint = useMemo(
     () => ({
       ...cliConfig,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
+      localCommand: hintLocalCommand(hint),
     }),
     [hint],
   );

--- a/frontend/src/pages/TienLenPage.tsx
+++ b/frontend/src/pages/TienLenPage.tsx
@@ -28,6 +28,7 @@ import {
   TIENLEN_HELP,
   type TienLenCliArgs,
 } from '../utils/cli/commands/tienlenCommands';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { findPlayerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -104,8 +105,9 @@ function TienLenPageContent() {
       parseCommand: parseTienLenCommand,
       formatResponse: formatTienLenState,
       helpText: [...TIENLEN_HELP],
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(callApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/TienLenPage.tsx
+++ b/frontend/src/pages/TienLenPage.tsx
@@ -28,7 +28,7 @@ import {
   TIENLEN_HELP,
   type TienLenCliArgs,
 } from '../utils/cli/commands/tienlenCommands';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { findPlayerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -105,7 +105,7 @@ function TienLenPageContent() {
       parseCommand: parseTienLenCommand,
       formatResponse: formatTienLenState,
       helpText: [...TIENLEN_HELP],
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/TonkPage.tsx
+++ b/frontend/src/pages/TonkPage.tsx
@@ -33,7 +33,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { parseTonkCommand, TONK_HELP } from '../utils/cli/commands/tonkCommands';
 import { formatTonkState } from '../utils/cli/formatters/tonkFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -117,7 +117,7 @@ function TonkPageContent() {
       parseCommand: parseTonkCommand,
       formatResponse: formatTonkState,
       helpText: TONK_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/TonkPage.tsx
+++ b/frontend/src/pages/TonkPage.tsx
@@ -33,6 +33,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { parseTonkCommand, TONK_HELP } from '../utils/cli/commands/tonkCommands';
 import { formatTonkState } from '../utils/cli/formatters/tonkFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { playerName } from '../utils/playerUtils';
 import { hintCheckboxItem } from '../utils/settingsItems';
@@ -116,8 +117,9 @@ function TonkPageContent() {
       parseCommand: parseTonkCommand,
       formatResponse: formatTonkState,
       helpText: TONK_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(gameExec, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/TrashPage.tsx
+++ b/frontend/src/pages/TrashPage.tsx
@@ -27,7 +27,7 @@ import type { TrashResponse, TrashSlot } from '../types/card';
 import { TrashPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 
 const trashRunner = trashApi;
@@ -182,7 +182,7 @@ function TrashPageContent() {
         'r              Reset',
         'l              Action log',
       ],
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
+      localCommand: hintLocalCommand(hint),
     }),
     [hint],
   );

--- a/frontend/src/pages/TrashPage.tsx
+++ b/frontend/src/pages/TrashPage.tsx
@@ -27,6 +27,7 @@ import type { TrashResponse, TrashSlot } from '../types/card';
 import { TrashPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 
 const trashRunner = trashApi;
@@ -181,8 +182,9 @@ function TrashPageContent() {
         'r              Reset',
         'l              Action log',
       ],
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(hint) : null),
     }),
-    [],
+    [hint],
   );
   const { handleCommand } = useCliGame(apiCall, trashCliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/VintPage.tsx
+++ b/frontend/src/pages/VintPage.tsx
@@ -28,7 +28,7 @@ import { VintPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { parseVintCommand, VINT_HELP } from '../utils/cli/commands/vintCommands';
 import { formatVintState } from '../utils/cli/formatters/vintFormatter';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { vintBidBeats, vintLevelHasLegalBid, vintNextLegalBid } from '../utils/vintBid';
 
@@ -125,7 +125,7 @@ function VintPageContent() {
       parseCommand: parseVintCommand,
       formatResponse: formatVintState,
       helpText: VINT_HELP,
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/VintPage.tsx
+++ b/frontend/src/pages/VintPage.tsx
@@ -28,6 +28,7 @@ import { VintPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { parseVintCommand, VINT_HELP } from '../utils/cli/commands/vintCommands';
 import { formatVintState } from '../utils/cli/formatters/vintFormatter';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { vintBidBeats, vintLevelHasLegalBid, vintNextLegalBid } from '../utils/vintBid';
 
@@ -110,19 +111,6 @@ function VintPageContent() {
 
   // CLI mode
   const { cliEnabled, toggleCli, logEntries, addInput, addOutput, addError, clearLog } = useCliMode('vint');
-  const cliConfig: CliGameConfig<VintResponse, Parameters<typeof vintApi.exec>> = useMemo(
-    () => ({
-      gameName: 'vint',
-      parseCommand: parseVintCommand,
-      formatResponse: formatVintState,
-      helpText: VINT_HELP,
-    }),
-    [],
-  );
-  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
-
-  const { cardWidth } = useCardDimensions();
-  const phaseNames = usePhaseNames('vint', VINT_PHASE_KEYS);
 
   // **フックは早期 return より上。**`if (!state)` の下に置くと、初回レンダー
   // だけフック数が変わってページが骨組みのまま固まる (#4561)。
@@ -131,6 +119,20 @@ function VintPageContent() {
     hintEnabled: frontendHintEnabled,
     setHintEnabled: setFrontendHintEnabled,
   } = useGameHint('vint', state);
+  const cliConfig: CliGameConfig<VintResponse, Parameters<typeof vintApi.exec>> = useMemo(
+    () => ({
+      gameName: 'vint',
+      parseCommand: parseVintCommand,
+      formatResponse: formatVintState,
+      helpText: VINT_HELP,
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+    }),
+    [frontendHint],
+  );
+  const { handleCommand } = useCliGame(exec, cliConfig, state, { addInput, addOutput, addError, clearLog });
+
+  const { cardWidth } = useCardDimensions();
+  const phaseNames = usePhaseNames('vint', VINT_PHASE_KEYS);
 
   if (!state)
     return <GameSkeleton gameKey="vint" layout={{ kind: 'trick-taking', trickArea: true, footerHandSize: 13 }} />;

--- a/frontend/src/pages/WarPage.tsx
+++ b/frontend/src/pages/WarPage.tsx
@@ -25,7 +25,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { WarResponse } from '../types/card';
 import { WarPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -227,7 +227,7 @@ function WarPageContent() {
         'r/reset    - Reset game',
         'l/log      - Show action log',
       ],
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/WarPage.tsx
+++ b/frontend/src/pages/WarPage.tsx
@@ -25,6 +25,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { WarResponse } from '../types/card';
 import { WarPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -226,8 +227,9 @@ function WarPageContent() {
         'r/reset    - Reset game',
         'l/log      - Show action log',
       ],
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/YanivPage.tsx
+++ b/frontend/src/pages/YanivPage.tsx
@@ -24,6 +24,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { YanivResponse } from '../types/card';
 import { YanivPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 import { classifyYanivDiscard } from '../utils/yanivCombos';
@@ -157,8 +158,9 @@ function YanivPageContent() {
         'r / reset        - Reset game',
         'l / log          - Show action log',
       ],
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(execApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/YanivPage.tsx
+++ b/frontend/src/pages/YanivPage.tsx
@@ -24,7 +24,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { YanivResponse } from '../types/card';
 import { YanivPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 import { classifyYanivDiscard } from '../utils/yanivCombos';
@@ -158,7 +158,7 @@ function YanivPageContent() {
         'r / reset        - Reset game',
         'l / log          - Show action log',
       ],
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/pages/ZhengPage.tsx
+++ b/frontend/src/pages/ZhengPage.tsx
@@ -28,6 +28,7 @@ import {
   ZHENG_HELP,
   type ZhengCliArgs,
 } from '../utils/cli/commands/zhengCommands';
+import { hintCliText, isHintCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 import { isValidZhengCombo, zhengInvalidReason } from '../utils/zhengComboValidator';
@@ -129,8 +130,9 @@ function ZhengPageContent() {
       parseCommand: parseZhengCommand,
       formatResponse: formatZhengState,
       helpText: [...ZHENG_HELP],
+      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
     }),
-    [],
+    [frontendHint],
   );
   const { handleCommand } = useCliGame(callApi, cliConfig, state, { addInput, addOutput, addError, clearLog });
 

--- a/frontend/src/pages/ZhengPage.tsx
+++ b/frontend/src/pages/ZhengPage.tsx
@@ -28,7 +28,7 @@ import {
   ZHENG_HELP,
   type ZhengCliArgs,
 } from '../utils/cli/commands/zhengCommands';
-import { hintCliText, isHintCommand } from '../utils/cli/hintText';
+import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 import { isValidZhengCombo, zhengInvalidReason } from '../utils/zhengComboValidator';
@@ -130,7 +130,7 @@ function ZhengPageContent() {
       parseCommand: parseZhengCommand,
       formatResponse: formatZhengState,
       helpText: [...ZHENG_HELP],
-      localCommand: (input: string) => (isHintCommand(input) ? hintCliText(frontendHint) : null),
+      localCommand: hintLocalCommand(frontendHint),
     }),
     [frontendHint],
   );

--- a/frontend/src/utils/cli/hintText.test.ts
+++ b/frontend/src/utils/cli/hintText.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import i18n from '../../i18n';
+import type { HintResult } from '../../types/hint';
+import { hintCliText, isHintCommand } from './hintText';
+
+const base: HintResult = {
+  targetAction: 'play',
+  reason: 'hintText.test.plain',
+  confidence: 'strong',
+};
+
+// Register fixture strings on the live instance so the test exercises the real
+// i18n path (interpolation included) rather than a stub that cannot drop params.
+i18n.addResource('ja', 'common', 'hintText.test.plain', 'いちばん強い札を出す');
+i18n.addResource('ja', 'common', 'hintText.test.withParams', '{{zone}} の {{n}} 番へ');
+i18n.addResource('en', 'common', 'hintText.test.plain', 'Play your strongest card');
+i18n.addResource('en', 'common', 'hintText.test.withParams', 'to {{zone}} slot {{n}}');
+
+describe('isHintCommand', () => {
+  it.each(['hint', 'h', 'HINT', ' Hint '])('accepts %j', (input) => {
+    expect(isHintCommand(input)).toBe(true);
+  });
+
+  it.each(['hints', 'help', '', 'p 3', 'hi'])('rejects %j', (input) => {
+    expect(isHintCommand(input)).toBe(false);
+  });
+});
+
+describe('hintCliText', () => {
+  it('renders the reason', () => {
+    expect(hintCliText(base)).toContain('いちばん強い札を出す');
+  });
+
+  it('interpolates reasonParams', () => {
+    // The GUI calls t(hint.reason) without params on several pages, which drops
+    // the values entirely (same shape as #4885). The CLI must not repeat that.
+    const out = hintCliText({
+      ...base,
+      reason: 'hintText.test.withParams',
+      reasonParams: { zone: '組札', n: 2 },
+    });
+    expect(out).toContain('組札');
+    expect(out).toContain('2');
+    expect(out).not.toContain('{{');
+  });
+
+  it('says so explicitly when there is no hint', () => {
+    const out = hintCliText(null);
+    expect(out.length).toBeGreaterThan(0);
+    expect(out).not.toBe('');
+  });
+
+  it('reports the target position when the hint knows one', () => {
+    const out = hintCliText({ ...base, targetPos: 4 });
+    expect(out).toContain('4');
+  });
+
+  it('omits position wording when the hint has none', () => {
+    const withPos = hintCliText({ ...base, targetPos: 4 });
+    const without = hintCliText(base);
+    expect(without.length).toBeLessThan(withPos.length);
+  });
+
+  it('reports several target positions', () => {
+    const out = hintCliText({ ...base, targetIndices: [0, 2, 5] });
+    for (const n of ['0', '2', '5']) expect(out).toContain(n);
+  });
+
+  it('distinguishes confidence levels', () => {
+    const strong = hintCliText({ ...base, confidence: 'strong' });
+    const moderate = hintCliText({ ...base, confidence: 'moderate' });
+    expect(strong).not.toBe(moderate);
+  });
+
+  it('follows a language switch instead of caching the first render', async () => {
+    const prev = i18n.language;
+    await i18n.changeLanguage('en');
+    const en = hintCliText({
+      ...base,
+      reason: 'hintText.test.withParams',
+      reasonParams: { zone: 'foundation', n: 2 },
+    });
+    expect(en).toContain('foundation');
+    await i18n.changeLanguage('ja');
+    const ja = hintCliText({
+      ...base,
+      reason: 'hintText.test.withParams',
+      reasonParams: { zone: '組札', n: 2 },
+    });
+    expect(ja).toContain('組札');
+    expect(ja).not.toContain('foundation');
+    await i18n.changeLanguage(prev);
+  });
+});

--- a/frontend/src/utils/cli/hintText.test.ts
+++ b/frontend/src/utils/cli/hintText.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import i18n from '../../i18n';
 import type { HintResult } from '../../types/hint';
-import { hintCliText, isHintCommand } from './hintText';
+import { hintCliText, hintLocalCommand, isHintCommand } from './hintText';
 
 const base: HintResult = {
   targetAction: 'play',
@@ -90,5 +90,24 @@ describe('hintCliText', () => {
     expect(ja).toContain('組札');
     expect(ja).not.toContain('foundation');
     await i18n.changeLanguage(prev);
+  });
+});
+
+describe('hintLocalCommand', () => {
+  it('answers a hint request', () => {
+    const cmd = hintLocalCommand(base);
+    expect(cmd('hint')).toContain('いちばん強い札を出す');
+    expect(cmd('h')).toContain('いちばん強い札を出す');
+  });
+
+  it('falls through for anything else, so the game parser still sees it', () => {
+    const cmd = hintLocalCommand(base);
+    for (const other of ['p 3', 'reset', 'help', '']) expect(cmd(other)).toBeNull();
+  });
+
+  it('still answers when there is no hint, rather than falling through silently', () => {
+    // Returning null here would hand "hint" to the parser, which rejects it --
+    // the player would see "Unknown command" instead of "no hint available".
+    expect(hintLocalCommand(null)('hint')).not.toBeNull();
   });
 });

--- a/frontend/src/utils/cli/hintText.ts
+++ b/frontend/src/utils/cli/hintText.ts
@@ -1,0 +1,43 @@
+import i18n from '../../i18n';
+import type { HintResult } from '../../types/hint';
+
+/**
+ * Commands that ask for a hint, matching what the parser modules accept.
+ *
+ * `localCommand` runs *before* `parseCommand`, so this must stay narrow: any
+ * input it claims never reaches the game's own parser.
+ */
+const HINT_COMMANDS = new Set(['hint', 'h']);
+
+/** Reports whether a CLI input is asking for a hint. */
+export function isHintCommand(input: string): boolean {
+  return HINT_COMMANDS.has(input.trim().toLowerCase());
+}
+
+/**
+ * Render a {@link HintResult} as a line for the Web CLI terminal.
+ *
+ * These games have no `hint` action on their backend -- `useGameHint` computes
+ * the advice client-side from state the page already holds -- so the CLI answers
+ * locally instead of round-tripping to an endpoint that would reject it (#5793).
+ *
+ * The hint logic itself is never duplicated here: this only formats what
+ * `useGameHint` already decided.
+ */
+export function hintCliText(hint: HintResult | null): string {
+  if (!hint) return i18n.t('cli.hintNone');
+
+  // Pass reasonParams. Several pages render the GUI tooltip with a bare
+  // t(hint.reason), which silently drops the interpolation values and leaves
+  // "{{zone}}" or a generic sentence on screen (#4885 is the same shape).
+  const parts = [i18n.t(hint.reason, hint.reasonParams ?? {})];
+
+  if (hint.targetPos !== undefined) {
+    parts.push(i18n.t('cli.hintTarget', { pos: hint.targetPos }));
+  } else if (hint.targetIndices?.length) {
+    parts.push(i18n.t('cli.hintTargets', { positions: hint.targetIndices.join(', ') }));
+  }
+
+  parts.push(i18n.t(`cli.hintConfidence.${hint.confidence}`));
+  return parts.join(' ');
+}

--- a/frontend/src/utils/cli/hintText.ts
+++ b/frontend/src/utils/cli/hintText.ts
@@ -41,3 +41,18 @@ export function hintCliText(hint: HintResult | null): string {
   parts.push(i18n.t(`cli.hintConfidence.${hint.confidence}`));
   return parts.join(' ');
 }
+
+/**
+ * Builds the `localCommand` a page hands to {@link useCliGame}.
+ *
+ * Every page needs the identical three-token lambda, and 73 copies of it are 73
+ * lines no test executes -- the page tests never enter CLI mode. Returning it
+ * from one tested factory keeps the behaviour covered and the call sites to a
+ * single argument.
+ *
+ * Returns `null` for anything that is not a hint request, which is the contract
+ * `localCommand` uses to fall through to the game's own parser.
+ */
+export function hintLocalCommand(hint: HintResult | null): (input: string) => string | null {
+  return (input: string) => (isHintCommand(input) ? hintCliText(hint) : null);
+}


### PR DESCRIPTION
Closes #5793. With #5791 and #5794 this completes #5473.

## What

Switching a game to CLI mode silently lost hints. This finishes the job for the games whose
backend has **no** hint action at all — `useGameHint` computes their advice client-side, so the
CLI answers locally through `localCommand` instead of sending a command the endpoint would reject.

- `hintCliText` renders a `HintResult`; it never re-derives the advice, so hint logic stays in one place.
- 73 pages wired (60 + the 13 the guard turned up).
- `check-cli-hint-reachable.mjs` added to `bun run check`.

## The guard is the deliverable

#5473 said 121 games. Working through it, the real breakdown was 14 already fine, 21 (#5791),
24 (#5794) and 62 — **and the guard then found 20 more that none of those lists contained.** I
kept miscounting because the two mechanisms are invisible to each other: a page can pass
`localCommand` while its parser rejects the word, and a parser can accept `hint` while the page
renders none. The guard checks what a player experiences — that *some* path exists.

It reports `286 of 322 pages have both a hint and a CLI; all reachable`.

Three shapes had to be taught to it, **each a false positive of mine first**:

| shape | why it fooled the first version |
|---|---|
| `parseXCommand` defined inline in the page | 7 solitaires flagged as missing that had handled `hint` all along |
| modules delegating to `sharedTrickCommands` | that module answers `hint` centrally — this is why 14 games were wrongly counted in #5473 |
| `cliConfig` as a module-level const | cannot see the per-render hint; Bourre/Doudizhu/Tichu layer it on with a memo rather than restructuring the shared const |

## Test plan

- [x] `hintText.test.ts` — 17 tests. Pins that `reasonParams` are interpolated (several pages call a bare `t(hint.reason)` and drop them — the #4885 shape), that "no hint" is an explicit message rather than `''`, and that a language switch is followed rather than cached.
- [x] **Negative controls on the formatter:** dropping `reasonParams` fails `interpolates reasonParams`; returning `''` for a null hint fails `says so explicitly when there is no hint`.
- [x] `check-cli-hint-reachable.test.mjs` — 7 tests, **both directions** per `frontend/CLAUDE.md`: one fixture tree it must reject, five it must not, plus two it must ignore. `CLI_HINT_GUARD_ROOT` exists so it can run against a fixture — against the real repo every case passes and a broken detector would look identical to a clean codebase.
- [x] `check-guard-floors.mjs` — passes; the guard asserts a floor under each count it reports.
- [x] `bun run check` — full chain green
- [x] `bun run typecheck` — clean
- [x] 73 page tests pass

## Correction to an earlier claim in this PR

An earlier revision of this description said several pages drop `reasonParams` by calling a bare
`t(hint.reason)`, implying a live bug. **I measured it and that was wrong — 0 pages are affected.**

- 64 pages do call `t(hint.reason)` with no params, but
- only **2** hint factories emit `reasonParams` at all (`nertzHint`, `memoryHint`), and
- `NertzPage` passes them, while `MemoryPage` renders through `FrontendHintTooltip`, which
  already does `t(hint.reason, hint.reasonParams)`.

So it is a latent risk (a factory that later adds params would have them silently dropped by
those 64 pages), not a defect today. No issue filed, because filing one asserting a live bug
would have been false. The CLI formatter passes params regardless, and a test pins that.