### PR TITLE
feat(doubt): add the CPU hesitation command and show the pause in the CUI

### DIFF
--- a/docs/manual/cui/doubt.md
+++ b/docs/manual/cui/doubt.md
@@ -109,6 +109,7 @@ flowchart TD
 | `setwindow <sec>` | `sw <sec>` | ダウト判定ウィンドウの秒数を設定（1〜60） |
 | `setmemory <level>` | `sm <level>` | CPU記憶力レベルを設定（0=Easy, 1=Normal, 2=Hard） |
 | `setpenalty <limit>` | `sp <limit>` | ペナルティドロー上限を設定（0=無制限, >0=上限） |
+| `sethesitation N` | `sh N` | CPU の迷い時間演出の切替（0=OFF, 1=ON）。ON にすると CPU の行動行に考えた秒数が付く |
 | `setmetaai N` | `smai N` | Meta-AI の切替（0=OFF, 1=ON） |
 | `resetprofile` | `rp` | Meta-AI のプロファイル（学習データ）をリセット |
 | `quit` | `q` | ゲーム終了 |

--- a/internal/adapter/controller/DoubtCuiController.go
+++ b/internal/adapter/controller/DoubtCuiController.go
@@ -32,6 +32,7 @@ func NewDoubtCuiController(di usecase.DoubtInteractorIF) *DoubtCuiController {
 //	sw / setwindow   → ダウト待機秒数設定 (1-60)
 //	sm / setmemory   → CPU記憶力設定 (0=Easy, 1=Normal, 2=Hard)
 //	sp / setpenalty  → ペナルティドロー上限設定 (0=無制限, >0=上限)
+//	sh / sethesitation → CPU の迷い時間演出 (0=OFF, 1=ON)
 func (c *DoubtCuiController) Exec(command string) string {
 	return execCuiCommand(
 		command,
@@ -42,6 +43,7 @@ func (c *DoubtCuiController) Exec(command string) string {
 		[]string{
 			"p", "play", "d", "doubt", "s", "skip", "sw", "setwindow",
 			"sm", "setmemory", "smetaai", "smai", "rp", "resetprofile", "sp", "setpenalty",
+			"sh", "sethesitation",
 			"log", "l",
 		},
 		func(cmd string, args []string) (string, bool) {
@@ -90,6 +92,12 @@ func (c *DoubtCuiController) Exec(command string) string {
 				return cuiutil.WithParsedIntKeys(args, "metaAiFlagRequired0Off1On", "invalidMetaAiFlag01", 0, 1, func(v int) string {
 					cfg := c.di.GetConfig()
 					cfg.CpuMetaAI = v == 1
+					return c.di.ResetWithConfig(cfg, nil)
+				})
+			case "sh", "sethesitation":
+				return cuiutil.WithParsedIntKeys(args, "hesitationFlagRequired0Off1On", "invalidHesitationFlag01", 0, 1, func(v int) string {
+					cfg := c.di.GetConfig()
+					cfg.CpuHesitationEnabled = v == 1
 					return c.di.ResetWithConfig(cfg, nil)
 				})
 			case "rp", "resetprofile":

--- a/internal/adapter/controller/DoubtCuiController_test.go
+++ b/internal/adapter/controller/DoubtCuiController_test.go
@@ -333,6 +333,37 @@ func TestDoubtCuiController_Exec(t *testing.T) {
 		result := c.Exec("")
 		assert.Contains(t, result, "'help' でコマンド一覧を表示します。")
 	})
+
+	t.Run("sh 1 turns the delay on", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewDoubtCuiController(m)
+		assert.Equal(t, mockOutput, c.Exec("sh 1"))
+		expected := domain.DefaultDoubtConfig()
+		expected.CpuHesitationEnabled = true
+		m.AssertCalled(t, "ResetWithConfig", expected, mock.Anything)
+	})
+
+	t.Run("sethesitation 0 turns it off", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewDoubtCuiController(m)
+		assert.Equal(t, mockOutput, c.Exec("sethesitation 0"))
+		expected := domain.DefaultDoubtConfig()
+		expected.CpuHesitationEnabled = false
+		m.AssertCalled(t, "ResetWithConfig", expected, mock.Anything)
+	})
+
+	t.Run("sh with no argument is refused", func(t *testing.T) {
+		c := controller.NewDoubtCuiController(newMock())
+		assert.True(t, msgRejected(c.Exec("sh")))
+	})
+
+	t.Run("sh rejects a non-boolean value", func(t *testing.T) {
+		c := controller.NewDoubtCuiController(newMock())
+		for _, bad := range []string{"abc", "-1", "2"} {
+			assert.Contains(t, c.Exec("sh "+bad), msgStem("invalidHesitationFlag01"), bad)
+		}
+	})
+
 }
 
 // #5390: `p abc` は宣言する値を 0 に落として通っていた。

--- a/internal/adapter/controller/DoubtCuiController_test.go
+++ b/internal/adapter/controller/DoubtCuiController_test.go
@@ -363,7 +363,6 @@ func TestDoubtCuiController_Exec(t *testing.T) {
 			assert.Contains(t, c.Exec("sh "+bad), msgStem("invalidHesitationFlag01"), bad)
 		}
 	})
