### PR TITLE
fix(seahaventowers): say in the aria-label why an over-limit card cannot move

### DIFF
--- a/frontend/src/pages/SeahavenTowersPage.test.tsx
+++ b/frontend/src/pages/SeahavenTowersPage.test.tsx
@@ -237,6 +237,45 @@ describe('SeahavenTowersPage', () => {
     await waitFor(() => expect(screen.getAllByText(/ゲームオーバー/).length).toBeGreaterThan(0));
   });
 
+  // **上限超過は title とリングだけで示していた。** ホバーできない利用者には
+  // draggable が落ちている理由が届かない (#5495)。
+  it('says in the aria-label why an over-limit card cannot be dragged', async () => {
+    // 予備セルが 1 つ埋まっている → 上限 = 1 + 1 = 2。3 枚の列の一番上は超過。
+    const tightState: SeahavenTowersResponse = {
+      ...playingState,
+      tableau: [
+        [card('SPADE', 13), card('HEART', 12), card('CLOVER', 11)],
+        [card('DIAMOND', 1)],
+        [card('SPADE', 2)],
+        [card('HEART', 3)],
+        [card('DIAMOND', 4)],
+        [card('CLOVER', 5)],
+        [card('SPADE', 6)],
+        [card('HEART', 7)],
+        [card('CLOVER', 8)],
+        [card('DIAMOND', 9)],
+      ],
+      reservedCells: [card('SPADE', 1), null],
+    };
+    mockExec.mockResolvedValue(tightState);
+    renderWithProviders(<SeahavenTowersPage />);
+    await waitFor(() => expect(screen.getByAltText('♠ K')).toBeInTheDocument());
+
+    // 3 枚を動かすことになる一番上の札は上限 2 を超える。
+    const blocked = screen.getByAltText('♠ K').closest('button') as HTMLButtonElement;
+    expect(blocked).toHaveAttribute('data-supermove-blocked', 'true');
+    expect(blocked.getAttribute('aria-label')).toContain('一度に動かせるのは2枚までです');
+
+    // **負のコントロール: 上限内の札はカード名のみ。** ここに理由が混ざると、
+    // 動かせる札まで動かせないように読み上げられる。
+    const movable = screen.getByAltText('♣ J').closest('button') as HTMLButtonElement;
+    expect(movable).not.toHaveAttribute('data-supermove-blocked');
+    expect(movable.getAttribute('aria-label')).not.toContain('一度に動かせるのは');
+
+    // 視覚側の挙動は変えていない。
+    expect(blocked.getAttribute('title')).toContain('一度に動かせるのは2枚までです');
+  });
+
   it('highlights the in-limit supermove block under the cursor', async () => {
     // Both reserved cells empty → limit = 1 + 2 = 3, so the bottom 3 cards form the movable block.
     const looseState: SeahavenTowersResponse = {

--- a/frontend/src/pages/SeahavenTowersPage.tsx
+++ b/frontend/src/pages/SeahavenTowersPage.tsx
@@ -415,7 +415,15 @@ function SeahavenTowersPageContent() {
                                         }
                                       }}
                                       disabled={!isPlaying || loading}
-                                      aria-label={cardAlt(card)}
+                                      // 上限超過は title とリングだけで示していたので、
+                                      // ホバーできる人にしか届いていなかった。draggable も
+                                      // 落としているのに、キーボード/読み上げ利用者には
+                                      // 動かせない理由が分からない (#5495)。
+                                      aria-label={
+                                        exceedsSupermove
+                                          ? `${cardAlt(card)} — ${t('supermoveLimitTooltip', { limit: supermoveLimit })}`
+                                          : cardAlt(card)
+                                      }
                                       aria-pressed={isSourceSelected('tableau', colIdx, undefined, cardIdx)}
                                       draggable={isPlaying && !loading && !exceedsSupermove}
                                       onDragStart={dnd.handleDragStart(cardZone)}


### PR DESCRIPTION
## 背景

`SeahavenTowersPage.tsx` は `maxMovableCards()`（`1 + 空きリザーブ数`）から
`supermoveLimit` を出し、超える枚数の列に対して

- ネイティブ `title` 属性のツールチップ
- `ring-1 ring-ds-error` の視覚リング

だけで警告していた。`title` は**マウスホバー時にしか読まれず**、
`aria-label={cardAlt(card)}` には一切反映されない。にもかかわらず
`draggable={... && !exceedsSupermove}` で操作は落としているので、
キーボード・スクリーンリーダー利用者には**動かせない理由が届かない**。

## 変更

`exceedsSupermove` が真のカードに限り、既存の `supermoveLimitTooltip`
（「一度に動かせるのは{{limit}}枚までです」）を `aria-label` へ追記する。

視覚側（`title` とリング、`data-supermove-blocked`）は変更していない（受け入れ条件）。

## テスト

予備セルを 1 つ埋めて上限 2、3 枚の列を用意し:

- 超過している一番上の札 → `aria-label` に理由が入る
- **上限内の札 → カード名のみ**（負のコントロール。ここに混ざると、動かせる札まで
  動かせないように読み上げられる）
- `title` は従来どおり出る

**負のコントロール（実測）**: `aria-label` を元に戻す変異で FAIL、
条件を外して常に追記する変異でも FAIL。

Closes #5495