### PR TITLE
feat(bigo): show which two hole cards made the hand in the CUI

### DIFF
--- a/internal/adapter/presenter/OmahaCuiPresenter.go
+++ b/internal/adapter/presenter/OmahaCuiPresenter.go
@@ -165,6 +165,14 @@ func (p *OmahaCuiPresenter) Output(o interfaces.OmahaGame, lastErr error) string
 		if len(results) > 0 && (o.GetPhase() == domain.OmahaPhaseEnd || o.GetPhase() == domain.OmahaPhaseShowdown) {
 			b.WriteString("==========\n")
 			b.WriteString(color.Bold(i18n.T("omaha.resultsHeader")) + "\n")
+			// 印の凡例は1度だけ。プレイヤーごとに繰り返すと、4人ショーダウンでは
+			// 同じ注記が4回並ぶ。
+			for _, r := range results {
+				if !r.Mucked && len(r.BestHand) > 0 {
+					b.WriteString(i18n.T("omaha.resultBestLegend") + "\n")
+					break
+				}
+			}
 			for _, r := range results {
 				name := cuiPlayerName(o.GetPlayer(r.PlayerIdx), r.PlayerIdx)
 				kickers := ""
@@ -178,6 +186,17 @@ func (p *OmahaCuiPresenter) Output(o interfaces.OmahaGame, lastErr error) string
 					b.WriteString(i18n.Tf("omaha.resultHand", "name", name, "hand", cuiPokerHandName(r.HandRank), "kickers", kickers))
 				default:
 					b.WriteString(i18n.Tf("omaha.resultPlayerOnly", "name", name))
+				}
+				// **どの2枚を手札から使ったのかは印が無いと追えない。** オマハ系は
+				// 手札から使う枚数が固定で (通常4枚のうち2枚、Big O は5枚のうち2枚)、
+				// Web は cardUsed/cardUnused ラベルでそれを見せている。CUI は役名と
+				// キッカーだけで、RoundResult.BestHand を使っていなかった (#5484)。
+				//
+				// マックした手は見せない。BestHand が空の結果 (フォールド勝ちなど) も
+				// 出さない -- 空行を出すと「役が無かった」ように読める。
+				if !r.Mucked && len(r.BestHand) > 0 {
+					b.WriteString(i18n.Tf("omaha.resultBest",
+						"cards", omahaBestHandStr(r.BestHand, o.GetPlayer(r.PlayerIdx))))
 				}
 				if o.GetIsHiLo() && r.LowQualifies {
 					b.WriteString(i18n.Tf("omaha.resultLow", "cards", cuiCardSliceStrEmoji(r.LowBestHand)))
@@ -236,4 +255,34 @@ func (p *OmahaCuiPresenter) Output(o interfaces.OmahaGame, lastErr error) string
 			b.WriteString(i18n.T("omaha.gameEnd") + "\n")
 		}
 	})
+}
+
+// omahaBestHandStr renders the winning five cards, suffixing the ones that came
+// from the player's own hole with CuiHoleMark.
+//
+// player が nil のときは印だけ落として5枚を並べる -- 印が付かないほうが、
+// 全部が手札由来に見えるより正直。
+func omahaBestHandStr(best []*domain.Card, player *domain.OmahaPlayer) string {
+	hole := make(map[string]bool)
+	if player != nil {
+		for i := 0; i < player.GetCardsSize(); i++ {
+			if c := player.GetCard(i); c != nil {
+				hole[omahaCardKey(c)] = true
+			}
+		}
+	}
+	parts := make([]string, 0, len(best))
+	for _, c := range best {
+		s := cuiCardStrEmoji(c)
+		if c != nil && hole[omahaCardKey(c)] {
+			s += CuiHoleMark
+		}
+		parts = append(parts, s)
+	}
+	return strings.Join(parts, "  ")
+}
+
+// omahaCardKey identifies a card within a single deck (suit+rank is unique).
+func omahaCardKey(c *domain.Card) string {
+	return strconv.Itoa(c.GetDesign()) + ":" + strconv.Itoa(c.GetValue())
 }

--- a/internal/adapter/presenter/OmahaCuiPresenter_test.go
+++ b/internal/adapter/presenter/OmahaCuiPresenter_test.go
@@ -2,6 +2,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -992,4 +993,93 @@ func TestOmahaCuiPresenter_ShowsWhetherCallingIsPlusEV(t *testing.T) {
 		assert.NotContains(t, out, i18n.T("omaha.learningEvPlus"))
 		assert.NotContains(t, out, i18n.T("omaha.learningEvMinus"))
 	})