-
 }
 
 // #5390: `p abc` は宣言する値を 0 に落として通っていた。

--- a/internal/adapter/presenter/DoubtCuiPresenter.go
+++ b/internal/adapter/presenter/DoubtCuiPresenter.go
@@ -99,6 +99,15 @@ func (p *DoubtCuiPresenter) Output(d interfaces.DoubtGame, lastErr error) string
 				if action.HasTell {
 					line += " " + color.Yellow(i18n.T("doubt.tell"))
 				}
+				// **間の長さもブラフの合図。** ブラフは 300-500ms か 1200-1800ms、
+				// 正直は 600-1000ms で範囲が重ならない。Web はこの秒数をそのまま
+				// 待ってプレイヤーに体感させるが、CUI は待てないので数値で出す。
+				// 「速い/遅い」と要約はしない -- 体感より綺麗な手掛かりになってしまう。
+				// 0 は「計測して 0 だった」ではなく設定 OFF なので、何も出さない。
+				if action.HesitationMs > 0 {
+					line += " " + i18n.Tf("doubt.cpuThinkTime",
+						"sec", strconv.FormatFloat(float64(action.HesitationMs)/1000, 'f', 1, 64))
+				}
 				b.WriteString(line + "\n")
 			}
 		}

--- a/internal/adapter/presenter/DoubtCuiPresenter_test.go
+++ b/internal/adapter/presenter/DoubtCuiPresenter_test.go
@@ -407,3 +407,41 @@ func TestDoubtCuiPresenter_ActionLogOutput(t *testing.T) {
 		mockGame.AssertExpectations(t)
 	})
 }
