### PR TITLE
feat(bigtwo): highlight the CPU whose turn it is

### DIFF
--- a/frontend/src/pages/BigTwoPage.test.tsx
+++ b/frontend/src/pages/BigTwoPage.test.tsx
@@ -186,4 +186,43 @@ describe('BigTwoPage', () => {
     const label = await screen.findByTestId('bt-table-playtype');
     expect(label).toHaveTextContent('フラッシュ');
   });
+
+  // **currentTurn は届いていたのに isHumanTurn の判定にしか使われていなかった。**
+  // 誰の番かが画面に出ておらず、Daifugo / Sevens だけがハイライトしていた (#5478)。
+  it('highlights the CPU whose turn it is', async () => {
+    mockExec.mockResolvedValue(makeState({ currentTurn: 2 }));
+    renderWithProviders(<BigTwoPage />);
+
+    const active = await screen.findByTestId('bt-cpu-2');
+    expect(active.className).toContain('border-game-status-waiting');
+    // 負のコントロール: 手番でない CPU には付かない。ここを見ないと
+    // 「全員に枠が付く」実装でも通る。
+    expect(screen.getByTestId('bt-cpu-1').className).not.toContain('border-game-status-waiting');
+    expect(screen.getByTestId('bt-cpu-3').className).not.toContain('border-game-status-waiting');
+  });
+
+  it('does not highlight anyone once the game is over', async () => {
+    mockExec.mockResolvedValue(makeState({ currentTurn: 2, gameEndFlag: true }));
+    renderWithProviders(<BigTwoPage />);
+    await waitFor(() => expect(screen.getByTestId('bt-cpu-2')).toBeInTheDocument());
+    expect(screen.getByTestId('bt-cpu-2').className).not.toContain('border-game-status-waiting');
+  });
+
+  it('dims a finished CPU instead of highlighting it', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        currentTurn: 2,
+        players: [
+          player(0, true, [card('SPADE', 3)]),
+          player(1, false, [card('HEART', 4)]),
+          player(2, false, [], { isFinished: true, rank: 1 }),
+          player(3, false, [card('CLOVER', 6)]),
+        ],
+      }),
+    );
+    renderWithProviders(<BigTwoPage />);
+    const finished = await screen.findByTestId('bt-cpu-2');
+    expect(finished.className).toContain('opacity-50');
+    expect(finished.className).not.toContain('border-game-status-waiting');
+  });
 });

--- a/frontend/src/pages/BigTwoPage.tsx
+++ b/frontend/src/pages/BigTwoPage.tsx
@@ -22,6 +22,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { badgeErrorColors } from '../styles/badgeStyles';
 import { btnPrimary, btnSecondary } from '../styles/buttonStyles';
+import { activeTurnClass, finishedPlayerClass } from '../styles/gameConstants';
 import { gameTheme } from '../styles/gameTheme';
 import type { BigTwoResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
@@ -178,7 +179,20 @@ function BigTwoPageContent() {
               {state.players
                 .filter((p) => !p.isHuman)
                 .map((p) => (
-                  <div key={p.id} className="text-center">
+                  <div
+                    key={p.id}
+                    data-testid={`bt-cpu-${p.id.toString()}`}
+                    // **手番中の CPU を枠線で示す。** currentTurn は届いていたのに
+                    // isHumanTurn の判定にしか使われておらず、誰の番か画面に出て
+                    // いなかった。Daifugo / Sevens と同じ共有スタイルを使う (#5478)。
+                    className={`text-center rounded-[8px] p-1 ${
+                      p.isFinished
+                        ? `${finishedPlayerClass} border-2 border-transparent`
+                        : state.currentTurn === p.id && !isGameEnd
+                          ? activeTurnClass
+                          : 'border-2 border-transparent'
+                    }`}
+                  >
                     <div className="text-xs text-ds-text-muted mb-1 flex items-center justify-center gap-1">
                       <span>{tc('player.cpu', { id: p.id })}</span>
                       {p.isFinished ? (


### PR DESCRIPTION
## 背景

`BigTwoWebPresenter` は `resObj.CurrentTurn` を常に返しており、`BigTwoPage.tsx` も
`state.currentTurn` を受け取っているが、**使い道は `isHumanTurn` の判定だけ**で、
CPU 一覧を描く箇所には手番の表現が一切ない。

兄弟の `DaifugoPage` / `SevensPage` は同じフィールドで手番中の CPU を枠線で示している。

## 変更

共有スタイル (`activeTurnClass` / `finishedPlayerClass`) を CPU の枠に適用:

- 手番中 → 枠線 + シャドウ
- **上がった席 → ハイライトではなく減光**（`Daifugo` の compact 版と同じ優先順）
- **決着後は誰も光らせない**

`CpuTurnArea` にそのまま乗せ換える手もあったが、あちらは名前の見出しごと描くので
BigTwo の「CPU1 — 残り5枚 / 順位」というヘッダーが組み替わる。issue が求めているのは
枠線・シャドウなので、スタイルだけ共有した。

## テスト

- 手番の CPU に枠が付き、**他の 2 席には付かない**（負のコントロール。ここを見ないと
  「全員に枠が付く」実装でも通る）
- 決着後は誰にも付かない
- 上がった席は減光され、ハイライトはされない

**負のコントロール（実測）**: 条件を `true` にする変異で 2 件 FAIL、
`&& !isGameEnd` を外す変異で 1 件 FAIL、`isFinished` 分岐を潰す変異で 1 件 FAIL。

なお最初に測ったときは `sed` が 1 行目の `isHumanTurn`（同じ部分文字列）を
書き換えており、**変異が当たっていないのに「検出できない」と読み違えた**。
一意になる文字列で測り直している。

Closes #5478