### PR TITLE
fix(e2e): stop asserting that one pass ends the Honeymoon Bridge auction

### DIFF
--- a/frontend/e2e/honeymoonbridge.spec.ts
+++ b/frontend/e2e/honeymoonbridge.spec.ts
@@ -97,7 +97,7 @@ test.describe('Honeymoon Bridge E2E', () => {
     // (domain の passCount)、相手が上を宣言すると passCount は 0 に戻り、手番は
     // こちらへ返ってくる —— つまりパスボタンは再び現れる。「パスしたらボタンが
     // 消える」と書いていたので、CPU が宣言した配りでだけ落ちていた。
-    const contractBefore = await page.getByTestId('hb-contract').innerText();
+    const contractBefore = await page.getByTestId('hb-contract').textContent();
     await page.getByTestId('hb-pass-btn').click();
 
     // パスが受理されたなら、競りが締まる (ボタンが消える) か、相手が上を宣言して
@@ -106,7 +106,7 @@ test.describe('Honeymoon Bridge E2E', () => {
       .poll(
         async () => {
           if ((await page.getByTestId('hb-pass-btn').count()) === 0) return true;
-          return (await page.getByTestId('hb-contract').innerText()) !== contractBefore;
+          return (await page.getByTestId('hb-contract').textContent()) !== contractBefore;
         },
         { timeout: TIMEOUT_ACTION },
       )

--- a/frontend/e2e/honeymoonbridge.spec.ts
+++ b/frontend/e2e/honeymoonbridge.spec.ts
@@ -93,9 +93,24 @@ test.describe('Honeymoon Bridge E2E', () => {
     await navigateTo(page, '/honeymoonbridge');
     await reachTheAuction(page);
 
+    // **1回パスしても競りは終わらない。** 締まるのは連続2回パスしたときだけで
+    // (domain の passCount)、相手が上を宣言すると passCount は 0 に戻り、手番は
+    // こちらへ返ってくる —— つまりパスボタンは再び現れる。「パスしたらボタンが
+    // 消える」と書いていたので、CPU が宣言した配りでだけ落ちていた。
+    const contractBefore = await page.getByTestId('hb-contract').innerText();
     await page.getByTestId('hb-pass-btn').click();
-    // 相手が宣言するか、両者パスでディールが流れる——どちらでも競りは終わる。
-    await expect(page.getByTestId('hb-pass-btn')).toHaveCount(0, { timeout: TIMEOUT_ACTION });
+
+    // パスが受理されたなら、競りが締まる (ボタンが消える) か、相手が上を宣言して
+    // 契約表示が変わるか、どちらかは必ず起きる。どちらも起きないのは拒否された時。
+    await expect
+      .poll(
+        async () => {
+          if ((await page.getByTestId('hb-pass-btn').count()) === 0) return true;
+          return (await page.getByTestId('hb-contract').innerText()) !== contractBefore;
+        },
+        { timeout: TIMEOUT_ACTION },
+      )
+      .toBe(true);
   });
 
   test('can reset the game via the reset confirmation dialog', async ({ page }) => {


### PR DESCRIPTION
## 症状

`honeymoonbridge.spec.ts > passing is accepted` が配りによって落ちる。
PR #5840 (Toepen、無関係) の E2E で **3回のリトライすべてで FAIL**:

```
> 98 |  await expect(page.getByTestId('hb-pass-btn')).toHaveCount(0, { timeout: TIMEOUT_ACTION });
1 failed / 242 passed
```

## 原因 — テストの前提が誤り

spec のコメントはこう書いている:

> 相手が宣言するか、両者パスでディールが流れる——どちらでも競りは終わる。

**前半が成り立たない。** `internal/domain/HoneymoonBridge.go` の `bidBy` は
宣言のたびに `h.passCount = 0` に戻し、手番を次へ進める。競りが締まるのは
`passCount >= HoneymoonBridgePlayerCnt` (= 連続2回パス) のときだけ。

つまり **こちらが1回パス → 相手が上を宣言 → 手番はこちらへ返る** ので、
パスボタンは再び現れる。相手もパスした配りでだけ、たまたま通っていた。

## 修正

パスが受理されたことを、次のどちらかで確かめる:

- 競りが締まった (パスボタンが消える)、または
- 相手が上を宣言して契約表示が変わった

**パス前の契約表示を控えてから比較する。** 競りに入る前に既に CPU が宣言して
いる配りでも、`hb-contract` が「未決定でない」ことを見るだけでは素通りしてしまう
ため。両方起きなければ (= パスが拒否されれば) 落ちる。

## 実測

| | 結果 |
|---|---|
| 修正前の assertion を 6 回 (`--repeat-each=6 --retries=0`) | **1 failed / 5 passed** |
| 修正後を 6 回 | **6 passed** |

ゲーム側のバグではないので domain は触っていない。