### PR TITLE
test(durak): stop asserting that no game in 200 reaches the bout limit

### DIFF
--- a/internal/domain/Durak_test.go
+++ b/internal/domain/Durak_test.go
@@ -872,7 +872,7 @@ func TestDurak_BoutLimitEndsTheGame(t *testing.T) {
 	}
 	d := domain.NewDurak(domain.NewTrumpCardsShortDeck(), players)
 
-	// 健全な局は上限から遠い (実測の最大は 78 バウト)。
+	// 健全な局は上限から遠い (2026-08-16 実測: 20,000 局での最大は 30 バウト)。
 	//
 	// **「200 局すべてが上限未満」は書けない。** すぐ上のコメントが書いているとおり
 	// 20 万局に 14 局は上限に到達するので、200 局を回すと
@@ -895,10 +895,12 @@ func TestDurak_BoutLimitEndsTheGame(t *testing.T) {
 			require.True(t, d.GetGameEndFlag(), "局が終わっていない")
 
 			if d.GetBoutNumber() >= domain.DurakMaxBouts {
+				// 上限に達した局が終局していることは、上の require.True が
+				// 全局について既に保証している。ここで assert.True を重ねても
+				// 決して落ちない空のアサーションになるだけなので置かない。
+				// 打ち切り局が敗者を決めることは "every finished game names a
+				// loser" が別に見ている。
 				capped++
-				// 打ち切られた局も敗者を決めて終わること。ここが崩れると
-				// 「上限に達したので投げ出した」状態を見逃す。
-				assert.True(t, d.GetGameEndFlag(), "上限に達した局が終局していない")
 				continue
 			}
 			if d.GetBoutNumber() > worstNormal {

--- a/internal/domain/Durak_test.go
+++ b/internal/domain/Durak_test.go
@@ -872,18 +872,53 @@ func TestDurak_BoutLimitEndsTheGame(t *testing.T) {
 	}
 	d := domain.NewDurak(domain.NewTrumpCardsShortDeck(), players)
 
-	// 健全な局は上限に触れない (実測の最大は 78 バウト)。
+	// 健全な局は上限から遠い (実測の最大は 78 バウト)。
+	//
+	// **「200 局すべてが上限未満」は書けない。** すぐ上のコメントが書いているとおり
+	// 20 万局に 14 局は上限に到達するので、200 局を回すと
+	// 1 - (1 - 14/200000)^200 = 1.4%、およそ 72 回に 1 回このサブテストが落ちる。
+	// 実際 #5799 として無関係な PR の CI を繰り返し赤くしていた。
+	//
+	// 到達した局は異常ではなく、#5415 で入れた打ち切りが正しく働いた局である。
+	// なので到達を許容しつつ、(1) 到達は稀であること (2) 到達しなかった局は上限の
+	// はるか下で終わること (3) 到達した局もちゃんと終局していること、を確かめる。
 	t.Run("a normal game finishes well inside the limit", func(t *testing.T) {
-		for range 200 {
+		const games = 200
+		capped, worstNormal := 0, 0
+		for range games {
 			d.Reset()
 			turns := 0
 			for !d.GetGameEndFlag() && turns < 500 {
 				d.CpuPlay()
 				turns++
 			}
-			assert.True(t, d.GetGameEndFlag())
-			assert.Less(t, d.GetBoutNumber(), domain.DurakMaxBouts)
+			require.True(t, d.GetGameEndFlag(), "局が終わっていない")
+
+			if d.GetBoutNumber() >= domain.DurakMaxBouts {
+				capped++
+				// 打ち切られた局も敗者を決めて終わること。ここが崩れると
+				// 「上限に達したので投げ出した」状態を見逃す。
+				assert.True(t, d.GetGameEndFlag(), "上限に達した局が終局していない")
+				continue
+			}
+			if d.GetBoutNumber() > worstNormal {
+				worstNormal = d.GetBoutNumber()
+			}
 		}
+
+		// 境界は推測せず実測から決めた (2026-08-16)。この 200 局ループ自体を 300 回
+		// 標本化したところ「200 局中の最大バウト数」は min=21 / p50=25 / p99=29 /
+		// max=31 と狭く分布する。45 なら観測最大の 31 から 45% の余裕があるので
+		// 普通の揺れでは落ちず、バウト数が 2 倍になる退行 (25 -> 50) は捕まえられる。
+		//
+		// 20,000 局での最大も 30 で、コメントにあった「実測の最大は 78」とは合わない。
+		// 78 が何を測った値かは追えなかったので、ここは自分で測った値を根拠にする。
+		const normalBoutCeiling = 45
+		assert.Less(t, worstNormal, normalBoutCeiling,
+			"上限に達しなかった局が長くなりすぎている (2026-08-16 の実測は最大 30 バウト)")
+		// 14/200000 なら 200 局での期待値は 0.014 件。3 件も出るなら頻度が桁違いに増えている。
+		assert.LessOrEqual(t, capped, 3,
+			"上限に達する局が想定より多い (#5414 の実測は 20 万局に 14 局)")
 	})
 
 	// 上限は健全な局の 2 倍以上離れていること。近すぎると普通の局を打ち切る。


### PR DESCRIPTION
Closes #5799

## The contradiction

The subtest ran 200 random games and required **every one** to finish below `DurakMaxBouts`,
while the comment four lines above it records that **14 games in 200,000 do reach the limit**
(#5414's measurement). Both cannot hold:

```
P(at least one of 200 games reaches the limit) = 1 - (1 - 14/200000)^200 = 0.0139
→ about one failure every 72 runs
```

`DurakMaxBouts = 200`, so a game that reaches it fails `assert.Less(200, 200)`. It reddened CI on
PRs that never touched Durak — **three times during #5797 alone**.

A game reaching the limit is not a defect; it is the cut-off added in #5415 working correctly.

## What it checks now

The same intent, stated so it can be true:

- every game ends (`require`)
- games that did **not** hit the limit finish far below it
- hitting the limit stays rare

## Both bounds are measured, not guessed

I sampled this exact 200-game loop **300 times** and recorded the worst bout count among
non-capped games:

| min | p50 | p99 | max |
|---:|---:|---:|---:|
| 21 | 25 | 29 | 31 |

So `45` leaves ~45% headroom over the observed maximum — wide enough never to flake, tight
enough to catch a regression.

**A correction while measuring**: over 20,000 games the worst was also **30**, and nothing hit
the limit (expected 1.4, consistent). That does not match the `実測の最大は 78` in the old
comment. I could not trace what 78 measured, so the new comment cites the numbers I took rather
than repeating one I cannot support.

## Test plan

- [x] **500 consecutive runs pass.** At the old 1.4% rate roughly 7 failures would be expected.
- [x] **Sensitivity verified by mutation**: inflating the bout counter **2x fails**, **3x fails**.
      My first attempt used a bound of 80 and only caught ≥5x — the comment claimed it caught 3x,
      which was false, so the bound was re-derived from the sampled distribution until the claim
      matched the behaviour.
- [x] Test-only change (39 insertions in `Durak_test.go`); no production code touched.
- [x] `go vet` / `goimports` clean

## Note

`#5798` (Sakura's tamper test panics when the field empties) is the other flake this PR's
investigation surfaced; it is filed separately and not fixed here.