### PR TITLE
feat(michigan): explain what the dead hand is

### DIFF
--- a/frontend/src/i18n/locales/en/michigan.json
+++ b/frontend/src/i18n/locales/en/michigan.json
@@ -66,5 +66,7 @@
     "leadBadge": "Lead"
   },
   "hintRequested": "Hint available",
-  "noHint": "No hint available"
+  "noHint": "No hint available",
+  "deadHandWhatTitle": "What is the dead hand?",
+  "deadHandWhat": "An extra hand dealt to nobody. These cards never come into play this round."
 }

--- a/frontend/src/i18n/locales/ja/michigan.json
+++ b/frontend/src/i18n/locales/ja/michigan.json
@@ -66,5 +66,7 @@
     "leadBadge": "リード"
   },
   "hintRequested": "ヒントがあります",
-  "noHint": "ヒントはありません"
+  "noHint": "ヒントはありません",
+  "deadHandWhatTitle": "デッドハンドとは？",
+  "deadHandWhat": "余分に1人分だけ配った札です。誰の手にも入らず、この局では最後まで使われません。"
 }

--- a/frontend/src/pages/MichiganPage.test.tsx
+++ b/frontend/src/pages/MichiganPage.test.tsx
@@ -82,6 +82,17 @@ describe('MichiganPage', () => {
     );
   });
 
+  // **数字だけでは謎の数でしかない。** 用語もその意味もどこにも説明が
+  // 無かった (#5700)。
+  it('explains what the dead hand is', async () => {
+    renderWithProviders(<MichiganPage />);
+    const help = await screen.findByTestId('michigan-deadhand-help');
+    expect(help).toHaveTextContent('デッドハンドとは');
+    expect(help).toHaveTextContent('誰の手にも入らず');
+    // 枚数の表示は残っていること。説明で置き換えると枚数が消える。
+    expect(screen.getByText(/デッドハンド: /)).toBeInTheDocument();
+  });
+
   it('shows the place-bets button on the human bet turn', async () => {
     renderWithProviders(<MichiganPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: '賭ける' })).toBeInTheDocument());

--- a/frontend/src/pages/MichiganPage.tsx
+++ b/frontend/src/pages/MichiganPage.tsx
@@ -258,6 +258,14 @@ function MichiganPageContent() {
               <span className="mr-4">{t('round', { n: state.roundNumber })}</span>
               <span className="mr-4">{t('ante', { amount: state.ante })}</span>
               <span>{t('deadHand', { count: state.deadHandCount })}</span>
+              {/* 数字だけでは謎の数でしかない。用語もその意味もどこにも
+                  説明が無かった (#5700)。 */}
+              <details className="mt-1 inline-block text-left" data-testid="michigan-deadhand-help">
+                <summary className="cursor-pointer select-none text-ds-text-muted text-xs">
+                  {t('deadHandWhatTitle')}
+                </summary>
+                <p className="mt-1 max-w-xs text-ds-text-muted text-xs">{t('deadHandWhat')}</p>
+              </details>
             </div>
 
             {/* Boodles (center betting cards) */}

--- a/internal/adapter/presenter/MichiganCuiPresenter.go
+++ b/internal/adapter/presenter/MichiganCuiPresenter.go
@@ -131,7 +131,10 @@ func (p *MichiganCuiPresenter) Output(g interfaces.MichiganGame, lastErr error) 
 			seqCard := domain.NewCard(g.GetSeqSuit(), g.GetSeqHighValue(), false)
 			b.WriteString(i18n.Tf("michigan.seqLine", "card", cuiCardStr(seqCard)) + "\n")
 		}
+		// **数字だけでは謎の数でしかない。** 「デッドハンド」という語も、それが
+		// 何を意味するかも、Web にも CUI にも説明が無かった (#5700)。
 		b.WriteString(i18n.Tf("michigan.deadHandLine", "count", strconv.Itoa(g.GetDeadHandCount())) + "\n")
