### PR TITLE
fix(shelem): credit the declarer's discard so a round still totals 100 points

### DIFF
--- a/internal/domain/Shelem.go
+++ b/internal/domain/Shelem.go
@@ -419,17 +419,38 @@ func (s *Shelem) PlayerDiscard(indices []int, suit int) error {
 			}
 		}
 	}
+	discarded := make([]*Card, 0, len(sorted))
 	for _, i := range sorted {
+		discarded = append(discarded, p.GetCard(i))
 		p.RemoveCard(i)
 	}
+	s.creditDiscard(discarded)
 	s.acceptTrump(suit)
 	return nil
+}
+
+// creditDiscard は捨て札のカード点を落札者チームに加える。
+//
+// カード点は 52 枚全体で ShelemHandPoints (100) 点あり、そのうち 4 枚はウィドウに
+// 伏せられている。落札者がウィドウを取り込んで 4 枚捨てたあと、その札の点を誰にも
+// 加算しないと、点札が捨て札に入った分だけラウンド合計が 100 を割る (#5795)。
+// ウィドウ・キティ系の通例どおり、捨てた点は落札者チームのものとして扱う。
+func (s *Shelem) creditDiscard(cards []*Card) {
+	if s.declarerIdx < 0 {
+		return
+	}
+	pts := 0
+	for _, c := range cards {
+		pts += ShelemCardPoints(c)
+	}
+	s.roundPoints[ShelemTeamOf(s.declarerIdx)] += pts
 }
 
 // cpuDiscardAndTrump CPU の落札者が点にならない札を捨て、長いスートを切り札にする
 func (s *Shelem) cpuDiscardAndTrump() {
 	suit := s.longestSuit(s.declarerIdx)
 	p := s.players[s.declarerIdx]
+	discarded := make([]*Card, 0, ShelemWidowSize)
 	// **切り札でなく、点にもならない札から捨てる。**
 	for p.GetCardsSize() > ShelemHandSize {
 		worst, worstScore := 0, 1<<30
@@ -443,8 +464,10 @@ func (s *Shelem) cpuDiscardAndTrump() {
 				worst, worstScore = i, score
 			}
 		}
+		discarded = append(discarded, p.GetCard(worst))
 		p.RemoveCard(worst)
 	}
+	s.creditDiscard(discarded)
 	s.acceptTrump(suit)
 }
 