+
+// #5480: CpuHesitationEnabled は HesitationMs を生むだけで、それを読んでいるのは
+// Web の useDoubtGame.ts だけだった。CUI は値を無視するので、設定を ON にしても
+// CUI では何も変わらない。**Web のプレイヤーは間の長さでブラフを読める。**
+// ブラフは 300-500ms (60%) か 1200-1800ms、正直は 600-1000ms と範囲が重ならない。
+func TestDoubtCuiPresenter_HesitationTime(t *testing.T) {
+	p := new(presenter.DoubtCuiPresenter)
+
+	t.Run("shows how long the CPU took when the setting produced a delay", func(t *testing.T) {
+		game, _ := makeDoubtGameForPresenter()
+		game.SetCpuActions([]*domain.DoubtCpuAction{
+			{PlayerIdx: 1, ClaimedValue: 3, CardCount: 2, HesitationMs: 1400},
+		})
+		assert.Contains(t, p.Output(game, nil), i18n.Tf("doubt.cpuThinkTime", "sec", "1.4"))
+	})
+
+	// **設定 OFF では HesitationMs が 0 のまま。**そこで「0.0秒」と出すと、
+	// 計測した結果が 0 だったように読めてしまう。何も出さないのが正しい。
+	t.Run("says nothing when the setting is off", func(t *testing.T) {
+		game, _ := makeDoubtGameForPresenter()
+		game.SetCpuActions([]*domain.DoubtCpuAction{
+			{PlayerIdx: 1, ClaimedValue: 3, CardCount: 2, HesitationMs: 0},
+		})
+		out := p.Output(game, nil)
+		assert.NotContains(t, out, i18n.Tf("doubt.cpuThinkTime", "sec", "0.0"))
+		assert.NotContains(t, out, "秒")
+	})
+
+	// 速い側の間も出る。**速さもブラフの合図。**300-500ms を落とすと、
+	// ブラフの 6 割が無印になる。
+	t.Run("shows a fast answer too, not only a long think", func(t *testing.T) {
+		game, _ := makeDoubtGameForPresenter()
+		game.SetCpuActions([]*domain.DoubtCpuAction{
+			{PlayerIdx: 1, ClaimedValue: 3, CardCount: 2, HesitationMs: 400},
+		})
+		assert.Contains(t, p.Output(game, nil), i18n.Tf("doubt.cpuThinkTime", "sec", "0.4"))
+	})
+}

--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -585,5 +585,7 @@
   "claimNeedsHalfSuitAndHolders": "Claim needs a half-suit and all six holders (e.g. c 0 0 0 2 2 4 4).",
   "layoffNeedsThreeInts": "Layoff needs three integers: <owner> <meldIdx> <cardIdx>.",
   "giveExactlyNIndexes": "Give exactly {{n}} card indexes.",
-  "notes": "Notes:"
+  "notes": "Notes:",
+  "hesitationFlagRequired0Off1On": "CPU hesitation flag is required (0=OFF, 1=ON).",
+  "invalidHesitationFlag01": "Invalid CPU hesitation flag: {{val}}. Please enter 0-1."
 }

--- a/internal/i18n/locales/en/doubt.json
+++ b/internal/i18n/locales/en/doubt.json
@@ -32,5 +32,7 @@
   "promptHonestValue": "An honest claim would be: {{value}}",
   "promptPlayHelp": "p <value> <idx...>: play cards",
   "tell": "(looks nervous…)",
-  "helpLog": "  l                    show the action log"
+  "helpLog": "  l                    show the action log",
+  "helpSetHesitation": "  sh <0|1>             CPU hesitation delay (0=OFF, 1=ON)",
+  "cpuThinkTime": "({{sec}}s)"
 }

--- a/internal/i18n/locales/ja/common.json
+++ b/internal/i18n/locales/ja/common.json
@@ -585,5 +585,7 @@
   "claimNeedsHalfSuitAndHolders": "claim にはハーフスートと 6 人分の持ち主が要ります (例: c 0 0 0 2 2 4 4)。",
   "layoffNeedsThreeInts": "レイオフには整数が 3 つ要ります: <owner> <meldIdx> <cardIdx>。",
   "giveExactlyNIndexes": "手札の番号をちょうど {{n}} 個指定してください。",
-  "notes": "補足:"
+  "notes": "補足:",
+  "hesitationFlagRequired0Off1On": "CPU の迷い時間演出の有無を指定してください (0=OFF, 1=ON)。",
+  "invalidHesitationFlag01": "CPU の迷い時間演出の有無が不正です: {{val}}。0-1 を入力してください。"
 }

--- a/internal/i18n/locales/ja/doubt.json
+++ b/internal/i18n/locales/ja/doubt.json
@@ -32,5 +32,7 @@
   "promptHonestValue": "正直に申告するなら: {{value}}",
   "promptPlayHelp": "p <値> <idx...>・・・カードを出す",
   "tell": "（そわそわしている…）",
