### PR TITLE
feat(sevens): mark the playable cards in the CUI hand

### DIFF
--- a/internal/adapter/presenter/SevensCuiPresenter.go
+++ b/internal/adapter/presenter/SevensCuiPresenter.go
@@ -38,7 +38,9 @@ func sevensPlayerStr(player *domain.SevensPlayer, i int, playable []int) string 
 			b.WriteString("\n")
 			// **空スライスを無印のまま出すと「判定していない」と区別が付かない。**
 			// 7並べでは出せる札が1枚も無い局面が普通に起きるので、明示的に言う。
-			if playable != nil && len(playable) == 0 && player.GetCardsSize() > 0 {
+			// 手札 0 枚のプレイヤーはここへ来ない -- 手札が尽きる経路 (assignRank /
+			// 失格処理) はどちらも isFinished を立てるので、上の分岐で捌かれている。
+			if playable != nil && len(playable) == 0 {
 				b.WriteString(i18n.T("sevens.noPlayable") + "\n")
 			}
 		}

--- a/internal/adapter/presenter/SevensCuiPresenter.go
+++ b/internal/adapter/presenter/SevensCuiPresenter.go
@@ -11,7 +11,11 @@ import (
 )
 
 // sevensPlayerStr returns the display string for a single Sevens player.