--- a/internal/domain/Shelem.go
+++ b/internal/domain/Shelem.go
@@ -436,9 +436,9 @@ func (s *Shelem) PlayerDiscard(indices []int, suit int) error {
 // 加算しないと、点札が捨て札に入った分だけラウンド合計が 100 を割る (#5795)。
 // ウィドウ・キティ系の通例どおり、捨てた点は落札者チームのものとして扱う。
 func (s *Shelem) creditDiscard(cards []*Card) {
-	if s.declarerIdx < 0 {
-		return
-	}
+	// declarerIdx の防御は置かない。PlayerDiscard は declarerIdx != 0 で早期 return し、
+	// cpuDiscardAndTrump は declarerIdx != 0 の分岐の中でしか呼ばれない。到達しない
+	// 分岐は codecov にも残る。
 	pts := 0
 	for _, c := range cards {
 		pts += ShelemCardPoints(c)

--- a/internal/domain/Shelem_test.go
+++ b/internal/domain/Shelem_test.go
@@ -708,3 +708,127 @@ func TestShelem_ActionLog(t *testing.T) {
 	}
 	assert.True(t, kinds["bid"])
 }
+
+// 捨て札に混ざったカード点が消えないこと。
+//
+// カード点は 52 枚全体で 100 点 (A/10 が 10 点 ×8 枚、5 が 5 点 ×4 枚)。配りは
+// 48 枚 + ウィドウ 4 枚で、落札者はウィドウを取り込んで 4 枚捨てる。捨て札の点を
+// 誰にも加算しないと、点札が捨て札に入った瞬間ラウンド合計が 100 を割る (#5795)。
+//
+// TestShelem_RoundPointsAlwaysSumToOneHundred は配り依存でしか露出しないので、
+// ここは点札を強制的に捨てさせて決定的に確かめる。
+func TestShelem_DiscardedCardPointsGoToTheDeclarer(t *testing.T) {
+	newDiscardShelem := func(t *testing.T) *Shelem {
+		t.Helper()
+		s := newTestShelem(t)
+		s.SetContractForTest(0, ShelemMinBid, false)
+		s.SetPhaseForTest(ShelemPhaseDiscard)
+		return s
+	}
+
+	t.Run("human discard credits the declarer's team", func(t *testing.T) {
+		s := newDiscardShelem(t)
+		// 先頭 4 枚を点札にして、それを捨てさせる: 10 + 10 + 5 + 5 = 30。
+		hand := []*Card{
+			NewCard(CardDesignSpade, 1, false),   // A = 10
+			NewCard(CardDesignHeart, 10, false),  // 10 = 10
+			NewCard(CardDesignClover, 5, false),  // 5  = 5
+			NewCard(CardDesignDiamond, 5, false), // 5  = 5
+		}
+		for i := range ShelemHandSize {
+			hand = append(hand, NewCard(CardDesignSpade, (i%4)+6, false)) // 6-9 のみ = 確実に 0 点
+		}
+		shelemHandOf(s, 0, hand...)
+
+		require.NoError(t, s.PlayerDiscard([]int{0, 1, 2, 3}, CardDesignSpade))
+
+		assert.Equal(t, 30, s.GetRoundPoints(ShelemTeamOf(0)),
+			"捨て札のカード点が落札者チームに入っていない")
+		assert.Equal(t, 0, s.GetRoundPoints(1-ShelemTeamOf(0)),
+			"相手チームには入らない")
+	})
+
+	t.Run("discarding only zero-point cards adds nothing", func(t *testing.T) {
+		s := newDiscardShelem(t)
+		hand := make([]*Card, 0, ShelemHandSize+ShelemWidowSize)
+		for i := range ShelemHandSize + ShelemWidowSize {
+			// 6-9 のみ。(i%7)+2 は 5 を含み、5 は 5 点なので 0 点札ではない。
+			hand = append(hand, NewCard(CardDesignSpade, (i%4)+6, false))
+		}
+		shelemHandOf(s, 0, hand...)
+
+		require.NoError(t, s.PlayerDiscard([]int{0, 1, 2, 3}, CardDesignSpade))
+
+		assert.Equal(t, 0, s.GetRoundPoints(ShelemTeamOf(0)))
+	})
+
+	t.Run("cpu discard credits the declarer's team too", func(t *testing.T) {
+		s := newTestShelem(t)
+		s.SetContractForTest(1, ShelemMinBid, false)
+		s.SetPhaseForTest(ShelemPhaseDiscard)
+		// CPU は点札を避けて捨てるので、点札しか持たせない配りを組む。
+		hand := make([]*Card, 0, ShelemHandSize+ShelemWidowSize)
+		for range ShelemHandSize + ShelemWidowSize {
+			hand = append(hand, NewCard(CardDesignHeart, 5, false)) // すべて 5 点
+		}
+		shelemHandOf(s, 1, hand...)
+
+		s.CpuDiscardAndTrumpForTest()
+
+		assert.Equal(t, ShelemWidowSize*5, s.GetRoundPoints(ShelemTeamOf(1)),
+			"CPU 経路でも捨て札の点が落札者チームに入る")
+	})
+
+	t.Run("the round still totals 100 when points are discarded", func(t *testing.T) {
+		s := newDiscardShelem(t)
+		hand := []*Card{
+			NewCard(CardDesignSpade, 1, false),
+			NewCard(CardDesignHeart, 10, false),
+			NewCard(CardDesignClover, 5, false),
+			NewCard(CardDesignDiamond, 5, false),
+		}
+		for i := range ShelemHandSize {
+			hand = append(hand, NewCard(CardDesignSpade, (i%4)+6, false))
+		}
+		shelemHandOf(s, 0, hand...)
+		require.NoError(t, s.PlayerDiscard([]int{0, 1, 2, 3}, CardDesignSpade))
+
+		// 残る 70 点が卓上で取り合われたとみなす。
+		s.SetRoundPointsForTest(1-ShelemTeamOf(0), 70)
+		assert.Equal(t, ShelemHandPoints,
+			s.GetRoundPoints(0)+s.GetRoundPoints(1),
+			"捨て札の点を含めてラウンド合計が 100 になる")
+	})
+}
+
+// 捨て札の点は契約達成の判定にも数える。
+//
+// finishRound は `got := s.roundPoints[declTeam]` を契約と比べるので、捨て札を
+// 加算した分だけ落札者は契約に近づく。ウィドウ・キティ系の通例どおりで意図的な
+// 挙動だが、#5795 の修正で判定が変わる箇所なのでテストで固定しておく。
+func TestShelem_DiscardedPointsCountTowardTheContract(t *testing.T) {
+	s := newTestShelem(t)
+	s.SetContractForTest(0, 100, false) // 卓上だけでは届かない契約にする
+	s.SetPhaseForTest(ShelemPhaseDiscard)
+
+	hand := []*Card{
+		NewCard(CardDesignSpade, 1, false),   // 10
+		NewCard(CardDesignHeart, 1, false),   // 10
+		NewCard(CardDesignClover, 1, false),  // 10
+		NewCard(CardDesignDiamond, 1, false), // 10
+	}
+	for i := range ShelemHandSize {
+		hand = append(hand, NewCard(CardDesignSpade, (i%4)+6, false))
+	}
+	shelemHandOf(s, 0, hand...)
+	require.NoError(t, s.PlayerDiscard([]int{0, 1, 2, 3}, CardDesignSpade))
+	require.Equal(t, 40, s.GetRoundPoints(ShelemTeamOf(0)), "捨て札 40 点が入っている")
+
+	// 卓上で 60 点取れば、捨て札の 40 と合わせてちょうど契約 100 に届く。
+	s.SetRoundPointsForTest(ShelemTeamOf(0), 100)
+	s.SetTrickNumberForTest(ShelemTricksPerRound)
+	s.FinishRoundForTest()
+
+	assert.Positive(t, s.GetScore(ShelemTeamOf(0)),
+		"契約達成として加点される（捨て札の点を数えないと未達になる）")
+}

--- a/internal/domain/Shelem_testhelpers.go
+++ b/internal/domain/Shelem_testhelpers.go
@@ -71,3 +71,6 @@ func (s *Shelem) PlayForTest(playerIdx, cardIndex int) error { return s.play(pla
 
 // CpuChoiceForTest CPU が選ぶ手札インデックスを返す
 func (s *Shelem) CpuChoiceForTest(playerIdx int) int { return s.chooseCpuCard(playerIdx) }
+
+// CpuDiscardAndTrumpForTest CPU 落札者の捨て札・切り札決定を直接呼ぶ
+func (s *Shelem) CpuDiscardAndTrumpForTest() { s.cpuDiscardAndTrump() }


### PR DESCRIPTION
Closes #5795

## The bug

Shelem's card points total **100 across all 52 cards** (A and 10 = 10 each, 5 = 5). The deal is
48 cards plus a **4-card widow**; the declarer takes the widow and discards four. Those four were
dropped with `RemoveCard` and credited to nobody — `roundPoints` only ever grew in
`resolveTrick` — so **any point card in the discard vanished from the round**.

## Why it only failed sometimes

The CPU discard heuristic scores point cards down (`shelemRank(c) + ShelemCardPoints(c)*10`), so
it discards zero-point cards whenever it can. Only a declarer whose 16 cards leave too few
zero-point candidates exposes it — which is why `TestShelem_RoundPointsAlwaysSumToOneHundred`
failed at 95 (one buried `5`) or 90 (an A or 10) on some deals and passed on others.

It surfaced as a CI failure on an unrelated PR (#5794). Per the flake-ledger rule — **one
sighting is not a flake, investigate it as a real failure** — it turned out to be a real
pre-existing bug on develop rather than something to re-run away.

## The fix

`creditDiscard` adds the discarded points to the declarer's team, on **both** the human
(`PlayerDiscard`) and CPU (`cpuDiscardAndTrump`) paths. That is the usual rule for widow/kitty
games.

**This changes contract settlement, deliberately.** `finishRound` compares
`roundPoints[declTeam]` against the contract, so a declarer who buries points now keeps them and
is closer to making the contract. That follows from the same rule, and a test pins it rather than
leaving it as an unexamined side effect of the fix.

## Test plan

- [x] `TestShelem_DiscardedCardPointsGoToTheDeclarer` — 4 deterministic subtests. They **force**
      point cards into the discard rather than waiting for a deal that does, so the fix is
      actually exercised: human path credits 30, CPU path credits 20, a zero-point discard adds
      nothing, and the round still totals 100 when points are buried.
- [x] `TestShelem_DiscardedPointsCountTowardTheContract` — pins the settlement change.
- [x] **Negative control:** removing `creditDiscard` from the human path fails 3 subtests.
- [x] **Negative control on the original flake:** `-count=200` passes with the fix; without it,
      200 runs still reproduce `expected: 100`.
- [x] Full `go test -tags test ./internal/domain/` — green (141s)
- [x] `golangci-lint run ./internal/domain/...` — 0 issues
- [x] `goimports -l` — clean

## A fixture bug worth noting

My first "zero-point filler" used `(i%7)+2`, which spans 2–8 and therefore **includes 5** — a
5-point card. The subtest asserting "discarding only zero-point cards adds nothing" failed at 5,
and the fault was the fixture, not the code. Fillers now use 6–9 only.