+}
+
+// #5484: Big O は5枚のホールカードから必ず2枚だけ使う。10通りの組み合わせの
+// どれが役になったのかを Web は cardUsed/cardUnused で示すのに、CUI の結果表示は
+// 役名とキッカーだけで、RoundResult.BestHand を一度も使っていなかった。
+func TestOmahaCuiPresenter_ResultBestHand(t *testing.T) {
+	p := new(presenter.OmahaCuiPresenter)
+	card := func(design, value int) *domain.Card { return domain.NewCard(design, value, false) }
+
+	t.Run("shows the five cards and marks the two that came from the hole", func(t *testing.T) {
+		h, players := makeOmahaForPresenter()
+		h.SetPhase(domain.OmahaPhaseEnd)
+		// ホール5枚 (Big O)。うち ♠A と ♠K がベストに入る。
+		for _, c := range []*domain.Card{
+			card(domain.CardDesignSpade, 1), card(domain.CardDesignSpade, 13),
+			card(domain.CardDesignHeart, 2), card(domain.CardDesignHeart, 3),
+			card(domain.CardDesignClover, 4),
+		} {
+			players[0].AddCard(c)
+		}
+		best := []*domain.Card{
+			card(domain.CardDesignSpade, 1), card(domain.CardDesignSpade, 13),
+			card(domain.CardDesignSpade, 12), card(domain.CardDesignSpade, 11), card(domain.CardDesignSpade, 10),
+		}
+		h.SetRoundResults([]domain.HoldemResult{
+			{PlayerIdx: 0, HandRank: domain.PokerHandFlush, HandName: "Flush", WonAmount: 100, BestHand: best},
+		})
+
+		out := p.Output(h, nil)
+		// 5枚とも出る (♠ は黒スートなので色コードが付かない)。
+		for _, want := range []string{"♠1", "♠13", "♠12", "♠11", "♠10"} {
+			assert.Contains(t, out, want)
+		}
+		// **ホール由来の2枚にだけ印。**印が5個なら、どれを使ったのか分からない
+		// のと同じ。
+		line := ""
+		for _, l := range strings.Split(out, "\n") {
+			if strings.Contains(l, i18n.T("omaha.resultBestLabel")) {
+				line = l
+			}
+		}
+		assert.NotEmpty(t, line, "ベストハンドの行が出ていない")
+		assert.Equal(t, 2, strings.Count(line, presenter.CuiHoleMark))
+	})
+
+	// マックしたプレイヤーは手を見せない。BestHand が残っていても出さない。
+	t.Run("says nothing for a mucked hand", func(t *testing.T) {
+		h, players := makeOmahaForPresenter()
+		h.SetPhase(domain.OmahaPhaseEnd)
+		players[0].AddCard(card(domain.CardDesignSpade, 1))
+		h.SetRoundResults([]domain.HoldemResult{
+			{PlayerIdx: 0, Mucked: true, BestHand: []*domain.Card{card(domain.CardDesignSpade, 1)}},
+		})
+		assert.NotContains(t, p.Output(h, nil), i18n.T("omaha.resultBestLabel"))
+	})
+
+	// BestHand が空の結果 (フォールド勝ちなど) では行ごと出さない。
+	t.Run("says nothing when there is no best hand", func(t *testing.T) {
+		h, _ := makeOmahaForPresenter()
+		h.SetPhase(domain.OmahaPhaseEnd)
+		h.SetRoundResults([]domain.HoldemResult{
+			{PlayerIdx: 0, HandRank: domain.PokerHandFlush, HandName: "Flush", WonAmount: 100, BestHand: nil},
+		})
+		assert.NotContains(t, p.Output(h, nil), i18n.T("omaha.resultBestLabel"))
+	})
+}
+
+// 凡例は1度だけ。4人ショーダウンで同じ注記が4回並ぶと読みにくい。
+func TestOmahaCuiPresenter_ResultBestLegendShownOnce(t *testing.T) {
+	p := new(presenter.OmahaCuiPresenter)
+	card := func(design, value int) *domain.Card { return domain.NewCard(design, value, false) }
+
+	h, players := makeOmahaForPresenter()
+	h.SetPhase(domain.OmahaPhaseEnd)
+	best := []*domain.Card{
+		card(domain.CardDesignSpade, 1), card(domain.CardDesignSpade, 13),
+		card(domain.CardDesignSpade, 12), card(domain.CardDesignSpade, 11), card(domain.CardDesignSpade, 10),
+	}
+	players[0].AddCard(card(domain.CardDesignSpade, 1))
+	players[1].AddCard(card(domain.CardDesignSpade, 13))
+	h.SetRoundResults([]domain.HoldemResult{
+		{PlayerIdx: 0, HandRank: domain.PokerHandFlush, HandName: "Flush", BestHand: best},
+		{PlayerIdx: 1, HandRank: domain.PokerHandFlush, HandName: "Flush", BestHand: best},
+	})
+
+	out := p.Output(h, nil)
+	assert.Equal(t, 1, strings.Count(out, i18n.T("omaha.resultBestLegend")))
+	// それでも各プレイヤーの行にはベストが出る。
+	assert.Equal(t, 2, strings.Count(out, i18n.T("omaha.resultBestLabel")))
 }