-func sevensPlayerStr(player *domain.SevensPlayer, i int) string {
+//
+// playable は人間の手札のうち今出せるインデックス。nil は「判定していない」
+// (人間の手番でない) で、空スライスは「1枚も出せない」— 意味が違うので
+// 呼び出し側で分けて扱う。
+func sevensPlayerStr(player *domain.SevensPlayer, i int, playable []int) string {
 	var b strings.Builder
 	b.WriteString(cuiPlayerName(player, i))
 	if player.GetIsFinished() {
@@ -30,8 +34,13 @@ func sevensPlayerStr(player *domain.SevensPlayer, i int) string {
 		}
 		b.WriteString("\n")
 		if player.GetIsHuman() {
-			b.WriteString(cuiIndexedCardListStr(player))
+			b.WriteString(cuiPlayableMarkedCardListStr(player, playable))
 			b.WriteString("\n")
+			// **空スライスを無印のまま出すと「判定していない」と区別が付かない。**
+			// 7並べでは出せる札が1枚も無い局面が普通に起きるので、明示的に言う。
+			if playable != nil && len(playable) == 0 && player.GetCardsSize() > 0 {
+				b.WriteString(i18n.T("sevens.noPlayable") + "\n")
+			}
 		}
 	}
 	return b.String()
@@ -133,8 +142,9 @@ func (p *SevensCuiPresenter) Output(s interfaces.SevensGame, lastErr error) stri
 	}
 
 	return buildCuiOutput(title, func(b *strings.Builder) {
+		playable := s.GetPlayableCardIndices()
 		for i := 0; i < s.GetPlayerCnt(); i++ {
-			b.WriteString(sevensPlayerStr(s.GetPlayer(i), i))
+			b.WriteString(sevensPlayerStr(s.GetPlayer(i), i, playable))
 		}
 
 		b.WriteString("----------\n")

--- a/internal/adapter/presenter/SevensCuiPresenter_test.go
+++ b/internal/adapter/presenter/SevensCuiPresenter_test.go
@@ -684,3 +684,47 @@ func TestSevensCuiPresenter_English(t *testing.T) {
 		assert.Contains(t, result, "[no joker finish]")
 	})
 }
+
+// #5479: CUI の手札は出せる札とそうでない札を区別していなかった。番号を入れて
+// 弾かれることでしか学べず、Web は SevensHumanArea.tsx が色付きで示している。
+func TestSevensCuiPresenter_PlayableMarks(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+	tsp := new(presenter.SevensCuiPresenter)
+
+	newGame := func(hand ...*domain.Card) *domain.Sevens {
+		players := makeSevensPlayersForPresenter()
+		s := domain.NewSevens(domain.NewTrumpCards(0), players, domain.DefaultSevensConfig())
+		for _, c := range hand {
+			players[0].AddCard(c)
+		}
+		for i := 1; i < 4; i++ {
+			players[i].AddCard(domain.NewCard(domain.CardDesignHeart, 2, false))
+		}
+		return s
+	}
+	card := func(design, value int) *domain.Card { return domain.NewCard(design, value, false) }
+
+	t.Run("stars the playable card and leaves the others bare", func(t *testing.T) {
+		s := newGame(card(domain.CardDesignSpade, 6), card(domain.CardDesignSpade, 11))
+		out := tsp.Output(s, nil)
+		assert.Contains(t, out, "[0]SPADE 6"+presenter.CuiLegalMark)
+		assert.NotContains(t, out, "[1]SPADE 11"+presenter.CuiLegalMark)
+	})
+
+	// **1枚も出せないときに無印にすると「判定していない」と区別が付かない。**
+	// 7並べではこれが普通に起きる局面なので、明示的に言う。
+	t.Run("says so when nothing is playable, rather than showing a bare hand", func(t *testing.T) {
+		s := newGame(card(domain.CardDesignSpade, 11), card(domain.CardDesignSpade, 12))
+		out := tsp.Output(s, nil)
+		assert.Contains(t, out, i18n.T("sevens.noPlayable"))
+		assert.NotContains(t, out, presenter.CuiLegalMark)
+	})
+
+	// 出せる札があるときに「出せる札がありません」を出さない (負のコントロール)。
+	t.Run("does not claim a dead hand when a card is playable", func(t *testing.T) {
+		s := newGame(card(domain.CardDesignSpade, 6))
+		assert.NotContains(t, tsp.Output(s, nil), i18n.T("sevens.noPlayable"))
+	})
+}

--- a/internal/domain/Sevens.go
+++ b/internal/domain/Sevens.go
@@ -346,7 +346,7 @@ func (s *Sevens) IsPlayable(card *Card) bool {
 // GetPlayableCardIndices は人間プレイヤーの手札のうち、いま出せるカードの
 // インデックスを返す (#5479)。
 //
-// 判定は PlayerPlay が使う IsPlayable そのものを通す。トンネル・スキップ幅・
+// 判定は PlayerPlay / PlayerPlayJoker が使うものをそのまま通す。トンネル・スキップ幅・
 // ジョーカーの配置可否といった盤面の状態は全部そちらが見るので、ここで規則を
 // 書き直さない。**別実装にすると「出せる」と印を付けた札が実際には弾かれる。**
 //
@@ -360,9 +360,18 @@ func (s *Sevens) GetPlayableCardIndices() []int {
 		return nil
 	}
 	player := s.players[s.currentTurn]
+	// **IsPlayable だけでは足りない。** ジョーカーについては「置ける場所が
+	// あるか」しか見ないが、PlayerPlayJoker は連続禁止・上がり禁止でも弾く。
+	// hasPlayableCard / findPlayableSimple / findPlayableStrategic と同じ
+	// jokerBlocked を通す -- 印を付けてから弾かれるのは、印が無いより悪い。
+	jokerBlocked := s.isJokerBlockedByFinishRule(player) || s.isJokerBlockedByConsecutiveRule(player)
 	idx := make([]int, 0, player.GetCardsSize())
 	for i := 0; i < player.GetCardsSize(); i++ {
-		if s.IsPlayable(player.GetCard(i)) {
+		card := player.GetCard(i)
+		if jokerBlocked && card != nil && card.GetDesign() == CardDesignJoker {
+			continue
+		}
+		if s.IsPlayable(card) {
 			idx = append(idx, i)
 		}
 	}

--- a/internal/domain/Sevens.go
+++ b/internal/domain/Sevens.go
@@ -343,6 +343,32 @@ func (s *Sevens) IsPlayable(card *Card) bool {
 	return s.isPositionPlayable(suit, value)
 }
 
+// GetPlayableCardIndices は人間プレイヤーの手札のうち、いま出せるカードの
+// インデックスを返す (#5479)。
+//
+// 判定は PlayerPlay が使う IsPlayable そのものを通す。トンネル・スキップ幅・
+// ジョーカーの配置可否といった盤面の状態は全部そちらが見るので、ここで規則を
+// 書き直さない。**別実装にすると「出せる」と印を付けた札が実際には弾かれる。**
+//
+// 戻り値は3状態を区別する:
+//   - nil          … 判定していない (人間の手番でない)
+//   - 空スライス    … 判定した上で1枚も出せない。7並べでは普通に起きる状態で、
+//     そこでプレイヤーはパスする。**nil と同じ扱いにはできない。**
+//   - 非空スライス  … 出せる手札のインデックス
+func (s *Sevens) GetPlayableCardIndices() []int {
+	if !s.IsHumanTurn() {
+		return nil
+	}
+	player := s.players[s.currentTurn]
+	idx := make([]int, 0, player.GetCardsSize())
+	for i := 0; i < player.GetCardsSize(); i++ {
+		if s.IsPlayable(player.GetCard(i)) {
+			idx = append(idx, i)
+		}
+	}
+	return idx
+}
+
 // placeCard ボードにカードを置く (ビットマスクを更新)
 func (s *Sevens) placeCard(card *Card) {
 	suit := card.GetDesign()

--- a/internal/domain/Sevens_test.go
+++ b/internal/domain/Sevens_test.go
@@ -4123,4 +4123,38 @@ func TestSevens_GetPlayableCardIndices(t *testing.T) {
 		s, _ := newGame(domain.NewCard(domain.CardDesignJoker, 0, true))
 		assert.Equal(t, []int{0}, s.GetPlayableCardIndices())
 	})
+
+	// **IsPlayable だけでは足りない。** ジョーカーは「置ける場所があるか」しか
+	// 見ないが、PlayerPlayJoker は連続禁止・上がり禁止でも弾く。印を付けてから
+	// 弾かれるのは、印が無いより悪い。
+	t.Run("does not mark a joker the consecutive-joker rule blocks", func(t *testing.T) {
+		s, players := newGame(domain.NewCard(domain.CardDesignJoker, 0, true),
+			card(domain.CardDesignSpade, 6))
+		cfg := domain.DefaultSevensConfig()
+		cfg.JokerConsecutiveBanned = true
+		s.SetConfig(cfg)
+		players[0].SetLastPlayedJoker(true)
+
+		assert.Equal(t, []int{1}, s.GetPlayableCardIndices(), "♠6 だけが残る")
+		// 実際に出そうとしても弾かれる (印と挙動が一致している)。
+		assert.Error(t, s.PlayerPlayJoker(0, domain.CardDesignSpade, 6))
+	})
+
+	t.Run("does not mark the last joker when finishing on a joker is banned", func(t *testing.T) {
+		s, _ := newGame(domain.NewCard(domain.CardDesignJoker, 0, true))
+		cfg := domain.DefaultSevensConfig()
+		cfg.NoJokerFinish = true
+		s.SetConfig(cfg)
+
+		assert.Empty(t, s.GetPlayableCardIndices())
+		assert.Error(t, s.PlayerPlayJoker(0, domain.CardDesignSpade, 6))
+	})
+
+	// 負のコントロール: 同じ配りでもルールが無効なら印は付く。
+	t.Run("still marks the joker when neither rule is enabled", func(t *testing.T) {
+		s, players := newGame(domain.NewCard(domain.CardDesignJoker, 0, true),
+			card(domain.CardDesignSpade, 6))
+		players[0].SetLastPlayedJoker(true)
+		assert.Equal(t, []int{0, 1}, s.GetPlayableCardIndices())
+	})
 }

--- a/internal/domain/Sevens_test.go
+++ b/internal/domain/Sevens_test.go
@@ -4069,3 +4069,58 @@ func TestSevens_ActionLog_Reset(t *testing.T) {
 	s.Reset()
 	assert.Nil(t, s.GetActionLog())
 }
+
+// #5479: IsPlayable は実装済みだったが interface に無く、CUI からは呼べなかった。
+// Web は SevensHumanArea.tsx が同じ判定をフロントで書き直して色を付けている。
+func TestSevens_GetPlayableCardIndices(t *testing.T) {
+	// 卓には最初から4枚の7が並んでいるので、6 と 8 が出せて 5 や J は出せない。
+	newGame := func(hand ...*domain.Card) (*domain.Sevens, []*domain.SevensPlayer) {
+		players := []*domain.SevensPlayer{
+			domain.NewSevensPlayer(true),
+			domain.NewSevensPlayer(false),
+			domain.NewSevensPlayer(false),
+			domain.NewSevensPlayer(false),
+		}
+		s := domain.NewSevens(domain.NewTrumpCards(0), players, domain.DefaultSevensConfig())
+		for _, c := range hand {
+			players[0].AddCard(c)
+		}
+		for i := 1; i < 4; i++ {
+			players[i].AddCard(domain.NewCard(domain.CardDesignHeart, 2, false))
+		}
+		return s, players
+	}
+	card := func(design, value int) *domain.Card { return domain.NewCard(design, value, false) }
+
+	t.Run("marks only the cards adjacent to the board", func(t *testing.T) {
+		s, _ := newGame(
+			card(domain.CardDesignSpade, 6),  // ♠7 の隣 → 出せる
+			card(domain.CardDesignSpade, 11), // ♠7 から離れている → 出せない
+			card(domain.CardDesignHeart, 8),  // ♥7 の隣 → 出せる
+		)
+		assert.Equal(t, []int{0, 2}, s.GetPlayableCardIndices())
+	})
+
+	// **空スライスと nil を区別する。**7並べは「1枚も出せない」が普通に起きる
+	// (そこでパスする) 局面なので、判定していない状態と同じ扱いにはできない。
+	t.Run("returns an empty slice, not nil, when nothing is playable", func(t *testing.T) {
+		s, _ := newGame(card(domain.CardDesignSpade, 11))
+		got := s.GetPlayableCardIndices()
+		assert.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	t.Run("returns nil when it is not the human turn", func(t *testing.T) {
+		s, _ := newGame(card(domain.CardDesignSpade, 6), card(domain.CardDesignSpade, 8))
+		require.NoError(t, s.PlayerPlay(0)) // 手番が CPU へ移る
+		require.False(t, s.IsHumanTurn())
+		assert.Nil(t, s.GetPlayableCardIndices())
+	})
+
+	// ジョーカーは置ける場所が1つでもあれば出せる。IsPlayable がそう書いてある
+	// のをここでも通す — 印の判定を presenter 側に書き直さないため。
+	t.Run("marks a joker while the board still has room", func(t *testing.T) {
+		s, _ := newGame(domain.NewCard(domain.CardDesignJoker, 0, true))
+		assert.Equal(t, []int{0}, s.GetPlayableCardIndices())
+	})
+}

--- a/internal/domain/interfaces/sevens.go
+++ b/internal/domain/interfaces/sevens.go
@@ -42,4 +42,7 @@ type SevensGame interface {
 	GetCpuActions() []*domain.SevensCpuAction
 	// GetTablePlaced 各スートの配置済みビットマスクを取得する
 	GetTablePlaced() [5]uint16
+	// GetPlayableCardIndices いま出せる人間の手札インデックスを取得する。
+	// nil は「判定していない」、空スライスは「1枚も出せない」で意味が違う。
+	GetPlayableCardIndices() []int
 }

--- a/internal/domain/interfaces/sevens_mock.go
+++ b/internal/domain/interfaces/sevens_mock.go
@@ -126,6 +126,15 @@ func (_m *MockSevensGame) GetTablePlaced() [5]uint16 {
 	return ret.Get(0).([5]uint16)
 }
 
+// GetPlayableCardIndices モック
+func (_m *MockSevensGame) GetPlayableCardIndices() []int {
+	ret := _m.Called()
+	if val, ok := ret.Get(0).([]int); ok {
+		return val
+	}
+	return nil
+}
+
 // GetActionLog モック
 func (_m *MockSevensGame) GetActionLog() []*domain.ActionLogEntry {
 	ret := _m.Called()

--- a/internal/i18n/locales/en/sevens.json
+++ b/internal/i18n/locales/en/sevens.json
@@ -30,5 +30,6 @@
   "jokerHint": "j [card index] [suit] [value] to place a joker",
   "boardSuitLine": "  {{suit}}: {{cells}}",
   "helpExamplePass": "  p                    pass when you cannot play",
-  "helpLog": "  l                    show the action log"
+  "helpLog": "  l                    show the action log",
+  "noPlayable": "No playable card -- pass with p"
 }

--- a/internal/i18n/locales/ja/sevens.json
+++ b/internal/i18n/locales/ja/sevens.json
@@ -30,5 +30,6 @@
   "jokerHint": "j [カードインデックス] [スート] [値] でジョーカーを配置",
   "boardSuitLine": "  {{suit}}: {{cells}}",
   "helpExamplePass": "  p                    出せる札が無いときはパスする",
-  "helpLog": "  l                    行動ログを表示"
+  "helpLog": "  l                    行動ログを表示",
+  "noPlayable": "出せる札がありません。p でパスしてください"
 }


### PR DESCRIPTION
## 背景

`internal/domain/Sevens.go` の `IsPlayable` は実装済みだが、
`internal/domain/interfaces/sevens.go` の `SevensGame` に公開されていない。
`SevensCuiPresenter` はインターフェース越しにしかゲームへアクセスできないので
**呼べない**。結果として CUI の手札 (`cuiIndexedCardListStr`) は出せる札と
出せない札を区別せず、プレイヤーは番号を入れて弾かれることでしか学べない。

Web は `SevensHumanArea.tsx` が同等ロジックをフロント側で再実装して色を付けている。
兄弟の大富豪は `GetPlayableCardIndices()` をインターフェース経由で公開済み。

## 変更

- `Sevens.GetPlayableCardIndices()` を追加し、`SevensGame` に公開
- `SevensCuiPresenter` は既存の共有ヘルパ `cuiPlayableMarkedCardListStr` で `*` を付ける

**判定を書き直さない。** `PlayerPlay` が使う `IsPlayable` をそのまま通すので、
トンネル・スキップ幅・ジョーカーの配置可否は全部そちらが見る。別実装にすると
「出せる」と印を付けた札が実際には弾かれる。

### nil と空スライスを分ける

7並べでは**出せる札が1枚も無い局面が普通に起きる**（そこでパスする）。
共有ヘルパは `len(playable) == 0` を無印に倒す仕様なので、そのままだと
「1枚も出せない」と「判定していない (CPU の手番)」が同じ見た目になる。

- `nil` … 人間の手番でない → 何もしない（従来どおり）
- 空スライス … 判定した上で0枚 → `sevens.noPlayable`「出せる札がありません。p でパスしてください」
- 非空 … 該当インデックスに `*`

## テスト

**domain** (`TestSevens_GetPlayableCardIndices`)
- 卓の7に隣接する札だけに印（離れた J には付かない）
- **空スライスが nil でないこと**を明示的に確認
- CPU の手番では nil
- ジョーカーは置ける場所があれば対象

**presenter** (`TestSevensCuiPresenter_PlayableMarks`)
- 出せる札に `*`、出せない札には付かない
- 0枚のときは `noPlayable` を出し、`*` を1つも出さない
- **負のコントロール**: 出せる札があるときに `noPlayable` を出さない

`ja` / `en` 両方に `noPlayable` を追加。

Closes #5479