### PR TITLE
test(lingerlonger): assert the hand size is unchanged across a won trick

### DIFF
--- a/frontend/e2e/lingerlonger.spec.ts
+++ b/frontend/e2e/lingerlonger.spec.ts
@@ -110,4 +110,31 @@ test.describe('Linger Longer E2E', () => {
     }
     test.skip(true, 'この配りでは人間が 40 トリック以内に 1 度も取れなかった');
   });
+
+  test('can reset the game via the reset confirmation dialog', async ({ page }) => {
+    await navigateTo(page, '/lingerlonger');
+    await expect(page.getByTestId('ll-stock')).toBeVisible({ timeout: TIMEOUT_TRANSITION });
+
+    await page
+      .getByRole('button', { name: /^リセット$|^Reset$/ })
+      .first()
+      .click();
+    await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: TIMEOUT_TRANSITION });
+    await page
+      .getByRole('button', { name: /^確認$|^Confirm$/ })
+      .first()
+      .click();
+    await expect(page.getByTestId('ll-stock')).toBeVisible({ timeout: TIMEOUT_TRANSITION });
+  });
+
+  test('give up ends the game', async ({ page }) => {
+    await navigateTo(page, '/lingerlonger');
+    await expect(page.getByTestId('ll-stock')).toBeVisible({ timeout: TIMEOUT_TRANSITION });
+
+    await page
+      .getByRole('button', { name: /^投了$|^Give up$/ })
+      .first()
+      .click();
+    await expect(page.getByTestId('ll-result')).toBeVisible({ timeout: TIMEOUT_ACTION });
+  });
 });

--- a/frontend/e2e/lingerlonger.spec.ts
+++ b/frontend/e2e/lingerlonger.spec.ts
@@ -48,50 +48,66 @@ test.describe('Linger Longer E2E', () => {
       .not.toBe(stockBefore);
   });
 
-  // **勝ち続けるかぎり手札は減らない。** そこがこのゲームの全部。
+  // **取ったトリックの前後で手札は減らない。** そこがこのゲームの全部。
+  //
+  // 以前はこれを「補充した席は必ず配り枚数(4枚)」と書いていたが、`[直前に補充]` が
+  // 意味するのは「直前のトリックを取った」だけで、それ以前に落としていないことは
+  // 保証しない。落とせば補充が無く 1 枚ずつ減るので、`手札1枚 / 獲得1回` という
+  // 正しい状態でテストが落ちていた (#5802)。不変条件は枚数の固定値ではなく
+  // 「取ったトリックを挟んで枚数が変わらない」こと。
   test('a seat that wins a trick keeps its hand size', async ({ page }) => {
     await navigateTo(page, '/lingerlonger');
     await expect(hand(page).first()).toBeVisible({ timeout: TIMEOUT_ACTION });
 
-    for (let i = 0; i < 12; i++) {
+    const seat0 = page.getByTestId('ll-seat-0');
+    const cardsOf = async (): Promise<number | null> => {
+      const m = /手札(\d+)枚/.exec((await seat0.textContent()) ?? '');
+      return m?.[1] === undefined ? null : Number(m[1]);
+    };
+    const stockOf = async (): Promise<number | null> => {
+      // ラベルは「山札 残り{{n}}枚」。`山札(\\d+)` では一致しない。
+      const m = /残り(\d+)枚/.exec((await page.getByTestId('ll-stock').textContent()) ?? '');
+      return m?.[1] === undefined ? null : Number(m[1]);
+    };
+
+    // **12 では足りない。** 人間が 1 度も取れずに skip で終わる配りが 20 回中 13 回
+    // あった (2026-08-16 実測)。skip は「通った」ではなく「何も確かめていない」なので、
+    // 取れるまでの手数を増やして実際に検証が走る割合を上げる。
+    for (let i = 0; i < 40; i++) {
       if (await page.getByTestId('ll-result').isVisible()) break;
-      const drew = page.getByTestId('ll-seat-0');
-      if ((await drew.textContent())?.includes('補充')) {
-        // 直前に補充した席は、出した 1 枚が戻っているので配った枚数のまま。
-        await expect(drew).toContainText('手札4枚');
-        return;
-      }
+
+      // **CPU が打ち終わるのを待つ。** 直後に legalCard を見て break していたため、
+      // 自分の手番が戻る前にループを抜けてしまい、40 手回しても skip 率が下がらなかった。
+      await expect(legalCard(page).first().or(page.getByTestId('ll-result'))).toBeVisible({
+        timeout: TIMEOUT_ACTION,
+      });
+      if (await page.getByTestId('ll-result').isVisible()) break;
       if (!(await legalCard(page).first().isVisible())) break;
+
+      const cardsBefore = await cardsOf();
+      const stockBefore = await stockOf();
       await legalCard(page).first().click();
-      await expect(hand(page).first().or(page.getByTestId('ll-result'))).toBeVisible({ timeout: TIMEOUT_ACTION });
+      await expect(hand(page).first().or(page.getByTestId('ll-result'))).toBeVisible({
+        timeout: TIMEOUT_ACTION,
+      });
+
+      const wonThisTrick = ((await seat0.textContent()) ?? '').includes('[直前に補充]');
+      if (!wonThisTrick) continue;
+
+      // **山札が空なら取っても補充できない。** その局面まで不変を求めると、
+      // ルールどおりに減った手札を異常と呼ぶことになる。さらに `[直前に補充]` は
+      // `lastDrawIdx` の表示で、補充が止まると**更新されず残る**ので、山札が尽きた
+      // 後はこの印を「今取った」の証拠に使えない。
+      //
+      // 読めなかったときに素通りさせない。ラベルが変われば黙って判定が壊れるので、
+      // 分からないなら止める。
+      expect(stockBefore, '山札の枚数が読めない (ラベルが変わった?)').not.toBeNull();
+      if (stockBefore !== null && stockBefore <= 0) break;
+
+      expect(cardsBefore).not.toBeNull();
+      expect(await cardsOf()).toBe(cardsBefore);
+      return;
     }
-    test.skip(true, 'この配りでは人間が 12 トリック以内に取れなかった');
-  });
-
-  test('can reset the game via the reset confirmation dialog', async ({ page }) => {
-    await navigateTo(page, '/lingerlonger');
-    await expect(page.getByTestId('ll-stock')).toBeVisible({ timeout: TIMEOUT_TRANSITION });
-
-    await page
-      .getByRole('button', { name: /^リセット$|^Reset$/ })
-      .first()
-      .click();
-    await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: TIMEOUT_TRANSITION });
-    await page
-      .getByRole('button', { name: /^確認$|^Confirm$/ })
-      .first()
-      .click();
-    await expect(page.getByTestId('ll-stock')).toBeVisible({ timeout: TIMEOUT_TRANSITION });
-  });
-
-  test('give up ends the game', async ({ page }) => {
-    await navigateTo(page, '/lingerlonger');
-    await expect(page.getByTestId('ll-stock')).toBeVisible({ timeout: TIMEOUT_TRANSITION });
-
-    await page
-      .getByRole('button', { name: /^投了$|^Give up$/ })
-      .first()
-      .click();
-    await expect(page.getByTestId('ll-result')).toBeVisible({ timeout: TIMEOUT_ACTION });
+    test.skip(true, 'この配りでは人間が 40 トリック以内に 1 度も取れなかった');
   });
 });


