### PR TITLE
test(horse): make the round-trip balance check say what it means

### DIFF
--- a/internal/domain/HorseJSON_test.go
+++ b/internal/domain/HorseJSON_test.go
@@ -34,18 +34,28 @@ func TestHorseRoundTripJSON_MidHand(t *testing.T) {
 	// フェーズが進むことだけを見ても足りない ── 回収の配線を繋ぎ直さなくても
 	// `settleIfHandOver` は nil を素通りして HandEnd にするので、**チップが
 	// 動いたか**まで見る (1 ハンド打てばブラインド/アンティは必ず動く)。
+	// **打つ直前の残高と比べる。** 以前は InitialChips と比べており、
+	// 打った結果たまたま全席が初期値へ戻る配りだと「1 席も動いていない」と
+	// 誤検知した (#5812 で 2 回観測、どちらも Horse と無関係な PR)。
+	// 見たいのは「このハンドでチップが動いたか」なので、基準は初期値ではなく
+	// 打つ直前の残高。
+	beforeFold := make([]int, back.GetSeatCount())
+	for i := range beforeFold {
+		beforeFold[i] = back.GetSeatChips(i)
+	}
+
 	horseFoldOutHand(t, &back)
 	require.Equal(t, HorsePhaseHandEnd, back.GetPhase())
 	assert.Equal(t, beforeChips, horseTotalChips(&back), "総量が変わっている")
 
 	moved := false
-	for i := 0; i < back.GetSeatCount(); i++ {
-		if back.GetSeatChips(i) != back.GetConfig().InitialChips {
+	for i := range beforeFold {
+		if back.GetSeatChips(i) != beforeFold[i] {
 			moved = true
 			break
 		}
 	}
-	assert.True(t, moved, "ハンドを打ったのに正本の残高が 1 席も動いていない (回収が繋がっていない)")
+	assert.True(t, moved, "ハンドを打ったのに残高が 1 席も動いていない (回収が繋がっていない)")
 }
 
 func TestHorseRoundTripJSON_BetweenHands(t *testing.T) {

--- a/internal/domain/Horse_test.go
+++ b/internal/domain/Horse_test.go
@@ -32,7 +32,8 @@ func horseTotalChips(g *Horse) int {
 // ことになる。
 func horseFoldOutHand(t *testing.T, g *Horse) {
 	t.Helper()
-	for steps := 0; g.GetPhase() == HorsePhaseHand; steps++ {
+	steps := 0
+	for ; g.GetPhase() == HorsePhaseHand; steps++ {
 		require.Less(t, steps, 50, "ハンドが終わらない")
 		if !g.IsHumanTurn() {
 			// CPU の手番のまま止まっているなら、種目側が進めていない。
@@ -40,6 +41,11 @@ func horseFoldOutHand(t *testing.T, g *Horse) {
 		}
 		require.NoError(t, g.PlayerAction(HoldemActionFold, 0, 0))
 	}
+	// **1 手も打たずに抜けたら、それは「ハンドを打った」ではない。**
+	// 呼び出し側は打ち終わった前提で残高やフェーズを見るので、ここが 0 のまま
+	// 素通りすると「何もしていないのに合格」になり、失敗は数手あとの無関係な
+	// アサーションに化ける (#5812)。
+	require.Positive(t, steps, "ハンドを打つ前に既に HorsePhaseHand ではなかった")
 }
 
 // --- 種目のローテーション ---


### PR DESCRIPTION
## 背景

`TestHorseRoundTripJSON_MidHand` が CI で 2 回落ちた（#5812、どちらも Horse に
触れていない PR）。調べるうちにテスト側にも 2 つ「通ってしまう」穴が見つかった。

**これはフレークの修正ではない。** 本体のバグは #5812 に残っている。

## 変更

1. **`horseFoldOutHand` が 1 手も打たずに抜けたら落ちる**
   今までは 0 手で素通りしても直後の `require.Equal(HandEnd)` は通ってしまい、
   「何もしていないのに合格」→ 失敗は数手あとの無関係なアサーションに化けていた

2. **残高の比較基準を `InitialChips` から「打つ直前の残高」へ**
   見たいのは「このハンドでチップが動いたか」なので、初期値と比べるのは proxy。
   打った結果たまたま全席が初期値へ戻る配りだと誤検知する

**どちらもフレーク率は変えない。** 今回観測した失敗例では打つ直前の残高が
ちょうど初期値なので、新旧のアサーションは同値。

## 本体のバグ（この PR では直さない）

新しいアサーションのおかげで `-count=50` でローカル再現でき、状態を出せた:

```
discipline=0 (Hold'em)  phase=1 (HandEnd)  steps=1
before=[1000 1000 1000 1000]  after=[1000 1000 1000 1000]
```

**決着済みのハンドで、4 席とも初期値のまま = ブラインドが 1 枚も動いていない。**
`HorseJSON_test.go` のコメントが置いている前提「1 ハンド打てばブラインド/アンティは
必ず動く」が、Hold'em の一部の配りで成立していない。ドメイン側の話なので #5812 に
詳細を残した。