--- a/internal/adapter/presenter/cui_card_helper.go
+++ b/internal/adapter/presenter/cui_card_helper.go
@@ -178,6 +178,13 @@ func cuiIndexedCardListStr(hand cuiCardList) string {
 	return formatCardList(hand, cuiCardStr, "  ", true)
 }
 
+// CuiHoleMark は「その札は自分の手札から出したもの」を示す印。ショーダウンで
+// ベストハンド5枚を並べたとき、どれがボード由来でどれが手札由来かを分ける。
+//
+// **オマハ系は手札から使う枚数が固定** (通常4枚のうち2枚、Big O は5枚のうち2枚)
+// なので、10通りの組み合わせのどれが役になったのかは印が無いと追えない (#5484)。
+const CuiHoleMark = "*"
+
 // CuiLegalMark は「この札は今出せる」ことを示す印。CrazyEights / Wizard /
 // Mushi / GoFish が以前から使っている後置の "*" に合わせている。
 const CuiLegalMark = "*"

--- a/internal/i18n/locales/en/omaha.json
+++ b/internal/i18n/locales/en/omaha.json
@@ -53,5 +53,8 @@
   "learningHeader": "[Learning mode]",
   "learningLine": "  Equity: {{equity}}% / Pot odds: {{potodds}}%",
   "learningEvPlus": "  +EV (equity beats pot odds; calling is favorable)",
-  "learningEvMinus": "  -EV (equity at or below pot odds; calling is unfavorable)"
+  "learningEvMinus": "  -EV (equity at or below pot odds; calling is unfavorable)",
+  "resultBest": " / Best: {{cards}}",
+  "resultBestLabel": "Best:",
+  "resultBestLegend": "  (* = card used from the hole)"
 }

--- a/internal/i18n/locales/ja/omaha.json
+++ b/internal/i18n/locales/ja/omaha.json
@@ -53,5 +53,8 @@
   "learningHeader": "[学習モード]",
   "learningLine": "  勝率: {{equity}}% / ポットオッズ: {{potodds}}%",
   "learningEvPlus": "  +EV (勝率がポットオッズを上回っています。コール有利)",
-  "learningEvMinus": "  -EV (勝率がポットオッズ以下です。コール不利)"
+  "learningEvMinus": "  -EV (勝率がポットオッズ以下です。コール不利)",
+  "resultBest": " / ベスト: {{cards}}",
+  "resultBestLabel": "ベスト:",
+  "resultBestLegend": "  (* = 自分の手札から使った札)"
 }


### PR DESCRIPTION
## 背景

Big O は5枚のホールカードから**必ず2枚だけ**使う。どの2枚が役を作ったのかは
10通りの組み合わせから選ばれるので、見た目の助けが無いと追いにくい。

Web の `BigOPage.tsx` はショーダウンで各ホールカードに `cardUsed` / `cardUnused`
ラベルを付けて示す。バックエンドにも同じ情報が `RoundResult.BestHand` に入っているが、
**CUI はそれを一度も使わず**、役名とキッカーしか出していなかった。

## 変更

結果行にベスト5枚を並べ、**手札由来の札に `*` を付ける**。通常のオマハ
(4枚のうち2枚) でも同じ仕組みで動く。

- **マックした手は見せない。** 降りた相手の手を明かすことになる
- **`BestHand` が空 (フォールド勝ちなど) は行ごと出さない。** 空の行は「役が無かった」と読める
- **凡例は結果ブロックに1度だけ。** プレイヤーごとに出すと4人ショーダウンで同じ注記が4回並ぶ

## テスト

- 5枚とも出て、**印はちょうど2個** — 5個なら「どれを使ったか」の情報がゼロなのと同じ
- マック時は行が出ない
- `BestHand` が空のときは行が出ない
- 2人ショーダウンで**凡例は1回、ベスト行は2回**

**変異テスト（実測、置換が当たったことを確認済み）**:

| 変異 | 落ちたテスト |
|---|---|
| ホール判定を外して全札に印 | 1 |
| マックでも行を出す | 1 |
| 凡例をプレイヤーごとに出す | 2 |

Closes #5484