### PR DESCRIPTION
Closes #5802

## The wrong assertion

The test read seat 0's label and, if it carried `[直前に補充]`, required the hand to be exactly
**4 cards**. That marker only means the seat took the **last** trick — it says nothing about
earlier ones. A seat that loses tricks shrinks by a card each time, so
`手札1枚 / 獲得1回` (the state CI actually hit) is a **correct board**. The assertion was wrong,
not the game.

## What it checks now

The real invariant: **a won trick leaves the hand size unchanged** — one card played, one drawn
back. It reads the count before the click and compares after, instead of pinning a constant.

Two conditions the old version ignored:

- **Empty stock** — a winner cannot draw, so the size legitimately drops.
- **Stale marker** — `[直前に補充]` renders from `lastDrawIdx`, which stops updating once drawing
  stops, so the marker lingers on a seat that did *not* just win.

Both are excluded by checking the stock first. An unreadable stock count now **fails loudly**
rather than falling through — otherwise renaming the label would silently disable the guard,
which is how the original defect survived.

## Skips are not passes

The loop broke the instant no legal card was on screen, which happened while the CPUs were still
playing. It now waits for the turn to come back.

| | runs reaching the assertion |
|---|---|
| before | 35% (7/20) |
| after | **43%** (39/90) |

The remainder still skip because the game can end before the human wins anything — inherent to
the deal. A skip is visible in the report rather than a false green, so I have not papered over it.

## Test plan

- [x] **90 repeats, 0 failures** (39 passed / 51 skipped)
- [x] **Mutation control:** inverting the comparison to `cardsBefore - 1` fails every run that
      reaches the assertion — proof it is actually evaluated and not just skipped past
- [x] Full spec passes (4 passed / 1 skipped)
- [x] `biome check` / `bun run typecheck` clean
- [x] Test-only change; no production code touched

## Context

This is the last of four pre-existing flakes surfaced while landing #5795: #5799 (Durak,
merged), #5798 (Sakura, merged), and this one. All four were deal-dependent tests reddening CI
on unrelated PRs.