### PR TITLE
fix(solitaire): say in the aria-label why an over-limit card cannot move

### DIFF
--- a/frontend/src/pages/BakersGamePage.test.tsx
+++ b/frontend/src/pages/BakersGamePage.test.tsx
@@ -768,6 +768,12 @@ describe('BakersGamePage', () => {
       expect(middleButton).toHaveAttribute('data-supermove-blocked', 'true');
       expect(topButton).toHaveAttribute('draggable', 'false');
       expect(topButton).toHaveAttribute('data-supermove-blocked', 'true');
+
+      // **動かせない理由が読み上げにも出る。** title はホバー時にしか読まれない
+      // ので、draggable=false の理由が届かなかった (#5820)。
+      expect(topButton.getAttribute('aria-label')).toContain('一度に動かせるのは');
+      // 負のコントロール: 動かせる札に理由が混ざってはいけない。
+      expect(bottomButton.getAttribute('aria-label')).not.toContain('一度に動かせるのは');
     });
 
     it('highlights the in-limit block under the cursor', async () => {

--- a/frontend/src/pages/BakersGamePage.tsx
+++ b/frontend/src/pages/BakersGamePage.tsx
@@ -434,7 +434,14 @@ function BakersGamePageContent() {
                                           : undefined
                                       }
                                       disabled={!isPlaying || loading}
-                                      aria-label={cardAlt(card)}
+                                      // 上限超過は title とリングだけで示していたので、
+                                      // ホバーできる人にしか届かない。draggable も落として
+                                      // いるのに、動かせない理由が読み上げに出ない (#5820)。
+                                      aria-label={
+                                        exceedsSupermove
+                                          ? `${cardAlt(card)} — ${t('supermoveLimitTooltip', { limit: supermoveLimit })}`
+                                          : cardAlt(card)
+                                      }
                                       aria-pressed={isSourceSelected('tableau', colIdx, undefined, cardIdx)}
                                       draggable={isPlaying && !loading && !exceedsSupermove}
                                       onDragStart={dnd.handleDragStart(cardZone)}

--- a/frontend/src/pages/EightOffPage.test.tsx
+++ b/frontend/src/pages/EightOffPage.test.tsx
@@ -123,6 +123,15 @@ describe('EightOffPage', () => {
     const title = blocked.getAttribute('title') ?? '';
     expect(title).toMatch(/空きフリーセル0/);
     expect(title).toMatch(/空き列0/);
+
+    // **同じ内容が読み上げにも出る。** title はホバー時にしか読まれない (#5820)。
+    const label = blocked.getAttribute('aria-label') ?? '';
+    expect(label).toContain('一度に動かせるのは');
+    expect(label).toMatch(/空きフリーセル0/);
+    // 負のコントロール: 上限内の札には付かない。
+    const movable = screen.getByTestId('eo-tableau-0-1');
+    expect(movable).not.toHaveAttribute('data-supermove-blocked');
+    expect(movable.getAttribute('aria-label') ?? '').not.toContain('一度に動かせるのは');
   });
 
   it('renders empty tableau columns with K placeholder', async () => {

--- a/frontend/src/pages/EightOffPage.tsx
+++ b/frontend/src/pages/EightOffPage.tsx
@@ -479,7 +479,14 @@ function EightOffPageContent() {
                                         isTopCard ? () => handleFoundationShortcut(cardZone, card) : undefined
                                       }
                                       disabled={!isPlaying || loading}
-                                      aria-label={cardAlt(card)}
+                                      // 上限超過は title とリングだけで示していたので、
+                                      // ホバーできる人にしか届かない。draggable も落として
+                                      // いるのに、動かせない理由が読み上げに出ない (#5820)。
+                                      aria-label={
+                                        exceedsSupermove
+                                          ? `${cardAlt(card)} — ${t('supermoveLimitTooltip', { limit: supermoveLimit, cells: emptyFreeCells, cols: emptyTableauCols })}`
+                                          : cardAlt(card)
+                                      }
                                       data-testid={`eo-tableau-${colIdx.toString()}-${cardIdx.toString()}`}
                                       aria-pressed={isSourceSelected('tableau', colIdx, undefined, cardIdx)}
                                       draggable={isPlaying && !loading && !exceedsSupermove}

--- a/frontend/src/pages/FreeCellPage.test.tsx
+++ b/frontend/src/pages/FreeCellPage.test.tsx
@@ -870,6 +870,13 @@ describe('FreeCellPage', () => {
       expect(middleButton).toHaveAttribute('data-supermove-blocked', 'true');
       expect(topButton).toHaveAttribute('draggable', 'false');
       expect(topButton).toHaveAttribute('data-supermove-blocked', 'true');
+
+      // **動かせない理由が読み上げにも出る。** title はホバー時にしか読まれない
+      // ので、キーボード/読み上げ利用者には draggable=false の理由が届かなかった
+      // (#5820)。
+      expect(topButton.getAttribute('aria-label')).toContain('一度に動かせるのは');
+      // 負のコントロール: 動かせる札に理由が混ざってはいけない。
+      expect(bottomButton.getAttribute('aria-label')).not.toContain('一度に動かせるのは');
     });
 
     it('highlights the in-limit block under the cursor', async () => {

--- a/frontend/src/pages/FreeCellPage.tsx
+++ b/frontend/src/pages/FreeCellPage.tsx
@@ -428,7 +428,14 @@ function FreeCellPageContent() {
                                           : undefined
                                       }
                                       disabled={!isPlaying || loading}
-                                      aria-label={cardAlt(card)}
+                                      // 上限超過は title とリングだけで示していたので、
+                                      // ホバーできる人にしか届かない。draggable も落として
+                                      // いるのに、動かせない理由が読み上げに出ない (#5820)。
+                                      aria-label={
+                                        exceedsSupermove
+                                          ? `${cardAlt(card)} — ${t('supermoveLimitTooltip', { limit: supermoveLimit })}`
+                                          : cardAlt(card)
+                                      }
                                       aria-pressed={isSourceSelected('tableau', colIdx, undefined, cardIdx)}
                                       draggable={isPlaying && !loading && !exceedsSupermove}
                                       onDragStart={dnd.handleDragStart(cardZone)}

--- a/frontend/src/pages/PenguinPage.test.tsx
+++ b/frontend/src/pages/PenguinPage.test.tsx
@@ -140,6 +140,13 @@ describe('PenguinPage', () => {
     expect(topCard).toHaveAttribute('data-supermove-blocked', 'true');
     // limit=1, cells=0, cols=0
     expect(topCard).toHaveAttribute('title', '一度に動かせるのは1枚まで（空きセル0・空き列0）');
+
+    // **同じ内容が読み上げにも出る。** title はホバー時にしか読まれない (#5820)。
+    expect(topCard.getAttribute('aria-label') ?? '').toContain('一度に動かせるのは1枚まで');
+    // 負のコントロール: 上限内の札には付かない。
+    const movable = screen.getByTestId('pg-tableau-0-1');
+    expect(movable).not.toHaveAttribute('data-supermove-blocked');
+    expect(movable.getAttribute('aria-label') ?? '').not.toContain('一度に動かせるのは');
   });
 
   it('shows a supermove-limit badge reflecting the free-cell/column counts', async () => {

--- a/frontend/src/pages/PenguinPage.tsx
+++ b/frontend/src/pages/PenguinPage.tsx
@@ -441,7 +441,14 @@ function PenguinPageContent() {
                                         }
                                       }}
                                       disabled={!isPlaying || loading}
-                                      aria-label={cardAlt(card)}
+                                      // 上限超過は title とリングだけで示していたので、
+                                      // ホバーできる人にしか届かない。draggable も落として
+                                      // いるのに、動かせない理由が読み上げに出ない (#5820)。
+                                      aria-label={
+                                        exceedsSupermove
+                                          ? `${cardAlt(card)} — ${t('supermoveLimitTooltip', { limit: supermoveLimit, cells: emptyFreeCells, cols: emptyTableauCols })}`
+                                          : cardAlt(card)
+                                      }
                                       aria-pressed={isSourceSelected('tableau', colIdx, undefined, cardIdx)}
                                       data-testid={`pg-tableau-${colIdx.toString()}-${cardIdx.toString()}`}
                                       draggable={isPlaying && !loading && !exceedsSupermove}


### PR DESCRIPTION
## 背景

#5495 (PR #5816) で SeahavenTowers を直したとき、レビューで**同じ形が 4 ページに
残っている**と指摘があり、実測で確認した（起票: #5820）。

| ページ | `exceedsSupermove` 参照 | `aria-label` に理由 |
|---|---|---|
| `BakersGamePage.tsx` | 5 | **0** |
| `EightOffPage.tsx` | 5 | **0** |
| `FreeCellPage.tsx` | 5 | **0** |
| `PenguinPage.tsx` | 5 | **0** |

いずれも `draggable` を落としているのに、**動かせない理由が読み上げに届かない**。

## 変更

各ページの `title` が渡している params を**そのまま**使って `aria-label` に追記:

- BakersGame / FreeCell → `{ limit }`
- EightOff / Penguin → `{ limit, cells, cols }`（文言に空きセル数・空き列数を含むため）

**フリーセル側のカードには手を付けていない。** 上限の概念が無く、
`exceedsSupermove` もスコープに無い。実際、置換パターンはネストの深さで
タブロー側だけに当たっており、4 ページとも素の `aria-label={cardAlt(card)}` が
1 つずつ（＝フリーセル側）残っていることを確認した。

## テスト

4 ページとも既存の supermove テストに追記:

- 超過カードの `aria-label` に理由が入る
- **上限内のカードには入らない**（負のコントロール）
- EightOff / Penguin は空きセル数・空き列数まで入ることも見る
- `title` の既存アサーションはそのまま（視覚側は不変）

**負のコントロール（実測）**: 4 ページを**1 つずつ**素の `aria-label` に戻す変異で、
それぞれのテストが FAIL することを確認した（まとめて戻した 1 回の実行では
集計行を読み違えたので、per-file で測り直している）。

Closes #5820