### PR TITLE
feat(shortdeck): show equity and pot odds in the CUI

### DIFF
--- a/internal/adapter/presenter/ShortDeckCuiPresenter.go
+++ b/internal/adapter/presenter/ShortDeckCuiPresenter.go
@@ -3,6 +3,7 @@
 package presenter
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -103,6 +104,30 @@ func (p *ShortDeckCuiPresenter) Output(o interfaces.ShortDeckGame, lastErr error
 
 			if player.GetIsHuman() && !player.GetFolded() {
 				b.WriteString(i18n.Tf("shortdeck.humanHand", "cards", cuiCardListStrEmoji(player)) + "\n")
+			}
+		}
+
+		// **学習モードの値は Web にしか出ていなかった (#5487)。** GetEquity /
+		// GetPotOdds はインターフェースにあり Holdem / Omaha の CUI は既に出して
+		// いるのに、ショートデックだけ2メソッドを一度も呼んでいなかった。
+		// GetEquity は人間が降りている局面などで nil を返し、そのとき表示は消える。
+		if o.IsHumanTurn() {
+			if eq := o.GetEquity(); eq != nil {
+				potOdds := o.GetPotOdds()
+				b.WriteString("----------\n")
+				b.WriteString(color.Bold(i18n.T("shortdeck.learningHeader")) + "\n")
+				b.WriteString(i18n.Tf("shortdeck.learningLine",
+					"equity", fmt.Sprintf("%.1f", eq.Equity*100),
+					"potodds", fmt.Sprintf("%.1f", potOdds)) + "\n")
+				// **コール額が無ければ判定しない。** ポットオッズ 0 のときに
+				// 「+EV」と出すと、何もコールしていない局面で有利判定が出る。
+				if potOdds > 0 {
+					if eq.Equity*100 > potOdds {
+						b.WriteString(i18n.T("shortdeck.learningEvPlus") + "\n")
+					} else {
+						b.WriteString(i18n.T("shortdeck.learningEvMinus") + "\n")
+					}
+				}
 			}
 		}
 

--- a/internal/adapter/presenter/ShortDeckCuiPresenter_test.go
+++ b/internal/adapter/presenter/ShortDeckCuiPresenter_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func makeShortDeckForPresenter() (*domain.ShortDeck, []*domain.ShortDeckPlayer) {
@@ -699,4 +700,70 @@ func TestShortDeckCuiPresenter_HandNameOrdering(t *testing.T) {
 			assert.NotContains(t, result, "あなた: "+tt.deny)
 		})
 	}
+}
+
+// #5487: GetEquity / GetPotOdds はインターフェースにあり、Web の ShortDeckPage は
+// EquityDisplay で出しているのに、CUI は2メソッドを一度も呼んでいなかった。
+// Holdem / Omaha の CUI は既に出しているので、ショートデックだけ取り残されていた。
+func TestShortDeckCuiPresenter_LearningMode(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+	p := new(presenter.ShortDeckCuiPresenter)
+
+	// pot / call を与えると potOdds が決まる。エクイティはモンテカルロなので
+	// 値そのものは固定せず、**必要ポットオッズの側を極端に振って** +EV / -EV の
+	// どちらへ倒れるかだけを決める。
+	render := func(pot, call int) string {
+		h, players := makeShortDeckForPresenter()
+		h.SetPhase(domain.ShortDeckPhaseFlop)
+		h.SetCurrentTurn(0)
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 14, false))
+		players[0].AddCard(domain.NewCard(domain.CardDesignHeart, 14, false))
+		h.SetCommunityCards([]*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 7, false),
+			domain.NewCard(domain.CardDesignClover, 9, false),
+			domain.NewCard(domain.CardDesignDiamond, 12, false),
+		})
+		h.SetPot(pot)
+		h.SetLastBet(call)
+		return p.Output(h, nil)
+	}
+
+	t.Run("shows the equity and pot odds during a hand", func(t *testing.T) {
+		out := render(100, 20)
+		assert.Contains(t, out, i18n.T("shortdeck.learningHeader"))
+		assert.Regexp(t, `勝率: [0-9]+\.[0-9]%`, out)
+		assert.Regexp(t, `ポットオッズ: [0-9]+\.[0-9]%`, out)
+	})
+
+	// **+EV / -EV の両方を通す。** 片方しか通らないテストは、判定の向きが
+	// 逆でも気づかない。ポット1000にコール1なら必要エクイティ約0.1%、
+	// ポット1にコール1000なら約99.9% で、モンテカルロの揺れでは反転しない。
+	t.Run("calls a cheap call +EV", func(t *testing.T) {
+		assert.Contains(t, render(1000, 1), i18n.T("shortdeck.learningEvPlus"))
+	})
+
+	t.Run("calls an expensive call -EV", func(t *testing.T) {
+		assert.Contains(t, render(1, 1000), i18n.T("shortdeck.learningEvMinus"))
+	})
+
+	// **コール額が無ければ判定しない。** ポットオッズ 0 のとき「+EV」と出すと、
+	// 何もコールしていない局面で有利判定が出てしまう。
+	t.Run("gives no verdict when there is nothing to call", func(t *testing.T) {
+		out := render(100, 0)
+		assert.Contains(t, out, i18n.T("shortdeck.learningHeader"))
+		assert.NotContains(t, out, i18n.T("shortdeck.learningEvPlus"))
+		assert.NotContains(t, out, i18n.T("shortdeck.learningEvMinus"))
+	})
+
+	// 人間が降りていればエクイティは nil。行ごと出さない。
+	t.Run("says nothing once the human has folded", func(t *testing.T) {
+		h, players := makeShortDeckForPresenter()
+		h.SetPhase(domain.ShortDeckPhaseFlop)
+		h.SetCurrentTurn(0)
+		players[0].AddCard(domain.NewCard(domain.CardDesignSpade, 14, false))
+		players[0].SetFolded(true)
+		assert.NotContains(t, p.Output(h, nil), i18n.T("shortdeck.learningHeader"))
+	})
 }