-  "helpLog": "  l                    行動ログを表示"
+  "helpLog": "  l                    行動ログを表示",
+  "helpSetHesitation": "  sh <0|1>             CPU hesitation delay (0=OFF, 1=ON)",
+  "cpuThinkTime": "({{sec}}秒)"
 }

--- a/internal/infrastructure/ui/DoubtCui.go
+++ b/internal/infrastructure/ui/DoubtCui.go
@@ -47,7 +47,7 @@ func (cui *DoubtCui) HelpLines() []string {
 	return BuildCuiHelp(CuiHelpSpec{
 		TitleKey:    "doubt.helpTitle",
 		CommandKeys: []string{"doubt.helpPlay", "doubt.helpDoubt", "doubt.helpSkip", "doubt.helpLog"},
-		SettingKeys: []string{"doubt.helpSetWindow", "doubt.helpSetMemory", "doubt.helpSetPenalty"},
+		SettingKeys: []string{"doubt.helpSetWindow", "doubt.helpSetMemory", "doubt.helpSetPenalty", "doubt.helpSetHesitation"},
 	})
 }
 


### PR DESCRIPTION
## 起票内容の訂正

issue は「hesitation を有効にする手段が無いので **tell 機能そのものが事実上使えない**」
としているが、コードを追うとそうではない:

```go
if isActuallyBluff {
    cpuAction.HasTell = rand.Float64() < calcTellChance(d.config.CpuMemoryLevel)
}
if d.config.CpuHesitationEnabled {
    cpuAction.HesitationMs = calcDoubtHesitationMs(isActuallyBluff)
}
```

`HasTell` は `CpuMemoryLevel` だけで決まり、**この設定とは無関係**。`doubt.tell`
バッジは設定 OFF のままでも既に CUI に出ている (`DoubtCuiPresenter.go:99`)。

この設定が生むのは `HesitationMs` だけで、読んでいるのは Web の
`useDoubtGame.ts:147` (その ms だけ待ってから結果を見せる) のみ。

## 変更

### 1. `sh` / `sethesitation` (issue の依頼どおり)

`smetaai` と同じ 0/1 の真偽値コマンド。`WithParsedIntKeys(args, ..., 0, 1, ...)`
で既存の `sw`/`sm`/`sp` と同じ引数検証。

### 2. CUI でも「間」を出す

**コマンドだけ足しても CUI では何も変わらない。** CUI は `HesitationMs` を捨てて
いるので、設定を ON にしても表示は 1 文字も動かない。それでは設定できる意味がない。

間の長さは本物の手掛かりで、範囲が重ならない:

| | ミリ秒 |
|---|---|
| ブラフ・速答 (60%) | 300–500 |
| ブラフ・長考 | 1200–1800 |
| 正直 | 600–1000 |

Web のプレイヤーはこの待ち時間を体感して読む。CUI は待てないので、CPU の行動行に
秒数をそのまま添える。

**「速い/遅い」と要約はしない。** 体感より綺麗な手掛かりになってしまい、Web より
簡単なゲームになる。数値を出して判断はプレイヤーに残す。

**0 のときは何も出さない。** `0.0秒` と書くと「計測したら 0 だった」と読めるが、
実際は設定 OFF で計測していない。

## テスト

- `sh 1` / `sethesitation 0` が `CpuHesitationEnabled` を正しく渡す
- 引数なし → 拒否、`abc` / `-1` / `2` → `invalidHesitationFlag01`
- presenter: 1400ms で `(1.4秒)`、**400ms の速答も出る**（落とすとブラフの6割が無印）
- **負のコントロール**: 0ms のとき秒数を一切出さない

**変異テスト（実測）**:

| 変異 | 落ちたテスト |
|---|---|
| `HesitationMs > 0` の判定を外して常に出す | 2 |
| `v == 1` を `v == 0` に反転 | 5 |
| 受理範囲を 0-1 → 0-9 に広げる | 3 |

ヘルプ (`doubt.helpSetHesitation`)、`docs/manual/cui/doubt.md` の表、
ja/en 両方の locale を同じコミットで更新。

Closes #5480