### PR TITLE
feat(holdem): show the blinds in the CUI outside tournament mode

### DIFF
--- a/internal/adapter/presenter/HoldemCuiPresenter.go
+++ b/internal/adapter/presenter/HoldemCuiPresenter.go
@@ -42,6 +42,14 @@ func (p *HoldemCuiPresenter) Output(h interfaces.HoldemGame, lastErr error) stri
 					"chips", strconv.Itoa(cfg.AddonChips),
 					"after", strconv.Itoa(cfg.AddonAfterHand)) + "\n")
 			}
+		} else {
+			// **ブラインド額はモードによらず効いている** (minRaise = BigBlind)。
+			// tournamentLine の中にしか無かったので、トーナメントでない大半の
+			// プレイでは額が一切出ていなかった。Web のヘッダーは常に出している。
+			// トーナメント側では tournamentLine が同じ SB/BB を含むので重ねない。
+			b.WriteString(i18n.Tf("holdem.blindsLine",
+				"sb", strconv.Itoa(cfg.SmallBlind),
+				"bb", strconv.Itoa(cfg.BigBlind)) + "\n")
 		}
 
 		b.WriteString(i18n.Tf("holdem.tableMax", "n", strconv.Itoa(h.GetPlayerCnt())) + "\n")

--- a/internal/adapter/presenter/HoldemCuiPresenter_test.go
+++ b/internal/adapter/presenter/HoldemCuiPresenter_test.go
@@ -2,6 +2,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +11,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func makeHoldemForPresenter() (*domain.Holdem, []*domain.HoldemPlayer) {
@@ -781,5 +783,52 @@ func TestHoldemCuiPresenter_ActionLogOutput(t *testing.T) {
 
 		assert.Contains(t, result, "棋譜はありません")
 		mockGame.AssertExpectations(t)
+	})
+}
+
+// #5481: SB/BB は tournamentLine の中にしか無く、トーナメントでない大半のプレイ
+// ではブラインド額が CUI に一切出ない。Web の HoldemPage.tsx はモードに関わらず
+// ヘッダーに出している。額はモードによらず使われる値 (minRaise = BigBlind)。
+func TestHoldemCuiPresenter_BlindsAlwaysShown(t *testing.T) {
+	p := new(presenter.HoldemCuiPresenter)
+
+	t.Run("shows the blinds outside tournament mode", func(t *testing.T) {
+		h, _ := makeHoldemForPresenter()
+		h.SetPhase(domain.HoldemPhasePreFlop)
+		h.SetConfig(domain.HoldemConfig{SmallBlind: 10, BigBlind: 20, InitChips: 1000})
+
+		out := p.Output(h, nil)
+		assert.Contains(t, out, i18n.Tf("holdem.blindsLine", "sb", "10", "bb", "20"))
+		// トーナメント表示は出さない。
+		assert.NotContains(t, out, i18n.T("holdem.tournamentLine"))
+	})
+
+	// **トーナメントでは二重に出さない。** tournamentLine が同じ SB/BB を含む。
+	t.Run("does not repeat the blinds in tournament mode", func(t *testing.T) {
+		h, _ := makeHoldemForPresenter()
+		h.SetPhase(domain.HoldemPhasePreFlop)
+		h.SetConfig(domain.HoldemConfig{
+			SmallBlind: 10, BigBlind: 20, InitChips: 1000,
+			TournamentMode: true, BlindLevelHands: 5, BlindMultiplier: 200,
+		})
+		h.SetHandCount(3)
+
+		out := p.Output(h, nil)
+		// blindsLine は tournamentLine の部分文字列なので Contains では区別が
+		// 付かない。**出現回数で見る。**独立行を足していれば 2 回になる。
+		assert.Equal(t, 1, strings.Count(out, i18n.Tf("holdem.blindsLine", "sb", "10", "bb", "20")))
+		// 既存のトーナメント表示は変わらない。
+		assert.Contains(t, out, "トーナメント ハンド#3 SB:10 BB:20 (レベルアップ:5ハンド毎)")
+	})
+
+	// 額が変われば表示も変わる。定数を書いているだけのテストにしない。
+	t.Run("reports the configured amounts, not fixed ones", func(t *testing.T) {
+		h, _ := makeHoldemForPresenter()
+		h.SetPhase(domain.HoldemPhasePreFlop)
+		h.SetConfig(domain.HoldemConfig{SmallBlind: 25, BigBlind: 50, InitChips: 1000})
+
+		out := p.Output(h, nil)
+		assert.Contains(t, out, i18n.Tf("holdem.blindsLine", "sb", "25", "bb", "50"))
+		assert.NotContains(t, out, i18n.Tf("holdem.blindsLine", "sb", "10", "bb", "20"))
 	})
 }

--- a/internal/i18n/locales/en/holdem.json
+++ b/internal/i18n/locales/en/holdem.json
@@ -58,5 +58,6 @@
   "resultBestFive": " [{{cards}}]",
   "helpExampleRaise": "  ra 200               raise to 200 chips total",
   "helpExampleCall": "  c                    call the current bet",
-  "helpLog": "  l                    show the action log"
+  "helpLog": "  l                    show the action log",
+  "blindsLine": "SB:{{sb}} BB:{{bb}}"
 }

--- a/internal/i18n/locales/ja/holdem.json
+++ b/internal/i18n/locales/ja/holdem.json
@@ -58,5 +58,6 @@
   "resultBestFive": " [{{cards}}]",
   "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする",
   "helpExampleCall": "  c                    現在のベットにコールする",
-  "helpLog": "  l                    行動ログを表示"
+  "helpLog": "  l                    行動ログを表示",
+  "blindsLine": "SB:{{sb}} BB:{{bb}}"
 }


### PR DESCRIPTION
## 背景

`HoldemCuiPresenter.Output` は SB/BB を `if cfg.TournamentMode { ... }` の中の
`tournamentLine` でしか出していない。**トーナメントでない大半のプレイでは
ブラインド額が CUI に一切出ない。**

額はモードによらず効いている値で (`internal/domain/Holdem.go`: `h.minRaise =
h.config.BigBlind`)、Web の `HoldemPage.tsx` はモードに関わらずヘッダーに出す。

## 変更

`else` に独立した `holdem.blindsLine` を置く。トーナメント側は `tournamentLine`
が同じ SB/BB を含むので**重ねない** — 既存のトーナメント表示は 1 文字も変えていない。

## テスト

- 通常モードで `SB:10 BB:20` が出る（トーナメント行は出ない）
- トーナメントでは **出現回数が 1**。`blindsLine` は `tournamentLine` の部分文字列
  なので `Contains` では区別が付かず、独立行を足していれば 2 回になる
- 25/50 を設定したら 25/50 が出て 10/20 は出ない（定数を書いただけのテストにしない）

**変異テスト（実測、置換が当たったことを確認済み）**:

| 変異 | 落ちたテスト |
|---|---|
| `else` を外してトーナメントでも出す | 1 |
| 額を config でなく "10"/"20" 固定にする | 2 |

Closes #5481