--- a/internal/i18n/locales/en/shortdeck.json
+++ b/internal/i18n/locales/en/shortdeck.json
@@ -50,5 +50,9 @@
   "handRank9": "Royal Flush",
   "helpExampleRaise": "  ra 200               raise to 200 chips total",
   "helpExampleCall": "  c                    call the current bet",
-  "helpLog": "  l                    show the action log"
+  "helpLog": "  l                    show the action log",
+  "learningHeader": "[Learning mode]",
+  "learningLine": "  Equity: {{equity}}% / Pot odds: {{potodds}}%",
+  "learningEvPlus": "  +EV (equity beats pot odds; calling is favorable)",
+  "learningEvMinus": "  -EV (equity at or below pot odds; calling is unfavorable)"
 }

--- a/internal/i18n/locales/ja/shortdeck.json
+++ b/internal/i18n/locales/ja/shortdeck.json
@@ -50,5 +50,9 @@
   "handRank9": "ロイヤルフラッシュ",
   "helpExampleRaise": "  ra 200               合計 200 チップになるようレイズする",
   "helpExampleCall": "  c                    現在のベットにコールする",
-  "helpLog": "  l                    行動ログを表示"
+  "helpLog": "  l                    行動ログを表示",
+  "learningHeader": "[学習モード]",
+  "learningLine": "  勝率: {{equity}}% / ポットオッズ: {{potodds}}%",
+  "learningEvPlus": "  +EV (勝率がポットオッズを上回っています。コール有利)",
+  "learningEvMinus": "  -EV (勝率がポットオッズ以下です。コール不利)"
 }


### PR DESCRIPTION
## 背景

`internal/domain/interfaces/shortdeck.go` は `GetEquity()` と `GetPotOdds()` を
持ち、`ShortDeckEquity.go` にモンテカルロ実装もある。Web の `ShortDeckPage.tsx` は
`<EquityDisplay>` でこれを出す。**CUI は2メソッドを一度も呼んでいなかった。**

Holdem の CUI も Omaha の CUI (#5482) も既に出しているので、ショートデックだけが
取り残されていた。

## 変更

Omaha と**同じ文言・同じ判定**で1ブロック出す。`GetEquity` は人間が降りている
局面などで nil を返し、そのとき表示ごと消える。

**コール額が無ければ +EV / -EV を判定しない。** ポットオッズ 0 のときに「+EV」と
出すと、何もコールしていない局面で有利判定が出てしまう。

## テスト

- 勝率・ポットオッズの数値が出る
- **+EV と -EV の両方を通す** — 片方しか通らないテストは判定の向きが逆でも気づかない。
  ポット1000にコール1なら必要エクイティ約0.1%、ポット1にコール1000なら約99.9% で、
  モンテカルロの揺れでは反転しない
- コール額 0 のときは判定を出さない
- 人間が降りていればブロックごと出さない

**変異テスト（実測）**:

| 変異 | 落ちたテスト |
|---|---|
| EV の比較を反転 | 2 |
| `potOdds > 0` を `>= 0` にする | 1 |
| nil ガードを外す | 3 |

Closes #5487