### PR TITLE
feat(war): announce each round result to screen readers

### DIFF
--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -2188,7 +2188,10 @@
     "missmilligan.errNothingToUndo": "Nothing to undo",
     "lingerlonger.result.lastTrickYou": "Everyone ran out at once, and you took the last trick.",
     "lingerlonger.result.lastTrickCpu": "Everyone ran out at once, and CPU{{idx}} took the last trick.",
-    "lingerlonger.result.giveUp": "You gave up. CPU{{idx}} wins."
+    "lingerlonger.result.giveUp": "You gave up. CPU{{idx}} wins.",
+    "war.round.humanWin": "You won the round.",
+    "war.round.cpuWin": "CPU won the round.",
+    "war.round.warBury": "War! Each side buries a card and reveals another."
   },
   "manual": {
     "ariaLabel": "Game Manual",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -2188,7 +2188,10 @@
     "missmilligan.errNothingToUndo": "元に戻せる操作がありません",
     "lingerlonger.result.lastTrickYou": "全員が同時に手札を出し切り、あなたが最後のトリックを取りました。",
     "lingerlonger.result.lastTrickCpu": "全員が同時に手札を出し切り、CPU{{idx}} が最後のトリックを取りました。",
-    "lingerlonger.result.giveUp": "あなたが投了しました。CPU{{idx}} の勝ちです。"
+    "lingerlonger.result.giveUp": "あなたが投了しました。CPU{{idx}} の勝ちです。",
+    "war.round.humanWin": "あなたがラウンドに勝ちました。",
+    "war.round.cpuWin": "CPU がラウンドに勝ちました。",
+    "war.round.warBury": "戦争です。伏せ札と表札を出します。"
   },
   "manual": {
     "ariaLabel": "ゲームマニュアル",

--- a/frontend/src/pages/WarPage.test.tsx
+++ b/frontend/src/pages/WarPage.test.tsx
@@ -351,4 +351,21 @@ describe('WarPage', () => {
     // The render cap keeps the layout stable on long war chains.
     expect(stack.querySelectorAll('[data-testid="animated-card-back"]')).toHaveLength(10);
   });
+
+  // **各ラウンドの決着を読み上げに乗せる。** 盤面の変化はリング色と不透明度だけで、
+  // ページに aria-live 領域が一つも無かった (#5530)。サーバがラウンドごとの
+  // messageCode を返すようになったので、既存の GameMessageBox がそのまま読み上げる。
+  it.each([
+    ['war.round.humanWin', 'あなたがラウンドに勝ちました'],
+    ['war.round.cpuWin', 'CPU がラウンドに勝ちました'],
+    ['war.round.warBury', '戦争です'],
+  ])('announces %s to screen readers', async (code, text) => {
+    mockExec.mockResolvedValue({ ...baseState, messageCode: code });
+    renderWithProviders(<WarPage />);
+
+    const box = await screen.findByText(new RegExp(text));
+    // GameMessageBox は role="status" / aria-live="polite" を内蔵している。
+    expect(box).toHaveAttribute('aria-live', 'polite');
+    expect(box).toHaveAttribute('role', 'status');
+  });
 });

--- a/internal/adapter/presenter/WarWebPresenter.go
+++ b/internal/adapter/presenter/WarWebPresenter.go
@@ -2,6 +2,7 @@ package presenter
 
 import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 )
 
@@ -55,6 +56,19 @@ func buildWarMessage(w interfaces.WarGame, lastErr error) (string, string, map[s
 			return "", "war.result.humanWin", nil
 		}
 		return "", "war.result.cpuWin", nil
+	}
+	// **各ラウンドの決着も伝える。** 以前は最終勝敗のときしかコードを返さず、
+	// 盤面の変化はリング色と不透明度だけだった。読み上げ利用者はどのラウンドで
+	// 誰が勝ったのかも、いつ戦争になったのかも知りようがない (#5530)。
+	// CUI の WarCuiPresenter は毎ラウンド promptResolved*/promptWarBury を出している。
+	switch w.GetPhase() {
+	case domain.WarPhaseResolved:
+		if w.GetLastWinnerIdx() == 0 {
+			return "", "war.round.humanWin", nil
+		}
+		return "", "war.round.cpuWin", nil
+	case domain.WarPhaseWarBury:
+		return "", "war.round.warBury", nil
 	}
 	return "", "", nil
 }

