### PR TITLE
feat(golf): announce the combo streak to screen readers

### DIFF
--- a/frontend/src/i18n/locales/en/golf.json
+++ b/frontend/src/i18n/locales/en/golf.json
@@ -46,5 +46,7 @@
     "complete": "9 holes done! Total score: {{total}} (lower is better)",
     "restart": "New scorecard",
     "pending": "-"
-  }
+  },
+  "comboAnnounce": "Combo ×{{count}} running",
+  "comboEnded": "Combo broken"
 }

--- a/frontend/src/i18n/locales/ja/golf.json
+++ b/frontend/src/i18n/locales/ja/golf.json
@@ -46,5 +46,7 @@
     "complete": "9ホール終了！ 合計スコア: {{total}}（少ないほど好成績）",
     "restart": "新しいスコアカード",
     "pending": "-"
-  }
+  },
+  "comboAnnounce": "コンボ ×{{count}} 継続中",
+  "comboEnded": "コンボが途切れました"
 }

--- a/frontend/src/pages/GolfPage.test.tsx
+++ b/frontend/src/pages/GolfPage.test.tsx
@@ -309,6 +309,30 @@ describe('GolfPage', () => {
     expect(badge.className).toContain('bg-ds-error');
   });
 
+  // **コンボは色とテキストだけで示されていた。** 読み上げ利用者には継続も
+  // 途切れも届かない (#5520)。
+  it('announces a running combo to screen readers', async () => {
+    mockCombo.mockReturnValue(3);
+    renderWithProviders(<GolfPage />);
+    const live = await screen.findByTestId('golf-combo-announce');
+    expect(live).toHaveAttribute('role', 'status');
+    expect(live).toHaveAttribute('aria-live', 'polite');
+    // 通知テキストに現在のコンボ数が入ること（受け入れ条件）。
+    expect(live).toHaveTextContent('3');
+  });
+
+  it('stays silent while there is no combo', async () => {
+    mockCombo.mockReturnValue(1);
+    renderWithProviders(<GolfPage />);
+    const live = await screen.findByTestId('golf-combo-announce');
+    // 要素は常に置く（出し入れすると読み上げが飛ぶ）が、中身は空。
+    expect(live).toBeEmptyDOMElement();
+    expect(screen.queryByTestId('combo-badge')).not.toBeInTheDocument();
+  });
+
+  // 途切れの遷移そのものは comboAnnounce.test.ts が純関数として押さえている。
+  // ここではページがその判断を live region に反映することだけを見る。
+
   it('does not show the 9-hole scorecard by default', async () => {
     renderWithProviders(<GolfPage />);
     await waitFor(() => expect(screen.getByText('捨て札')).toBeInTheDocument());

--- a/frontend/src/pages/GolfPage.tsx
+++ b/frontend/src/pages/GolfPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { golfApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { ActionShortcutsPanel } from '../components/ActionShortcutsPanel';
@@ -43,6 +43,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { GOLF_HELP, parseGolfCommand } from '../utils/cli/commands/golfCommands';
 import { formatGolfState } from '../utils/cli/formatters/golfFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { comboAnnouncement } from '../utils/comboAnnounce';
 import { isGolfAdjacent } from '../utils/hints/golfHint';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
@@ -163,6 +164,18 @@ function GolfPageContent() {
 
   const combo = useChainCombo(state?.moveCount, state?.stockCount);
 
+  // **バッジは combo >= 2 のときだけ描かれる。** 消えることは live region では
+  // 伝わらないので、途切れた瞬間だけ別の文言を出す。要素そのものは常に置いて
+  // おく (出し入れすると読み上げが飛ぶ)。
+  const [comboAnnounce, setComboAnnounce] = useState('');
+  const prevCombo = useRef(0);
+  useEffect(() => {
+    const was = prevCombo.current;
+    prevCombo.current = combo;
+    const next = comboAnnouncement(combo, was);
+    setComboAnnounce(next ? t(next.key, { count: next.count }) : '');
+  }, [combo, t]);
+
   // 9-hole mode: accumulate each finished deal's remaining-card score across 9 deals (issue #3114).
   const { nineHole, setEnabled: setNineHoleEnabled, recordHole, resetCard } = useGolfNineHole();
   const nineHoleEnabled = nineHole.enabled;
@@ -241,6 +254,11 @@ function GolfPageContent() {
               {t('combo', { count: combo })}
             </span>
           )}
+          {/* コンボは色とテキストの変化だけで示されており、読み上げ利用者には
+              継続も途切れも届いていなかった (#5520)。 */}
+          <span className="sr-only" role="status" aria-live="polite" data-testid="golf-combo-announce">
+            {comboAnnounce}
+          </span>
           <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
         </>
       }

--- a/frontend/src/utils/comboAnnounce.test.ts
+++ b/frontend/src/utils/comboAnnounce.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { comboAnnouncement } from './comboAnnounce';
+
+describe('comboAnnouncement', () => {
+  it('reports the running chain once the badge appears', () => {
+    // バッジが出るのは 2 以上。読み上げも同じ境界で始める。
+    expect(comboAnnouncement(2, 1)).toEqual({ key: 'comboAnnounce', count: 2 });
+    expect(comboAnnouncement(7, 6)).toEqual({ key: 'comboAnnounce', count: 7 });
+  });
+
+  it('reports the break when a chain drops out of range', () => {
+    expect(comboAnnouncement(0, 4)).toEqual({ key: 'comboEnded', count: 0 });
+    expect(comboAnnouncement(1, 2)).toEqual({ key: 'comboEnded', count: 0 });
+  });
+
+  // **負のコントロール。** 連鎖が無かったところで「途切れた」と言うと、
+  // 一手ごとに雑音が出る。
+  it('says nothing when there was no chain to break', () => {
+    expect(comboAnnouncement(0, 0)).toBeNull();
+    expect(comboAnnouncement(1, 1)).toBeNull();
+    expect(comboAnnouncement(0, 1)).toBeNull();
+  });
+});

--- a/frontend/src/utils/comboAnnounce.ts
+++ b/frontend/src/utils/comboAnnounce.ts
@@ -1,0 +1,24 @@
+/** What a combo live region should say, or `null` for "say nothing". */
+export interface ComboAnnouncement {
+  /** i18n key, relative to the game's namespace. */
+  key: 'comboAnnounce' | 'comboEnded';
+  /** Interpolation count; only meaningful for `comboAnnounce`. */
+  count: number;
+}
+
+/**
+ * Decide what a combo live region should announce for a chain transition.
+ *
+ * The badge only renders at `combo >= 2`, so it *disappears* when the chain
+ * breaks — and a removed element cannot be announced. Screen-reader users got
+ * neither the streak nor its end, which is the whole point of the badge
+ * (#5520). Keeping the region mounted and changing its text fixes both.
+ *
+ * Returns `null` when there is nothing to say: no chain now and none before.
+ */
+export function comboAnnouncement(combo: number, previous: number): ComboAnnouncement | null {
+  if (combo >= 2) return { key: 'comboAnnounce', count: combo };
+  // Only worth announcing a break if there was a streak to break.
+  if (previous >= 2) return { key: 'comboEnded', count: 0 };
+  return null;
+}


### PR DESCRIPTION
## 背景

`GolfPage.tsx` のコンボバッジ (`data-testid="combo-badge"`) は
色分け（青→黄→赤）とテキストの再レンダーだけで、`role="status"` も
`aria-live` も持たない。連続除去という Golf Solitaire の中心的な達成感が
**まるごと視覚だけの体験**になっていた。

## 消えることは live region では伝わらない

バッジは `combo >= 2` のときだけ描かれる。つまり連鎖が途切れると**要素ごと
消える**が、削除された要素は読み上げられない。受け入れ条件の

> コンボが途切れて非表示になる際も何らかの形で通知される

を満たすには、**領域を常に置いたまま中身を差し替える**必要がある。

## 変更

- `golf-combo-announce` の sr-only 領域を常設し、`role="status" aria-live="polite"`
- 連鎖中は「コンボ ×N 継続中」、途切れた瞬間だけ「コンボが途切れました」、
  それ以外は空
- 遷移の判断は `comboAnnouncement(combo, previous)` という**純関数**に出した。
  TriPeaks も同じ `useChainCombo` を使っているので、広げるときに再利用できる

## テスト

- util: 2 以上で継続を報告 / 2 未満へ落ちたら途切れを報告 /
  **連鎖が無かったところでは何も言わない**（負のコントロール。ここが漏れると
  一手ごとに雑音が出る）
- ページ: `role`/`aria-live` が付くこと、通知テキストにコンボ数が入ること、
  連鎖が無いときは空であること

**負のコントロール（実測）**: live region を常に空にする変異で FAIL、
途切れの報告を消す変異で FAIL。

途切れの遷移そのものは純関数側で押さえている。ページ側で
`rerender` を使う版も書いたが、`renderWithProviders` のラッパーが外れて
`No QueryClient set` になるので、判断をユニットに出すほうが素直だった。

Closes #5520