### PR TITLE
feat(courchevel): announce the live best hand to screen readers

### DIFF
--- a/frontend/src/i18n/locales/en/courchevel.json
+++ b/frontend/src/i18n/locales/en/courchevel.json
@@ -95,5 +95,6 @@
     "straightFlush": "Straight Flush",
     "royalFlush": "Royal Flush"
   },
-  "exposedNotice": "The first board card is already face up before the opening bet"
+  "exposedNotice": "The first board card is already face up before the opening bet",
+  "livePreviewAria": "Current best hand: {{hand}}"
 }

--- a/frontend/src/i18n/locales/ja/courchevel.json
+++ b/frontend/src/i18n/locales/ja/courchevel.json
@@ -95,5 +95,6 @@
     "straightFlush": "ストレートフラッシュ",
     "royalFlush": "ロイヤルフラッシュ"
   },
-  "exposedNotice": "1枚目は最初のベットの前から見えています"
+  "exposedNotice": "1枚目は最初のベットの前から見えています",
+  "livePreviewAria": "現在の役: {{hand}}"
 }

--- a/frontend/src/pages/CourchevelPage.test.tsx
+++ b/frontend/src/pages/CourchevelPage.test.tsx
@@ -1609,6 +1609,46 @@ describe('CourchevelPage', () => {
     expect(badge.textContent?.trim()).toBeTruthy();
   });
 
+  // #5486: 役名の span には role も aria-live も無く、ストリートが進んで最善役が
+  // 変わってもスクリーンリーダーには何も読まれなかった。5枚から2枚を選ぶ組み合わせは
+  // 10通りあり、見えている人ほど得をする表示になっていた。
+  it('announces the current best hand to a screen reader', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(flopState);
+    renderWithProviders(<CourchevelPage />);
+
+    const live = await screen.findByTestId('courchevel-live-besthand-status');
+    expect(live).toHaveAttribute('role', 'status');
+    expect(live).toHaveAttribute('aria-live', 'polite');
+    // **ラベルと役名を1文で読ませる。** 2要素に割れていると「現在の役:」と
+    // 役名が別々に読まれ、対応が取れない。
+    const badge = screen.getByTestId('courchevel-live-besthand-name');
+    expect(live.textContent).toContain(badge.textContent?.trim());
+    expect(live.textContent).not.toMatch(/hand\./);
+  });
+
+  // 視覚表示は据え置き。読み上げ用の文が画面に二重に出てはいけない。
+  it('keeps the announcement out of the visible layout', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(flopState);
+    renderWithProviders(<CourchevelPage />);
+
+    const live = await screen.findByTestId('courchevel-live-besthand-status');
+    expect(live).toHaveClass('sr-only');
+    // 見えているバッジ側は今までどおり残る。
+    expect(screen.getByTestId('courchevel-live-besthand-name')).toBeInTheDocument();
+  });
+
+  it('drops the announcement at showdown along with the preview', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(showdownState);
+    renderWithProviders(<CourchevelPage />);
+    await waitFor(() => expect(screen.queryByTestId('courchevel-live-besthand-status')).not.toBeInTheDocument());
+  });
+
   it('drops the preview at showdown, where the final hand is already shown', async () => {
     localStorage.clear();
     mockExec.mockReset();

--- a/frontend/src/pages/CourchevelPage.tsx
+++ b/frontend/src/pages/CourchevelPage.tsx
@@ -362,10 +362,25 @@ function CourchevelPageContent() {
                 </div>
                 {liveBestHandKey && (
                   <div className="mb-1" data-testid="courchevel-live-besthand">
-                    <span className="text-ds-text-primary text-xs">{t('livePreview')}</span>
+                    {/* **見えている2要素は読み上げ向きではない。** ラベルと役名が
+                        別々に読まれると対応が取れないので、1文にまとめた sr-only の
+                        live region を別に置き、視覚側は aria-hidden にする (#5486).
+                        バッジのスタイルは変えていない。 */}
+                    <div
+                      className="sr-only"
+                      role="status"
+                      aria-live="polite"
+                      data-testid="courchevel-live-besthand-status"
+                    >
+                      {t('livePreviewAria', { hand: t(`hand.${liveBestHandKey}`) })}
+                    </div>
+                    <span className="text-ds-text-primary text-xs" aria-hidden="true">
+                      {t('livePreview')}
+                    </span>
                     <span
                       className={`inline-block ml-1.5 text-xs font-bold rounded px-2 py-0.5 ${handNameBadgeClass}`}
                       data-testid="courchevel-live-besthand-name"
+                      aria-hidden="true"
                     >
                       {t(`hand.${liveBestHandKey}`)}
                     </span>


### PR DESCRIPTION
## 背景

`CourchevelPage.tsx` はコミュニティカードが増えるたび `courchevel-live-besthand-name`
に現在の最善役名を出す。コード内コメント自身が

> Courchevel deals five hole cards — ten pairings to weigh by eye — so the
> preview matters more here than in plain Omaha (#4681/#4682)

と書いているのに、**この span には `role` も `aria-live` も無い。** ストリートが
進んで最善役が変わっても、スクリーンリーダー利用者には何も読まれなかった。

## 変更

1文にまとめた **sr-only の `role="status" aria-live="polite"`** を別に置き、
視覚側の2要素は `aria-hidden` にする。

**ラベルと役名を1文で読ませる。** 「現在の役:」と「フラッシュ」が別々の要素のまま
だと、読み上げでも別々に流れて対応が取れない。`livePreviewAria`
(`現在の役: {{hand}}`) を新設した。

- **バッジのスタイルは変更していない**（受け入れ条件 3）
- ショーダウンではプレビューごと消えるので、読み上げ領域も一緒に消える
  （`showdownBest5` のハイライトとは独立、受け入れ条件 4）

## テスト

- `role="status"` / `aria-live="polite"` が付いている
- **読み上げ文に役名が含まれる** — ラベルだけでは何の役か分からない
- `sr-only` である（読み上げ文が画面に二重に出ない）
- ショーダウンでは読み上げ領域も消える

**変異テスト（実測）**:

| 変異 | 落ちたテスト |
|---|---|
| `aria-live` を外す | 1 |
| 読み上げ文をラベルだけにする | 1 |
| `sr-only` を外して画面にも出す | 1 |

Closes #5486