+		b.WriteString(i18n.T("michigan.deadHandNote") + "\n")
 
 		for i := 0; i < g.GetPlayerCnt(); i++ {
 			b.WriteString(michiganPlayerStr(g, i))

--- a/internal/adapter/presenter/MichiganCuiPresenter_test.go
+++ b/internal/adapter/presenter/MichiganCuiPresenter_test.go
@@ -2,6 +2,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -144,4 +145,24 @@ func TestMichiganCuiPresenter_ActionLog(t *testing.T) {
 	g := michiganResultGame(false)
 	p := new(presenter.MichiganCuiPresenter)
 	assert.NotEmpty(t, p.ActionLogOutput(g))
+}
+
+// **数字だけでは謎の数でしかない。** 「デッドハンド」という語も、それが何を
+// 意味しどう影響するかも、Web にも CUI にも説明が無かった (#5700)。
+func TestMichiganCuiPresenter_ExplainsTheDeadHand(t *testing.T) {
+	g := domain.NewDefaultMichigan()
+	p := new(presenter.MichiganCuiPresenter)
+	out := p.Output(g, nil)
+
+	assert.Contains(t, out, i18n.T("michigan.deadHandNote"))
+	// 枚数の行はそのまま残っていること。説明で置き換えてしまうと枚数が消える。
+	assert.Contains(t, out, i18n.Tf("michigan.deadHandLine",
+		"count", strconv.Itoa(g.GetDeadHandCount())))
+
+	// 英語ロケールでも説明が出ること (キーが片方だけだと素通りする)。
+	i18n.SetLang("en")
+	defer i18n.SetLang("ja")
+	en := p.Output(g, nil)
+	assert.Contains(t, en, i18n.T("michigan.deadHandNote"))
+	assert.NotContains(t, en, "余分に")
 }

--- a/internal/i18n/locales/en/michigan.json
+++ b/internal/i18n/locales/en/michigan.json
@@ -46,5 +46,6 @@
   "result.humanWin": "Game over! You win!",
   "result.cpuWin": "Game over! CPU {{player}} wins!",
   "helpExampleNext": "  n                         go to the next deal",
-  "helpHint": "  h                         show a hint"
+  "helpHint": "  h                         show a hint",
+  "deadHandNote": "  (an extra hand dealt to nobody -- these cards never come into play this round)"
 }

--- a/internal/i18n/locales/ja/michigan.json
+++ b/internal/i18n/locales/ja/michigan.json
@@ -46,5 +46,6 @@
   "result.humanWin": "ゲーム終了！あなたの勝ち！",
   "result.cpuWin": "ゲーム終了！CPU {{player}} の勝ち！",
   "helpExampleNext": "  n                         次のディールへ進む",
-  "helpHint": "  h                         助言を表示"
+  "helpHint": "  h                         助言を表示",
+  "deadHandNote": "  （余分に1人分だけ配った札です。誰の手にも入らず、この局では最後まで使われません）"
 }


### PR DESCRIPTION
## 背景

Web は情報バーに `deadHand: {count}` の**生の数字**を、CUI は `michigan.deadHandLine` で
**枚数だけ**を出していた。「デッドハンド」という用語も、それが何を意味しどう影響するかも、
どちらにも説明が無い。初見のプレイヤーには謎の数字にしか見えない。

## 文言はドメインで確かめた

「配りきれなかった端数」だと思って書きかけたが、`Michigan.go` の配り処理を読むと違った:

```go
r := i % recipients          // recipients = 人数 + 1
if r < n { g.players[r].AddCard(c) } else { g.state.deadHand = append(...) }
```

**余分に「1 人分」を配っていて、その 1 人分がまるごとデッドハンド**になる。
端数ではないので、説明もそう書いた（「余分に1人分だけ配った札」）。

## 変更

- **CUI**: `deadHandLine` の直後に説明行
- **Web**: 数字の隣に `<details>` の説明トグル
- **枚数の表示はどちらも残す**（説明で置き換えると枚数が消える）
- ja/en 両ロケールに追加

## テスト

- CUI: 説明行が出ること / **枚数の行も残っていること** / **英語ロケールでも出て、
  日本語が漏れないこと**（キーが片方だけだと素通りする）
- Web: トグルに用語と説明が入ること / 枚数表示が残っていること

**負のコントロール（実測）**: CUI の説明行を消す変異で 2 件 FAIL、
Web の `<details>` を消す変異で 1 件 FAIL。

Closes #5700