### PR TITLE
fix(colourwhist): stop showing a partner row for the solo contracts

### DIFF
--- a/frontend/src/pages/ColourWhistPage.test.tsx
+++ b/frontend/src/pages/ColourWhistPage.test.tsx
@@ -164,6 +164,27 @@ describe('ColourWhistPage', () => {
     expect(screen.getByTestId('colourwhist-partner')).toHaveTextContent('未公開');
   });
 
+  // **単独契約には相方がいない。** partnerIdx は「いない」も「いるが未公開」も
+  // -1 なので、契約で判定しないと「相方: 非公開」と出て、隠れた味方がいると
+  // 誤解させる (#5773)。
+  it.each([
+    ['alleen', ColourWhistContract.ALLEEN],
+    ['miserie', ColourWhistContract.MISERIE],
+  ])('shows no partner row for the solo contract %s', async (_name, contract) => {
+    mockApi.mockResolvedValue({ ...playState, contract, partnerIdx: -1 });
+    renderWithProviders(<ColourWhistPage />);
+
+    await waitFor(() => expect(screen.getByTestId('colourwhist-contract')).toBeInTheDocument());
+    expect(screen.queryByTestId('colourwhist-partner')).not.toBeInTheDocument();
+  });
+
+  it('still shows the partner row once Troel reveals it', async () => {
+    mockApi.mockResolvedValue({ ...playState, contract: ColourWhistContract.TROEL, partnerIdx: 2 });
+    renderWithProviders(<ColourWhistPage />);
+
+    await waitFor(() => expect(screen.getByTestId('colourwhist-partner')).toHaveTextContent('#2'));
+  });
+
   it('offers the four trumps in the call phase', async () => {
     mockApi.mockResolvedValue({
       ...bidState,

--- a/frontend/src/pages/ColourWhistPage.tsx
+++ b/frontend/src/pages/ColourWhistPage.tsx
@@ -32,6 +32,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { COLOURWHIST_CLI_HELP, parseColourWhistCommand } from '../utils/cli/commands/colourwhistCommands';
 import { formatColourWhistState } from '../utils/cli/formatters/colourwhistFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { colourWhistHasPartner } from '../utils/colourWhistPartner';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
 const CW_TUTORIAL_STEPS: TutorialStep[] = [
@@ -188,7 +189,10 @@ function ColourWhistPageContent() {
                   {t('label.declarer')}: #{state.declarerIdx} ({t('label.declarerTricks')} {state.declarerTricks})
                 </div>
               )}
-              {state.contract !== ColourWhistContract.NONE && (
+              {/* Alleen と Miserie には相方がいない。partnerIdx は「相方なし」も
+                  「相方はいるが未公開」も -1 なので、契約で判定しないと単独契約に
+                  「相方: 非公開」と出て、隠れた味方がいると誤解させる (#5773)。 */}
+              {colourWhistHasPartner(state.contract) && (
                 <div data-testid="colourwhist-partner">
                   {t('label.partner')}: {state.partnerIdx >= 0 ? `#${state.partnerIdx}` : t('label.hidden')}
                 </div>

--- a/frontend/src/utils/colourWhistPartner.test.ts
+++ b/frontend/src/utils/colourWhistPartner.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { ColourWhistContract } from '../types/phases';
+import { colourWhistHasPartner } from './colourWhistPartner';
+
+describe('colourWhistHasPartner', () => {
+  it('is true for the two-against-two contracts', () => {
+    expect(colourWhistHasPartner(ColourWhistContract.SAMEN)).toBe(true);
+    // Troel は競りで選べず、配りで自動的に成立する。相方は 4 枚目のエース保持者。
+    expect(colourWhistHasPartner(ColourWhistContract.TROEL)).toBe(true);
+  });
+
+  it('is false for the solo contracts and before anyone declares', () => {
+    expect(colourWhistHasPartner(ColourWhistContract.ALLEEN)).toBe(false);
+    expect(colourWhistHasPartner(ColourWhistContract.MISERIE)).toBe(false);
+    expect(colourWhistHasPartner(ColourWhistContract.NONE)).toBe(false);
+  });
+
+  // ドメインの契約は 0..4 の 5 種類しかない。範囲外を true にすると、
+  // 未知の契約が増えたときに「隠れた味方がいる」と出てしまう。
+  it('is false for anything outside the domain range', () => {
+    for (const c of [-1, 5, 99]) expect(colourWhistHasPartner(c)).toBe(false);
+  });
+});

--- a/frontend/src/utils/colourWhistPartner.ts
+++ b/frontend/src/utils/colourWhistPartner.ts
@@ -1,0 +1,17 @@
+import { ColourWhistContract } from '../types/phases';
+
+/**
+ * Whether the given contract has a partner at all.
+ *
+ * Mirrors `ColourWhistHasPartner` in `internal/domain/ColourWhistConfig.go`:
+ * only Samen (the declarer calls a partner) and Troel (forced by the deal, the
+ * holder of the fourth ace becomes the partner) are two-against-two. Alleen and
+ * Miserie are solo contracts.
+ *
+ * This matters because `partnerIdx` is `-1` for both "there is no partner" and
+ * "the partner exists but is not revealed yet". Keying the UI on `partnerIdx`
+ * alone told players a hidden ally existed in solo contracts (#5773).
+ */
+export function colourWhistHasPartner(contract: number): boolean {
+  return contract === ColourWhistContract.SAMEN || contract === ColourWhistContract.TROEL;
+}


### PR DESCRIPTION
## 背景

`ColourWhistPage.tsx:191` のパートナー欄は

```tsx
{state.contract !== ColourWhistContract.NONE && ( ... 相方: 非公開 ... )}
```

という条件だけで出ていた。ところが契約 5 種のうち**相方がいるのは 2 種だけ**:

| 契約 | 相方 |
|---|---|
| Samen | あり（宣言者が呼ぶ） |
| Troel | あり（配りで自動成立。4 枚目のエース保持者） |
| **Alleen** | **なし**（単独 8 トリック） |
| **Miserie** | **なし**（単独、1 トリックも取らない） |
| None | まだ宣言前 |

`GetPartnerIdx()` は「**相方がいない**」と「**相方はいるが未公開**」の両方を
同じ `-1` で返すので、`partnerIdx` を見ても区別できない。結果、単独契約でも
「相方: 非公開」と出て、**隠れた味方がいるとプレイヤーに誤解させていた。**

## 変更

ドメインの `ColourWhistHasPartner`
(`internal/domain/ColourWhistConfig.go:135`) と同じ判定を持つ純関数
`colourWhistHasPartner` を `src/utils/` に足し、欄の条件をそれに差し替えた。
ドメイン側は変更していない。

## テスト

- util: Samen/Troel は true、Alleen/Miserie/None は false、
  **範囲外 (-1, 5, 99) も false**（契約が増えたとき「隠れた味方」が出ないように）
- ページ: Alleen と Miserie で欄が**出ない**こと / Troel で相方が公開されたら
  `#2` が出ること（受け入れ条件の troelForced 経路）
- 既存の「Samen の相方は指名札が出るまで伏せる」テストはそのまま通る
  （＝未公開の表示自体は壊していない）

**負のコントロール（実測）**: 条件を元の `!== NONE` に戻す変異で 2 件 FAIL、
util を `!== NONE` に緩める変異で 2 件 FAIL。

Closes #5773