### PR TITLE
feat(tripeaks): announce the combo streak to screen readers

### DIFF
--- a/frontend/src/i18n/locales/en/tripeaks.json
+++ b/frontend/src/i18n/locales/en/tripeaks.json
@@ -44,5 +44,7 @@
     "canRemove": "An exposed card can be removed — it is adjacent to the waste top",
     "multipleRemovable": "Multiple cards can be removed — look for chain opportunities",
     "drawFromStock": "No removable cards — try drawing from the stock"
-  }
+  },
+  "comboAnnounce": "Combo ×{{count}} running",
+  "comboEnded": "Combo broken"
 }

--- a/frontend/src/i18n/locales/ja/tripeaks.json
+++ b/frontend/src/i18n/locales/ja/tripeaks.json
@@ -44,5 +44,7 @@
     "canRemove": "除去できるカードがあります — 捨て札と隣接しています",
     "multipleRemovable": "複数のカードが除去可能です — 連鎖を狙いましょう",
     "drawFromStock": "除去できるカードがありません — 山札から引いてみましょう"
-  }
+  },
+  "comboAnnounce": "コンボ ×{{count}} 継続中",
+  "comboEnded": "コンボが途切れました"
 }

--- a/frontend/src/pages/TriPeaksPage.test.tsx
+++ b/frontend/src/pages/TriPeaksPage.test.tsx
@@ -350,6 +350,24 @@ describe('TriPeaksPage', () => {
     expect(screen.queryByTestId('combo-badge')).not.toBeInTheDocument();
   });
 
+  // **コンボは色とテキストだけで示されていた。** Golf と同じ欠落 (#5821 / #5520)。
+  it('announces a running combo to screen readers', async () => {
+    mockCombo.mockReturnValue(3);
+    renderWithProviders(<TriPeaksPage />);
+    const live = await screen.findByTestId('tripeaks-combo-announce');
+    expect(live).toHaveAttribute('role', 'status');
+    expect(live).toHaveAttribute('aria-live', 'polite');
+    expect(live).toHaveTextContent('3');
+  });
+
+  it('stays silent while there is no combo', async () => {
+    mockCombo.mockReturnValue(1);
+    renderWithProviders(<TriPeaksPage />);
+    const live = await screen.findByTestId('tripeaks-combo-announce');
+    // 領域は常設し、中身だけ空にする（出し入れすると読み上げが飛ぶ）。
+    expect(live).toBeEmptyDOMElement();
+  });
+
   it('renders the combo badge with blue styling when combo is 2', async () => {
     mockCombo.mockReturnValue(2);
     renderWithProviders(<TriPeaksPage />);

--- a/frontend/src/pages/TriPeaksPage.tsx
+++ b/frontend/src/pages/TriPeaksPage.tsx
@@ -38,6 +38,7 @@ import { cardAlt } from '../utils/cardAlt';
 import { parseTripeaksCommand, TRIPEAKS_HELP } from '../utils/cli/commands/tripeaksCommands';
 import { formatTripeaksState } from '../utils/cli/formatters/tripeaksFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { comboAnnouncement } from '../utils/comboAnnounce';
 import { hintCheckboxItem } from '../utils/settingsItems';
 import { triPeaksPlayableCells } from '../utils/triPeaksPlayable';
 
@@ -199,6 +200,18 @@ function TriPeaksPageContent() {
 
   const combo = useChainCombo(state?.moveCount, state?.stockCount);
 
+  // **バッジは combo >= 2 のときだけ描かれる。** 消えることは live region では
+  // 伝わらないので、領域は常設して中身を差し替える。判断は Golf と共有の
+  // 純関数に任せる (#5821, もとは #5520)。
+  const [comboAnnounce, setComboAnnounce] = useState('');
+  const prevCombo = useRef(0);
+  useEffect(() => {
+    const was = prevCombo.current;
+    prevCombo.current = combo;
+    const next = comboAnnouncement(combo, was);
+    setComboAnnounce(next ? t(next.key, { count: next.count }) : '');
+  }, [combo, t]);
+
   // Remaining-card count per peak, derived from the board layout (issue #3085).
   const peakRemaining = useMemo(() => computePeakRemaining(state?.layout), [state?.layout]);
   const isPlayingForPeaks = state?.phase === TriPeaksPhase.PLAYING;
@@ -325,6 +338,9 @@ function TriPeaksPageContent() {
               {t('combo', { count: combo })}
             </span>
           )}
+          <span className="sr-only" role="status" aria-live="polite" data-testid="tripeaks-combo-announce">
+            {comboAnnounce}
+          </span>
           <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
         </>
       }


### PR DESCRIPTION
## 背景

#5520 (PR #5817) で Golf のコンボバッジに読み上げ通知を足した。そのレビューで
TriPeaks に同じ欠落が残っていると指摘があり、実測で確認した:

- `TriPeaksPage.tsx:200` — 同じ `useChainCombo`
- `TriPeaksPage.tsx:316` — 同じ `combo-badge`
- `aria-live` の出現回数 **0**

## 変更

判断は #5520 で切り出した純関数 `comboAnnouncement(combo, previous)` を
**そのまま再利用**（新しいロジックは書いていない）。ページ側は
`role="status" aria-live="polite"` の sr-only 領域を**常設**して中身を差し替えるだけ。

**バッジは `combo >= 2` のときだけ描かれるので、途切れたことは要素の消失でしか
表現されず live region では伝わらない。** 領域を出し入れしてはいけない、というのが
#5520 の肝で、ここでも同じ。

## テスト

- `role` / `aria-live` が付き、通知テキストにコンボ数が入ること
- コンボが無いときは**空**であること（領域自体は在る）

途切れの遷移そのものは `comboAnnounce.test.ts`（#5817 で追加、負のコントロール
`(0,0)` `(1,1)` `(0,1)` → `null` 込み）が押さえている。

**負のコントロール（実測）**: 通知を常に空にする変異で FAIL。

Closes #5821