### PR TITLE
fix(yukon): lock the other actions while auto-complete runs

### DIFF
--- a/frontend/src/pages/YukonPage.test.tsx
+++ b/frontend/src/pages/YukonPage.test.tsx
@@ -183,6 +183,35 @@ describe('YukonPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
   });
 
+  // **自動完成中は他の操作を止める。** 複数手が続けて動く間に Undo や
+  // ギブアップを押されると、表示中のアニメーションとサーバ状態がずれる (#5533)。
+  it('locks undo, hint and give-up while auto-complete is running', async () => {
+    const readyState: YukonResponse = {
+      ...playingState,
+      canUndo: true,
+      tableau: [
+        [{ card: card('SPADE', 1), faceUp: true }],
+        [{ card: card('HEART', 7), faceUp: true }],
+        [{ card: card('CLOVER', 2), faceUp: true }],
+      ],
+    };
+    mockExec.mockResolvedValue(readyState);
+    renderWithProviders(<YukonPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+
+    // **押す前は使える。** ここを確かめないと、単に常時無効なだけの実装でも通る。
+    expect(screen.getByRole('button', { name: 'ヒント' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: '元に戻す' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'ギブアップ' })).toBeEnabled();
+
+    fireEvent.click(screen.getByTestId('autocomplete-button'));
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeDisabled());
+    expect(screen.getByRole('button', { name: '元に戻す' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'ギブアップ' })).toBeDisabled();
+    expect(screen.getByTestId('autocomplete-button')).toBeDisabled();
+  });
+
   it('autocomplete button is disabled while face-down cards exist', async () => {
     renderWithProviders(<YukonPage />);
     await waitFor(() => expect(screen.getByTestId('autocomplete-button')).toBeInTheDocument());

--- a/frontend/src/pages/YukonPage.tsx
+++ b/frontend/src/pages/YukonPage.tsx
@@ -19,6 +19,7 @@ import { StalemateEscapeButton } from '../components/StalemateEscapeButton';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
+import { useAutoCompleteState } from '../hooks/useAutoCompleteState';
 import { useCardDimensions, useWindowWidth } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
@@ -201,9 +202,15 @@ function YukonPageContent() {
     setState((prev) => (prev ? { ...prev, hint: res.hint } : prev));
   }, [setState]);
 
+  // **自動完成は複数手が続けて動く。** その間に Undo やギブアップを押されると
+  // 表示中のアニメーションとサーバ状態がずれる。兄弟のソリティア
+  // (Spiderette / Terrace / Windmill) と同じ共有フックで窓を作る (#5533)。
+  const { isAutoCompleting, startAutoComplete } = useAutoCompleteState();
+
   const handleAutoComplete = useCallback(() => {
+    startAutoComplete();
     void apiExec('autocomplete');
-  }, [apiExec]);
+  }, [apiExec, startAutoComplete]);
 
   const handleUndo = useCallback(() => {
     void apiExec('undo');
@@ -533,14 +540,19 @@ function YukonPageContent() {
 
               {isPlaying && (
                 <>
-                  <button type="button" className={btnOutline} onClick={handleHint} disabled={loading}>
+                  <button
+                    type="button"
+                    className={btnOutline}
+                    onClick={handleHint}
+                    disabled={loading || isAutoCompleting}
+                  >
                     {t('hint')}
                   </button>
                   <button
                     type="button"
-                    className={`${btnSuccess}${autoCompleteReady && !loading ? ' animate-pulse ring-2 ring-ds-success' : ''}`}
+                    className={`${btnSuccess}${autoCompleteReady && !loading && !isAutoCompleting ? ' animate-pulse ring-2 ring-ds-success' : ''}`}
                     onClick={handleAutoComplete}
-                    disabled={loading || !autoCompleteReady}
+                    disabled={loading || isAutoCompleting || !autoCompleteReady}
                     data-testid="autocomplete-button"
                     title={autoCompleteReady ? undefined : t('autoCompleteNotReady')}
                   >
@@ -550,18 +562,23 @@ function YukonPageContent() {
                     type="button"
                     className={btnOutline}
                     onClick={handleUndo}
-                    disabled={loading || !state.canUndo}
+                    disabled={loading || isAutoCompleting || !state.canUndo}
                   >
                     {t('undo')}
                   </button>
-                  <button type="button" className={btnDanger} onClick={confirmGiveUpAction} disabled={loading}>
+                  <button
+                    type="button"
+                    className={btnDanger}
+                    onClick={confirmGiveUpAction}
+                    disabled={loading || isAutoCompleting}
+                  >
                     {t('giveup')}
                   </button>
                   {state.isStalemate && (
                     <StalemateEscapeButton
                       undoToEscape={state.undoToEscape ?? -1}
                       onEscape={handleUndoEscape}
-                      disabled={loading}
+                      disabled={loading || isAutoCompleting}
                     />
                   )}
                 </>


### PR DESCRIPTION
## 背景

`YukonPage.tsx` は `autoCompleteReady` は持つが**実行中フラグを持たず**、
Undo・ヒント・ギブアップは `disabled={loading}` だけだった。

自動完成は複数手が続けて動くので、その最中に押されると表示中のアニメーションと
サーバ状態がずれる。兄弟の `SpiderettePage` / `TerracePage` / `WindmillPage` は
`loading || isAutoCompleting` で揃ってロックしている。

## 変更

共有フック `useAutoCompleteState`（3 秒の自己解除窓）を使い、
Undo・ヒント・ギブアップ・脱出ボタン・自動完成自身を窓の間だけ無効化する。
自動完成ボタンの pulse も窓の間は止める。通常時の挙動は変えていない。

## テスト

`locks undo, hint and give-up while auto-complete is running`:

- **押す前に 3 つとも enabled であることを先に確かめる。** ここを見ないと、
  「常時無効」な実装でもテストが通ってしまう
- 自動完成を押した後、4 つとも disabled になる

**負のコントロール（実測）**: `startAutoComplete()` の呼び出しを消す変異で FAIL、
ヒント/ギブアップの `isAutoCompleting` を外す変異で FAIL。

Closes #5533