--- a/internal/adapter/presenter/WarWebPresenter_test.go
+++ b/internal/adapter/presenter/WarWebPresenter_test.go
@@ -67,7 +67,7 @@ func TestWarWebPresenter_Output(t *testing.T) {
 	// **各ラウンドの決着も伝える。** 以前は最終勝敗のときしかコードが出ず、
 	// 盤面の変化はリング色と不透明度だけだった。読み上げ利用者はどのラウンドで
 	// 誰が勝ったのかも、いつ戦争になったのかも知りようがなかった (#5530)。
-	t.Run("每ラウンドの決着にコードが出る", func(t *testing.T) {
+	t.Run("毎ラウンドの決着にコードが出る", func(t *testing.T) {
 		override := func(phase domain.WarPhase, lastWinner int) string {
 			w := setupWarTest()
 			data, _ := json.Marshal(w)

--- a/internal/adapter/presenter/WarWebPresenter_test.go
+++ b/internal/adapter/presenter/WarWebPresenter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
@@ -61,6 +62,35 @@ func TestWarWebPresenter_Output(t *testing.T) {
 		assert.NotNil(t, resObj.PlayerRevealed)
 		assert.NotNil(t, resObj.CpuRevealed)
 		assert.Equal(t, 2, resObj.WarPotSize)
+	})
+
+	// **各ラウンドの決着も伝える。** 以前は最終勝敗のときしかコードが出ず、
+	// 盤面の変化はリング色と不透明度だけだった。読み上げ利用者はどのラウンドで
+	// 誰が勝ったのかも、いつ戦争になったのかも知りようがなかった (#5530)。
+	t.Run("每ラウンドの決着にコードが出る", func(t *testing.T) {
+		override := func(phase domain.WarPhase, lastWinner int) string {
+			w := setupWarTest()
+			data, _ := json.Marshal(w)
+			var raw map[string]json.RawMessage
+			_ = json.Unmarshal(data, &raw)
+			raw["ph"], _ = json.Marshal(phase)
+			raw["lw"], _ = json.Marshal(lastWinner)
+			newData, _ := json.Marshal(raw)
+			require.NoError(t, json.Unmarshal(newData, w))
+			require.Equal(t, phase, w.GetPhase(), "改竄が効いていない")
+
+			var resObj controller.WarWebOutput
+			require.NoError(t, json.Unmarshal([]byte(p.Output(w, nil)), &resObj))
+			return resObj.MessageCode
+		}
+
+		assert.Equal(t, "war.round.humanWin", override(domain.WarPhaseResolved, 0))
+		assert.Equal(t, "war.round.cpuWin", override(domain.WarPhaseResolved, 1))
+		assert.Equal(t, "war.round.warBury", override(domain.WarPhaseWarBury, -1))
+
+		// **負のコントロール: めくる前は何も言わない。** ここでコードが出ると
+		// 1 手ごとに同じ文が読み上げられる。
+		assert.Empty(t, override(domain.WarPhaseReveal, -1))
 	})
 
 	t.Run("game end message via JSON override", func(t *testing.T) {


### PR DESCRIPTION
## 背景

`WarPage.tsx` はラウンドの決着を `revealedCardEmphasis` のリング色・不透明度だけで
表現しており、**ページに `aria-live` 領域が一つも無い**。

`GameMessageBox` 自体は `role="status"` / `aria-live="polite"` を内蔵しているが、
`buildWarMessage` は**エラー時と最終勝敗のときしか**メッセージを返さないので、
対局中は `messageCode` が空で box ごと描画されない。

結果、読み上げ利用者は最終的な勝敗以外、**どのラウンドで誰が勝ったのかも、
いつ War（賭け金が積まれる状態）が起きたのかも一切分からない**。
CUI の `WarCuiPresenter` は毎ラウンド `promptResolvedHuman` /
`promptResolvedCpu` / `promptWarBury` を色付きで出している。

## 変更

issue が第一案に挙げていたほう — **`buildWarMessage` の拡張**を採った。
`WarPhaseResolved` / `WarPhaseWarBury` にコードを足しただけで、判定は CUI の
分岐と同じ。

**ページ側の変更は要らなかった**: `WarPage` は既に `messageCode` を
`GameMessageBox` へ渡していて、読み上げの属性はそこに入っている。

## テスト

- presenter: Resolved(勝者0/1) と WarBury でそれぞれのコードが出ること
- **負のコントロール**: `WarPhaseReveal` では空のまま（ここで返すと 1 手ごとに
  同じ文が読み上げられる）。既存の "initial state" テストの
  `assert.Empty(MessageCode)` もそのまま通る
- ページ: 3 つのコードが `role="status"` / `aria-live="polite"` の要素として出ること

**負のコントロール（実測）**: ラウンドのコードを空にする変異で 3 件 FAIL、
`WarBury` を `default` に変える変異で 2 件 FAIL。

なお最初の変異は `domain` が未使用になってビルドが落ちており、テスト 0 件を
「検出できない」と読みかけた。コンパイルの通る変異で測り直している。

Closes #5530