### PR TITLE
fix(agnes): take the stalemate answer from the domain

### DIFF
--- a/frontend/src/pages/AgnesPage.test.tsx
+++ b/frontend/src/pages/AgnesPage.test.tsx
@@ -33,6 +33,7 @@ const playingState: AgnesResponse = {
   phase: 0,
   moveCount: 0,
   canUndo: false,
+  isStalemate: false,
   message: '',
   messageCode: 'agnes.playing',
 };
@@ -336,12 +337,9 @@ describe('AgnesPage', () => {
   // --- Stalemate detection + undo-escape (issue #3289) ---
 
   it('shows the stalemate banner when no legal move remains', async () => {
-    const stuck: AgnesResponse = {
-      ...playingState,
-      stockCount: 0,
-      tableau: [[up('SPADE', 8)], [up('HEART', 3)]],
-      foundation: [[], [], [], []],
-    };
+    // 手詰まりかどうかはドメインが決める。盤面を組み直しても、フロントは
+    // もう自前で判定しない (#5601)。
+    const stuck: AgnesResponse = { ...playingState, stockCount: 0, isStalemate: true };
     mockExec.mockResolvedValue(stuck);
     renderWithProviders(<AgnesPage />);
     await waitFor(() => expect(screen.getByTestId('ag-stalemate-banner')).toBeInTheDocument());
@@ -355,13 +353,7 @@ describe('AgnesPage', () => {
   });
 
   it('offers an undo-to-escape button in the stalemate banner and fires undo', async () => {
-    const stuck: AgnesResponse = {
-      ...playingState,
-      stockCount: 0,
-      canUndo: true,
-      tableau: [[up('SPADE', 8)], [up('HEART', 3)]],
-      foundation: [[], [], [], []],
-    };
+    const stuck: AgnesResponse = { ...playingState, stockCount: 0, canUndo: true, isStalemate: true };
     mockExec.mockResolvedValue(stuck);
     renderWithProviders(<AgnesPage />);
     const escapeBtn = await screen.findByTestId('ag-stalemate-undo');
@@ -371,13 +363,7 @@ describe('AgnesPage', () => {
   });
 
   it('hides the undo-to-escape button when there is nothing to undo', async () => {
-    const stuck: AgnesResponse = {
-      ...playingState,
-      stockCount: 0,
-      canUndo: false,
-      tableau: [[up('SPADE', 8)], [up('HEART', 3)]],
-      foundation: [[], [], [], []],
-    };
+    const stuck: AgnesResponse = { ...playingState, stockCount: 0, canUndo: false, isStalemate: true };
     mockExec.mockResolvedValue(stuck);
     renderWithProviders(<AgnesPage />);
     await waitFor(() => expect(screen.getByTestId('ag-stalemate-banner')).toBeInTheDocument());

--- a/frontend/src/pages/AgnesPage.tsx
+++ b/frontend/src/pages/AgnesPage.tsx
@@ -31,7 +31,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { AgnesResponse } from '../types/card';
 import { AgnesPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
-import { agnesHasLegalMove, agnesNextFoundationMove } from '../utils/agnesMoves';
+import { agnesNextFoundationMove } from '../utils/agnesMoves';
 import { AGNES_HELP, parseAgnesCommand } from '../utils/cli/commands/agnesCommands';
 import { formatAgnesState } from '../utils/cli/formatters/agnesFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
@@ -192,13 +192,11 @@ function AgnesPageContent() {
   // Auto-complete is offered once the stock is exhausted and every tableau card
   // is face-up — the endgame sweep, mirroring Spiderette's `autoCompleteReady`.
   const autoCompleteReady = isPlaying && (state?.stockCount ?? 1) === 0 && isTableauAllFaceUp(state?.tableau ?? []);
-  // Stalemate: no deal, no foundation move, and no tableau move remain. Detected
-  // on the frontend from the deterministic move rules (the backend exposes no
-  // stalemate flag), so the UI can prompt an undo / give-up escape.
-  const hasLegalMove = state
-    ? agnesHasLegalMove(state.tableau, state.foundation, state.baseRank, state.stockCount)
-    : true;
-  const isStalemate = isPlaying && !loading && !isAutoCompleting && !hasLegalMove;
+  // Stalemate: no deal, no foundation move, and no tableau move remain. The
+  // domain decides it (`Agnes.IsStalemate()`) and sends the answer; the page
+  // used to re-derive the same rule in TypeScript, which meant a new legal move
+  // in Go would silently leave the banner wrong here (#5601).
+  const isStalemate = isPlaying && !loading && !isAutoCompleting && (state?.isStalemate ?? false);
 
   // Keyboard shortcuts for the primary actions, matching other solitaire pages.
   // Give-up (g) is routed through its confirm dialog since it is irreversible.

--- a/frontend/src/types/games/agnes.ts
+++ b/frontend/src/types/games/agnes.ts
@@ -27,6 +27,12 @@ export interface AgnesResponse extends BaseGameResponse {
   phase: number;
   moveCount: number;
   canUndo: boolean;
+  /**
+   * Whether no legal move remains. Decided by the domain's `Agnes.IsStalemate()`
+   * -- the page used to re-derive it from the move rules in TypeScript, so the
+   * same rule lived in two places and could drift (#5601).
+   */
+  isStalemate: boolean;
   hint?: AgnesHint;
 }
 

--- a/frontend/src/utils/agnesMoves.test.ts
+++ b/frontend/src/utils/agnesMoves.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { AgnesTableauCard, Card, CardDesign } from '../types/card';
-import {
-  agnesCanPlaceOnFoundation,
-  agnesCanPlaceOnTableau,
-  agnesHasLegalMove,
-  agnesNextFoundationMove,
-} from './agnesMoves';
+import { agnesCanPlaceOnFoundation, agnesNextFoundationMove } from './agnesMoves';
 
 const card = (design: CardDesign, value: number): Card => ({ design, value });
 const up = (design: CardDesign, value: number): AgnesTableauCard => ({ card: card(design, value), faceUp: true });
@@ -35,27 +30,6 @@ describe('agnesCanPlaceOnFoundation', () => {
   });
 });
 
-describe('agnesCanPlaceOnTableau', () => {
-  const tableau: AgnesTableauCard[][] = [[up('SPADE', 8)], [], [up('HEART', 8)]];
-
-  it('accepts a same-color card one rank lower', () => {
-    // Clover 7 (black) onto Spade 8 (black).
-    expect(agnesCanPlaceOnTableau(card('CLOVER', 7), tableau, 0)).toBe(true);
-  });
-
-  it('rejects a different-color card', () => {
-    expect(agnesCanPlaceOnTableau(card('HEART', 7), tableau, 0)).toBe(false);
-  });
-
-  it('rejects an empty column', () => {
-    expect(agnesCanPlaceOnTableau(card('CLOVER', 7), tableau, 1)).toBe(false);
-  });
-
-  it('rejects a wrong rank', () => {
-    expect(agnesCanPlaceOnTableau(card('CLOVER', 6), tableau, 0)).toBe(false);
-  });
-});
-
 describe('agnesNextFoundationMove', () => {
   it('returns the first column with a foundation-eligible end card', () => {
     const foundation: Card[][] = [[card('SPADE', 5)], [], [], []];
@@ -72,28 +46,5 @@ describe('agnesNextFoundationMove', () => {
   it('returns -1 when no move exists', () => {
     const tableau: AgnesTableauCard[][] = [[up('HEART', 9)]];
     expect(agnesNextFoundationMove(tableau, emptyFoundation(), 5)).toBe(-1);
-  });
-});
-
-describe('agnesHasLegalMove', () => {
-  it('is true while stock remains', () => {
-    expect(agnesHasLegalMove([[]], emptyFoundation(), 5, 23)).toBe(true);
-  });
-
-  it('is true when a foundation move exists', () => {
-    const foundation: Card[][] = [[card('SPADE', 5)], [], [], []];
-    const tableau: AgnesTableauCard[][] = [[up('SPADE', 6)]];
-    expect(agnesHasLegalMove(tableau, foundation, 5, 0)).toBe(true);
-  });
-
-  it('is true when a tableau-to-tableau move exists', () => {
-    const tableau: AgnesTableauCard[][] = [[up('SPADE', 8)], [up('CLOVER', 7)]];
-    expect(agnesHasLegalMove(tableau, emptyFoundation(), 5, 0)).toBe(true);
-  });
-
-  it('is false when stuck (no deal, no foundation, no tableau move)', () => {
-    // Spade 8 and Heart 3: no foundation (base 5), no same-color one-lower stack.
-    const tableau: AgnesTableauCard[][] = [[up('SPADE', 8)], [up('HEART', 3)]];
-    expect(agnesHasLegalMove(tableau, emptyFoundation(), 5, 0)).toBe(false);
   });
 });

--- a/frontend/src/utils/agnesMoves.ts
+++ b/frontend/src/utils/agnesMoves.ts
@@ -16,16 +16,6 @@ function nextRank(r: number): number {
   return (r % 13) + 1;
 }
 
-/** Whether a card is a black suit (Spade or Clover), matching the domain `isBlack`. */
-function isBlack(card: Card): boolean {
-  return card.design === 'SPADE' || card.design === 'CLOVER';
-}
-
-/** Whether two cards share a color, matching the domain `isSameColor`. */
-function sameColor(a: Card, b: Card): boolean {
-  return isBlack(a) === isBlack(b);
-}
-
 /** Face-up end (bottom) card of a tableau column, or null when empty/face-down. */
 function endFaceUpCard(col: readonly AgnesTableauCard[]): Card | null {
   if (col.length === 0) return null;
@@ -48,23 +38,6 @@ export function agnesCanPlaceOnFoundation(card: Card, foundation: readonly Card[
 }
 
 /**
- * Whether a card can stack on a tableau column's end card: same color, one rank
- * lower, no wrap. Empty columns cannot be filled manually. Mirrors the domain
- * `canPlaceOnTableau`.
- */
-export function agnesCanPlaceOnTableau(
-  card: Card,
-  tableau: readonly (readonly AgnesTableauCard[])[],
-  toCol: number,
-): boolean {
-  const col = tableau[toCol];
-  if (!col || col.length === 0) return false;
-  const top = col[col.length - 1]?.card;
-  if (!top) return false;
-  return sameColor(card, top) && card.value === top.value - 1;
-}
-
-/**
  * Index of the first tableau column whose face-up end card can move to a
  * foundation, or -1 if none. Drives the auto-complete sweep by re-reading the
  * board after each move (mirrors the domain's foundation-first hint priority).
@@ -79,28 +52,4 @@ export function agnesNextFoundationMove(
     if (card && agnesCanPlaceOnFoundation(card, foundation, baseRank)) return col;
   }
   return -1;
-}
-
-/**
- * Whether any legal move remains: a pending deal, a tableau→foundation move, or a
- * tableau→tableau move. Used to detect a stalemate so the UI can prompt the
- * player to undo or give up. Mirrors the union of the domain's `DealStock`
- * availability and `GetHint` move search.
- */
-export function agnesHasLegalMove(
-  tableau: readonly (readonly AgnesTableauCard[])[],
-  foundation: readonly Card[][],
-  baseRank: number,
-  stockCount: number,
-): boolean {
-  if (stockCount > 0) return true;
-  for (let col = 0; col < tableau.length; col++) {
-    const card = endFaceUpCard(tableau[col]);
-    if (!card) continue;
-    if (agnesCanPlaceOnFoundation(card, foundation, baseRank)) return true;
-    for (let to = 0; to < tableau.length; to++) {
-      if (to !== col && agnesCanPlaceOnTableau(card, tableau, to)) return true;
-    }
-  }
-  return false;
 }

--- a/frontend/src/utils/cli/formatters/agnesFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/agnesFormatter.test.ts
@@ -11,6 +11,7 @@ function makeState(overrides?: Partial<AgnesResponse>): AgnesResponse {
     phase: 0,
     moveCount: 0,
     canUndo: false,
+    isStalemate: false,
     message: '',
     ...overrides,
   };

--- a/frontend/src/utils/hints/agnesHint.test.ts
+++ b/frontend/src/utils/hints/agnesHint.test.ts
@@ -11,6 +11,7 @@ function makeState(overrides: Partial<AgnesResponse> = {}): AgnesResponse {
     phase: 0,
     moveCount: 0,
     canUndo: false,
+    isStalemate: false,
     message: '',
     ...overrides,
   };

--- a/internal/adapter/controller/AgnesWebController.go
+++ b/internal/adapter/controller/AgnesWebController.go
@@ -46,7 +46,11 @@ type AgnesWebOutput struct {
 	Phase      int                            `json:"phase"`
 	MoveCount  int                            `json:"moveCount"`
 	CanUndo    bool                           `json:"canUndo"`
-	Hint       *AgnesWebOutputHint            `json:"hint,omitempty"`
+	// IsStalemate は合法手が 1 つも無いかどうか。判定はドメインの
+	// Agnes.IsStalemate() だけが持つ。以前はここに載せておらず、
+	// フロントが agnesHasLegalMove() で同じ規則を実装し直していた (#5601)。
+	IsStalemate bool                `json:"isStalemate"`
+	Hint        *AgnesWebOutputHint `json:"hint,omitempty"`
 	WebOutputBase
 }
 

--- a/internal/adapter/presenter/AgnesWebPresenter.go
+++ b/internal/adapter/presenter/AgnesWebPresenter.go
@@ -107,10 +107,11 @@ func (p *AgnesWebPresenter) ActionLogOutput(c interfaces.AgnesGame) string {
 
 func (p *AgnesWebPresenter) buildBaseOutput(c interfaces.AgnesGame) *controller.AgnesWebOutput {
 	return &controller.AgnesWebOutput{
-		BaseRank:   c.GetBaseRank(),
-		Phase:      int(c.GetPhase()),
-		MoveCount:  c.GetMoveCount(),
-		StockCount: c.GetStockCount(),
-		CanUndo:    c.CanUndo(),
+		BaseRank:    c.GetBaseRank(),
+		Phase:       int(c.GetPhase()),
+		MoveCount:   c.GetMoveCount(),
+		StockCount:  c.GetStockCount(),
+		CanUndo:     c.CanUndo(),
+		IsStalemate: c.IsStalemate(),
 	}
 }

--- a/internal/adapter/presenter/AgnesWebPresenter_test.go
+++ b/internal/adapter/presenter/AgnesWebPresenter_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 )
@@ -76,6 +77,36 @@ func TestAgnesWebPresenter_Output(t *testing.T) {
 
 // **受動ヒントは Output() に載る。**Agnes は実ドメインオブジェクトを使うので
 // モックの差し替えが要らないぶん、ヒントを検証するテストが無いまま通っていた。
+// **手詰まりの判定はドメインが持つ。** 以前は載せておらず、フロントが
+// agnesHasLegalMove() で同じ規則を実装し直していた (#5601)。
+func TestAgnesWebPresenter_OutputCarriesTheStalemateFlag(t *testing.T) {
+	t.Run("stock left is never a stalemate", func(t *testing.T) {
+		a := newWebAgnes() // 山札 1 枚 = 必ず配れる
+		require.False(t, a.IsStalemate())
+		assert.Contains(t, new(AgnesWebPresenter).Output(a, nil), `"isStalemate":false`)
+	})
+
+	t.Run("no stock and no move is a stalemate", func(t *testing.T) {
+		a := newWebAgnes()
+		a.SetStock(nil)
+		// place できない盤面にする: 各列 1 枚で、組札にも積めない値。
+		var tab [domain.AgnesTableauCnt][]*domain.AgnesTableauCard
+		for i := range tab {
+			tab[i] = []*domain.AgnesTableauCard{
+				{Card: domain.NewCard(domain.CardDesignSpade, 2, false), FaceUp: true},
+			}
+		}
+		a.SetTableau(tab)
+		var f [domain.AgnesFoundationCnt][]*domain.Card
+		a.SetFoundation(f)
+
+		// ドメインがそう言うことを先に確かめる。ここが false のままだと、
+		// 出力の検査は「たまたま false」を見ているだけになる。
+		require.True(t, a.IsStalemate())
+		assert.Contains(t, new(AgnesWebPresenter).Output(a, nil), `"isStalemate":true`)
+	})
+}
+
 func TestAgnesWebPresenter_OutputCarriesTheHint(t *testing.T) {
 	t.Run("while the game is playable", func(t *testing.T) {
 		a := domain.NewDefaultAgnes()


### PR DESCRIPTION
## 背景

ドメインの `Agnes.IsStalemate()` が手詰まりを判定し、`AgnesCuiPresenter` は
それを使って毎回案内している (#4830)。ところが `AgnesWebPresenter` はこの値を
JSON に載せておらず、`AgnesPage.tsx` にはこうコメントがあった:

> the backend exposes no stalemate flag

そのため `agnesMoves.ts` の `agnesHasLegalMove()` が**同じ規則をゼロから
再実装**していた。ドメイン側に合法手が増えたとき複製を直し忘れれば、
Web だけバナーが出ない/誤って出る。

## 変更

- `AgnesWebOutput.IsStalemate` を追加し、`c.IsStalemate()` をそのまま返す
- `AgnesPage.tsx` は `state.isStalemate` を使う
- **複製の削除**（受け入れ条件「二重に存在しないこと」）:
  - `agnesHasLegalMove` — 唯一の呼び出し元がページだった
  - `agnesCanPlaceOnTableau` — 唯一の呼び出し元が上記だった
  - `sameColor` / `isBlack` — 唯一の呼び出し元が上記だった

  連鎖して不要になったものまで消しているので、`git show --stat` の削除行数が
  issue の想定より多い。`agnesCanPlaceOnFoundation` は
  `agnesNextFoundationMove`（自動完成で今も使う）が呼ぶので残している。

## テスト

- Go: 山札が残っていれば `"isStalemate":false` / 山札も合法手も無い盤面で
  `"isStalemate":true`。**どちらも先に `a.IsStalemate()` を require で確かめてから**
  出力を見る（そうしないと「たまたま false」を検査するだけになる）
- フロント: 既存の `ag-stalemate-banner` 系 3 件は、手詰まりの盤面を組む代わりに
  `isStalemate: true` を渡す形に更新。判定はもうフロントに無いので、盤面を
  作り込む意味がなくなった

**負のコントロール（実測）**: presenter が `false` を固定で返す変異で FAIL、
ページが state を無視する変異で 3 件 FAIL。

Closes #5601