### PR TITLE
fix(oldmaid): stop showing the player where the CPU hid the odd card

### DIFF
--- a/frontend/src/components/oldmaid/OldMaidPlayerArea.test.tsx
+++ b/frontend/src/components/oldmaid/OldMaidPlayerArea.test.tsx
@@ -82,28 +82,37 @@ describe('OldMaidPlayerArea suspect/target a11y', () => {
   });
 });
 
-describe('OldMaidPlayerArea CPU highlight', () => {
+describe('OldMaidPlayerArea does not reveal the CPU placement trap', () => {
   const selectableProps = { ...defaultProps, isTarget: true, isHumanTurn: true };
 
-  it('applies gold accent border and glow to highlighted card via tokens', () => {
-    render(<OldMaidPlayerArea {...selectableProps} player={makeCpuPlayer(3)} highlightedCardIdx={1} />);
-    // Selectable cards are rendered as buttons; style is on the img inside
-    const buttons = screen.getAllByRole('button');
-    const imgs = buttons.map((btn) => btn.querySelector('img'));
-    // Highlighted card (index 1) should reference design tokens via CSS custom properties
-    expect(imgs[1]?.getAttribute('style')).toContain('var(--color-ds-accent)');
-    expect(imgs[1]?.getAttribute('style')).toContain('var(--shadow-ds-accent-glow)');
-    // Non-highlighted card (index 0) should have transparent border
-    expect(imgs[0]).toHaveStyle({ border: '2px solid transparent' });
-  });
-
-  it('does not highlight when highlightedCardIdx is -1', () => {
-    render(<OldMaidPlayerArea {...selectableProps} player={makeCpuPlayer(3)} highlightedCardIdx={-1} />);
-    const buttons = screen.getAllByRole('button');
-    for (const btn of buttons) {
-      const img = btn.querySelector('img');
+  // cpuPlacementStrategy は「人間が引きたくなる位置に奇数札を置く」誘い込み。
+  // その位置を光らせると、引く前に避けるべき札を教える案内に反転する (#5476)。
+  // 以前のテストは金枠とグローが**付くこと**を要求しており、バグを固定していた。
+  it('renders every CPU card with the same neutral style', () => {
+    render(<OldMaidPlayerArea {...selectableProps} player={makeCpuPlayer(3)} />);
+    const imgs = screen.getAllByRole('button').map((btn) => btn.querySelector('img'));
+    expect(imgs.length).toBeGreaterThan(1);
+    for (const img of imgs) {
       expect(img).not.toBeNull();
       expect(img).toHaveStyle({ border: '2px solid transparent' });
+    }
+  });
+
+  it('leaves no card visually distinguishable from the others', () => {
+    render(<OldMaidPlayerArea {...selectableProps} player={makeCpuPlayer(4)} />);
+    const styles = screen.getAllByRole('button').map((btn) => btn.querySelector('img')?.getAttribute('style') ?? '');
+    expect(styles.length).toBeGreaterThan(1);
+    // 一枚でも違えば、それが罠の位置を指す手がかりになる。
+    expect(new Set(styles).size).toBe(1);
+  });
+
+  it('applies no accent colour, lift or glow to any card', () => {
+    render(<OldMaidPlayerArea {...selectableProps} player={makeCpuPlayer(4)} />);
+    for (const btn of screen.getAllByRole('button')) {
+      const style = btn.querySelector('img')?.getAttribute('style') ?? '';
+      expect(style).not.toContain('var(--color-ds-accent)');
+      expect(style).not.toContain('var(--shadow-ds-accent-glow)');
+      expect(style).not.toContain('translateY');
     }
   });
 });

--- a/frontend/src/components/oldmaid/OldMaidPlayerArea.test.tsx
+++ b/frontend/src/components/oldmaid/OldMaidPlayerArea.test.tsx
@@ -32,7 +32,6 @@ const defaultProps = {
   isHumanTurn: false,
   gameEndFlag: false,
   loading: false,
-  highlightedCardIdx: -1,
   onDraw: vi.fn(),
 };
 

--- a/frontend/src/components/oldmaid/OldMaidPlayerArea.tsx
+++ b/frontend/src/components/oldmaid/OldMaidPlayerArea.tsx
@@ -25,7 +25,6 @@ export interface PlayerAreaProps {
   isHumanTurn: boolean;
   gameEndFlag: boolean;
   loading: boolean;
-  highlightedCardIdx: number;
   isSuspect?: boolean;
   onToggleSuspect?: () => void;
   onDraw: (drawIdx: number) => void;
@@ -53,7 +52,6 @@ export function OldMaidPlayerArea({
   isHumanTurn,
   gameEndFlag,
   loading,
-  highlightedCardIdx,
   isSuspect,
   onToggleSuspect,
   onDraw,
@@ -267,18 +265,15 @@ export function OldMaidPlayerArea({
         ) : showSelectable ? (
           <>
             {Array.from({ length: showCount }, (_, i) => {
-              const isHighlighted = isTarget && !player.isHuman && i === highlightedCardIdx;
+              // **罠の位置を光らせない。** cpuPlacementStrategy は「人間が引きたく
+              // なる位置に奇数札を置く」誘い込みで、その位置を金枠・浮き上がり・
+              // グローで描くと、引く前に避けるべき札を教える案内に反転する (#5476)。
+              // ドメイン側の配置そのものは機能なので触らない。見せないだけ。
               const cardStyle: React.CSSProperties = {
-                border: isHighlighted ? '2px solid var(--color-ds-accent)' : '2px solid transparent',
+                border: '2px solid transparent',
                 borderRadius: 4,
                 cursor: 'pointer',
                 transition: 'transform 0.2s, border-color 0.2s, box-shadow 0.2s',
-                ...(isHighlighted
-                  ? {
-                      transform: 'translateY(-8px)',
-                      boxShadow: 'var(--shadow-ds-accent-glow)',
-                    }
-                  : {}),
               };
               return (
                 <CardBack

--- a/frontend/src/components/oldmaid/OldMaidPlayerArea.tsx
+++ b/frontend/src/components/oldmaid/OldMaidPlayerArea.tsx
@@ -46,6 +46,20 @@ export interface PlayerAreaProps {
 }
 
 /** Renders a player area for Old Maid with draw targets, hand display, and reorder support. */
+/**
+ * すべての CPU カードに同じ見た目を与える。
+ *
+ * cpuPlacementStrategy は「人間が引きたくなる位置に奇数札を置く」誘い込みなので、
+ * その位置だけ枠や影を変えると、引く前に避けるべき札を教える案内に反転する (#5476)。
+ * 1 枚でも見た目が違えばそれが手がかりになるため、定数を全枚に使い回す。
+ */
+const NEUTRAL_CARD_STYLE: React.CSSProperties = {
+  border: '2px solid transparent',
+  borderRadius: 4,
+  cursor: 'pointer',
+  transition: 'transform 0.2s, border-color 0.2s, box-shadow 0.2s',
+};
+
 export function OldMaidPlayerArea({
   player,
   isTarget,
@@ -265,21 +279,12 @@ export function OldMaidPlayerArea({
         ) : showSelectable ? (
           <>
             {Array.from({ length: showCount }, (_, i) => {
-              // **罠の位置を光らせない。** cpuPlacementStrategy は「人間が引きたく
-              // なる位置に奇数札を置く」誘い込みで、その位置を金枠・浮き上がり・
-              // グローで描くと、引く前に避けるべき札を教える案内に反転する (#5476)。
-              // ドメイン側の配置そのものは機能なので触らない。見せないだけ。
-              const cardStyle: React.CSSProperties = {
-                border: '2px solid transparent',
-                borderRadius: 4,
-                cursor: 'pointer',
-                transition: 'transform 0.2s, border-color 0.2s, box-shadow 0.2s',
-              };
+              // 全カードを同一スタイルで描く。罠の位置を光らせない (#5476)。
               return (
                 <CardBack
                   key={i}
                   width={cardWidth}
-                  style={cardStyle}
+                  style={NEUTRAL_CARD_STYLE}
                   onClick={() => onDraw(i)}
                   ariaLabel={t('drawCardAriaLabel', { idx: i + 1 })}
                 />

--- a/frontend/src/pages/OldMaidPage.test.tsx
+++ b/frontend/src/pages/OldMaidPage.test.tsx
@@ -243,18 +243,26 @@ describe('OldMaidPage', () => {
     expect(screen.getByText('ジジ抜き')).toBeInTheDocument();
   });
 
-  it('highlighted card has translateY style', async () => {
-    const highlightedState: OldMaidResponse = {
+  // #5476: cpuHighlightedCardIdx が指す罠の位置を、引く前に見せてはいけない。
+  // 以前はここで translateY(-8px) が**付くこと**を要求しており、バグを固定していた。
+  it('does not reveal the CPU placement trap before the human draws', async () => {
+    const trapState: OldMaidResponse = {
       ...humanTurnState,
       cpuHighlightedCardIdx: 0,
       nextDrawTargetIdx: 1,
       currentTurn: 0,
     };
-    mockExec.mockResolvedValue(highlightedState);
+    mockExec.mockResolvedValue(trapState);
     await startGame();
-    const btn = screen.getByRole('button', { name: 'カード 1 枚目を引く' });
-    const img = btn.querySelector('img') as HTMLImageElement;
-    expect(img).toHaveStyle({ transform: 'translateY(-8px)' });
+    const btns = screen.getAllByRole('button', { name: /カード \d+ 枚目を引く/ });
+    expect(btns.length).toBeGreaterThan(1);
+    const styles = btns.map((b) => b.querySelector('img')?.getAttribute('style') ?? '');
+    // 罠の位置 (0) が他と同じ見た目であること。1 枚でも違えば手がかりになる。
+    expect(new Set(styles).size).toBe(1);
+    for (const style of styles) {
+      expect(style).not.toContain('translateY');
+      expect(style).not.toContain('var(--shadow-ds-accent-glow)');
+    }
   });
 
   it('non-highlighted cards do not have translateY style', async () => {

--- a/frontend/src/pages/OldMaidPage.tsx
+++ b/frontend/src/pages/OldMaidPage.tsx
@@ -288,7 +288,6 @@ function OldMaidPageContent() {
                     isHumanTurn={isHumanTurn}
                     gameEndFlag={state.gameEndFlag}
                     loading={loading}
-                    highlightedCardIdx={state.nextDrawTargetIdx === player.id ? state.cpuHighlightedCardIdx : -1}
                     isSuspect={suspectPins.has(player.id)}
                     compactNonTarget={isMobile}
                     onToggleSuspect={() =>
@@ -386,7 +385,6 @@ function OldMaidPageContent() {
                   isHumanTurn={isHumanTurn}
                   gameEndFlag={state.gameEndFlag}
                   loading={loading}
-                  highlightedCardIdx={-1}
                   drawnCardIdx={humanDrawnCardIdx}
                   onDraw={(drawIdx) => gameExec('draw', drawIdx)}
                   onReorder={handleReorder}


### PR DESCRIPTION
Closes #5476

## The bug

`ArrangeTargetForHumanDraw` is a **lure**. With `cpuPlacementStrategy` on, the CPU moves its
unpaired card to a position the human is likely to pick — and with `CpuMetaAI`, to the position
that particular player has historically favoured (`humanProfile.StrategicPlacement`).

The page then rendered that exact index with a gold border, `translateY(-8px)` and a glow —
**before the human draws**. So the feature inverted: "the card we want you to take" became "the
card to avoid", and the better the CPU aimed, the clearer the warning.

## The fix

The visual highlight is removed. The domain is **untouched** — the placement is the feature and
still happens, it is simply no longer announced, which is what the issue asks for.

`highlightedCardIdx` was then unused, so the prop is dropped rather than left as a no-op. The
`cpuHighlightedCardIdx` response field stays: removing it would reach Go, `api/openapi.yaml` and
the shared types for no benefit.

I did **not** keep a screen-reader-only version. The issue floats that option, but announcing the
trap to screen-reader users only moves the unfairness rather than fixing it.

## Three tests were pinning the bug

| test | required |
|---|---|
| `applies gold accent border and glow to highlighted card via tokens` | the accent border **and** glow |
| `highlighted card has translateY style` | the `-8px` lift |
| `does not highlight when highlightedCardIdx is -1` | (correct — asserted absence) |

The first two are replaced by their opposite: **every CPU card must render with an identical
style**, since one card differing at all is the tell. That is stronger than checking for specific
properties, which would miss a future highlight done a different way.

## Test plan

- [x] `OldMaidPlayerArea.test.tsx` — 3 new cases: neutral style on every card, all styles
      identical (`new Set(styles).size === 1`), and no accent/lift/glow anywhere
- [x] `OldMaidPage.test.tsx` — with `cpuHighlightedCardIdx: 0` set in state, no card is
      distinguishable
- [x] **Negative control:** re-introducing the highlight fails all three new component tests
- [x] 138 tests pass across both files
- [x] `bun run check` (biome + 17 guards) — exit 0
- [x] `bun run typecheck` — clean