### PR TITLE
fix(pineapple): stop counting undiscarded cards in the equity

### DIFF
--- a/internal/domain/Pineapple.go
+++ b/internal/domain/Pineapple.go
@@ -1413,16 +1413,16 @@ func (p *Pineapple) bestKeepAfterDiscard(hole []*Card) []*Card {
 	if len(hole) <= pineappleKeepAfterDiscard {
 		return hole
 	}
-	var best []*Card
-	bestRank := -1
-	for _, keep := range combinations(hole, pineappleKeepAfterDiscard) {
+	// 上の枚数チェックを通っているので組み合わせは必ず1つ以上ある。先頭を初期値に
+	// 置くことで「1つも選べなかった」場合の分岐そのものを無くす -- 到達しない
+	// フォールバックはテストできず、壊れても気づけない。
+	combos := combinations(hole, pineappleKeepAfterDiscard)
+	best, bestRank := combos[0], p.bestRankWithBoard(combos[0])
+	for _, keep := range combos[1:] {
 		if rank := p.bestRankWithBoard(keep); rank > bestRank {
 			bestRank = rank
 			best = keep
 		}
-	}
-	if best == nil {
-		return hole
 	}
 	return best
 }

--- a/internal/domain/Pineapple.go
+++ b/internal/domain/Pineapple.go
@@ -798,6 +798,15 @@ func (p *Pineapple) GetEquity() *HoldemEquityResult {
 	for i := 0; i < humanPlayer.GetCardsSize(); i++ {
 		humanCards[i] = humanPlayer.GetCard(i)
 	}
+	// **まだ捨てていない札を勝率に数えない。** ベッティング中の手札は捨てる前の
+	// 枚数 (Pineapple 系は3枚、Irish Poker は4枚) で、そのまま渡すと CalcEquity の
+	// 中の evalBestFromSeven が全部を自由に組み合わせて最善役を探す。実際には
+	// 作れない手まで数えるので勝率が水増しされる (実測で 4.6 ポイント高く出た)。
+	//
+	// 捨てるタイミングは変種で違う (Crazy Pineapple / Irish Poker はフロップの
+	// ベッティング後、通常の Pineapple はフロップ前) が、**どの変種でも「まだ
+	// 3枚以上持っている間」は同じ水増しが起きる。**枚数だけを見て絞る (#5489)。
+	humanCards = p.bestKeepAfterDiscard(humanCards)
 	activePlayers := 0
 	for _, pl := range p.players {
 		if !pl.GetIsHuman() && !pl.GetFolded() {
@@ -1387,4 +1396,33 @@ func (p *Pineapple) Resize(players []*PineapplePlayer) {
 	p.threeBetTracked = make([]bool, n)
 	p.discardDone = make([]bool, n)
 	p.initTournamentState(n)
+}
+
+// pineappleKeepAfterDiscard はディスカード後に手元へ残るホールカード枚数。
+// Crazy Pineapple は3枚のうち1枚、Irish Poker は4枚のうち2枚を捨てて、
+// どちらも2枚が残る。
+const pineappleKeepAfterDiscard = 2
+
+// bestKeepAfterDiscard は、まだ捨てていない手札から「捨てたあとに残る2枚」を
+// 選んで返す。既に2枚以下ならそのまま返す。
+//
+// 選び方は CPU の捨て方 (cpuDiscard) と GetHumanDiscardPreviews の推奨が使う
+// bestRankWithBoard そのもの。**別実装にすると、ゲームが勧める捨て方とは違う
+// 2枚の勝率を出すことになる** -- 画面上の「推奨」と数字が食い違う。
+func (p *Pineapple) bestKeepAfterDiscard(hole []*Card) []*Card {
+	if len(hole) <= pineappleKeepAfterDiscard {
+		return hole
+	}
+	var best []*Card
+	bestRank := -1
+	for _, keep := range combinations(hole, pineappleKeepAfterDiscard) {
+		if rank := p.bestRankWithBoard(keep); rank > bestRank {
+			bestRank = rank
+			best = keep
+		}
+	}
+	if best == nil {
+		return hole
+	}
+	return best
 }

--- a/internal/domain/Pineapple_test.go
+++ b/internal/domain/Pineapple_test.go
@@ -738,3 +738,138 @@ func TestPineapple_GetHumanDiscardPairPreviews(t *testing.T) {
 		assert.Nil(t, p.GetHumanDiscardPairPreviews())
 	})
 }
+
+// #5489: Crazy Pineapple はフロップのベッティングが終わってから1枚捨てるので、
+// ベッティング中の手はまだ3枚ある。GetEquity はその3枚をそのまま CalcEquity に
+// 渡していて、内部の evalBestFromSeven は3枚全部を自由に組み合わせて最善役を
+// 探す。**実際には2枚しか残せないのに3枚分の勝率が出る。**しかもその誤差が
+// 乗るのは、まさにベット判断の要であるフロップのベッティング中。
+//
+// 選ぶ側のロジックはここで決定的に検査する。勝率そのものはモンテカルロなので、
+// **2つの推定値を細かい差で比べるテストは配りでなく乱数で落ちる。**
+func TestPineapple_bestKeepAfterDiscard(t *testing.T) {
+	board := []*Card{
+		NewCard(CardDesignHeart, 2, false),
+		NewCard(CardDesignHeart, 3, false),
+		NewCard(CardDesignDiamond, 13, false),
+	}
+	withBoard := func() *Pineapple {
+		p := newTestPineapple()
+		p.communityCards = board
+		return p
+	}
+
+	t.Run("keeps the two cards that make the strongest hand", func(t *testing.T) {
+		p := withBoard()
+		hole := []*Card{
+			NewCard(CardDesignHeart, 4, false),    // ♥4: フラッシュ/ストレートドロー
+			NewCard(CardDesignHeart, 5, false),    // ♥5: 同上
+			NewCard(CardDesignDiamond, 13, false), // ♦K: ボードの K とペア
+		}
+		keep := p.bestKeepAfterDiscard(hole)
+		assert.Len(t, keep, 2, "捨てたあとに残るのは2枚")
+		// ペアが立つ組み合わせが最強なので ♦K は残る。
+		assert.Contains(t, keep, hole[2])
+	})
+
+	// **既に2枚ならそのまま。**捨て終わったあとに呼ばれても札を落とさない。
+	t.Run("leaves a two-card hand untouched", func(t *testing.T) {
+		hole := []*Card{NewCard(CardDesignSpade, 14, false), NewCard(CardDesignSpade, 13, false)}
+		assert.Equal(t, hole, withBoard().bestKeepAfterDiscard(hole))
+	})
+
+	// Irish Poker は4枚配って2枚捨てる。同じ経路で2枚に絞られる。
+	t.Run("reduces an Irish Poker hand from four to two", func(t *testing.T) {
+		hole := []*Card{
+			NewCard(CardDesignSpade, 7, false), NewCard(CardDesignClover, 8, false),
+			NewCard(CardDesignDiamond, 13, false), NewCard(CardDesignSpade, 13, false),
+		}
+		keep := withBoard().bestKeepAfterDiscard(hole)
+		assert.Len(t, keep, 2)
+		// K が2枚あればボードの K と合わせてスリーカード。両方残るのが最強。
+		assert.Contains(t, keep, hole[2])
+		assert.Contains(t, keep, hole[3])
+	})
+}
+
+// 統合側は「水増しが消えたか」だけを見る。**24.8 ポイントの誤差に対して
+// 10 ポイントの余裕**なので、モンテカルロの揺れ (σ≒1.1 ポイント) では落ちない。
+func TestPineapple_GetEquityDoesNotCountUndiscardedCards(t *testing.T) {
+	board := []*Card{
+		NewCard(CardDesignHeart, 2, false),
+		NewCard(CardDesignHeart, 3, false),
+		NewCard(CardDesignDiamond, 13, false),
+	}
+	fixture := func(hole []*Card) *Pineapple {
+		p := newTestPineapple()
+		p.discardAfterFlopBetting = true
+		p.phase = PineapplePhaseFlop
+		p.communityCards = board
+		p.players[0].Reset()
+		for _, c := range hole {
+			p.players[0].AddCard(c)
+		}
+		for i := 1; i < len(p.players); i++ {
+			p.players[i].Reset()
+			p.players[i].AddCard(NewCard(CardDesignClover, 3, false))
+			p.players[i].AddCard(NewCard(CardDesignClover, 8, false))
+		}
+		return p
+	}
+
+	three := []*Card{
+		NewCard(CardDesignHeart, 4, false),
+		NewCard(CardDesignHeart, 5, false),
+		NewCard(CardDesignDiamond, 13, false),
+	}
+	got := fixture(three).GetEquity()
+	require.NotNil(t, got)
+
+	best := 0.0
+	for k := 0; k < 3; k++ {
+		keep := make([]*Card, 0, 2)
+		for i, c := range three {
+			if i != k {
+				keep = append(keep, c)
+			}
+		}
+		e := fixture(keep).GetEquity()
+		require.NotNil(t, e)
+		if e.Equity > best {
+			best = e.Equity
+		}
+	}
+	// 修正前はこの配りで 79.1% (実際に残せる2枚の上限は 54.3%) が出ていた。
+	assert.LessOrEqual(t, got.Equity, best+0.10,
+		"3枚分の組み合わせで計算すると、実際に残せる2枚のどれよりも高い勝率が出る")
+}
+
+// 通常の Pineapple もフロップ前に捨てるだけで、プリフロップのベッティング中は
+// 3枚持っている。**起票時の受け入れ条件は「通常版には影響しない」と書いていたが、
+// 通常版にも同じ水増しがある。**枚数だけを見て絞るので両方直る。
+func TestPineapple_GetEquityWorksForThePlainVariant(t *testing.T) {
+	p := newTestPineapple() // discardAfterFlopBetting = false
+	p.phase = PineapplePhasePreFlop
+	p.players[0].Reset()
+	for _, c := range []*Card{
+		NewCard(CardDesignSpade, 14, false),
+		NewCard(CardDesignSpade, 13, false),
+		NewCard(CardDesignHeart, 14, false),
+	} {
+		p.players[0].AddCard(c)
+	}
+	for i := 1; i < len(p.players); i++ {
+		p.players[i].Reset()
+		p.players[i].AddCard(NewCard(CardDesignClover, 3, false))
+		p.players[i].AddCard(NewCard(CardDesignClover, 4, false))
+	}
+	eq := p.GetEquity()
+	require.NotNil(t, eq)
+	assert.Greater(t, eq.Equity, 0.0)
+	// プリフロップでも3枚のままでは計算しない。
+	assert.Len(t, p.bestKeepAfterDiscard([]*Card{
+		NewCard(CardDesignSpade, 14, false),
+		NewCard(CardDesignSpade, 13, false),
+		NewCard(CardDesignHeart, 14, false),
+	}), 2)
+}


### PR DESCRIPTION
## 症状

Crazy Pineapple はフロップのベッティングが**終わってから**1枚捨てる
(`discardAfterFlopBetting`)。ベッティング中の手札はまだ3枚あるのに、
`GetEquity()` はその3枚をそのまま `CalcEquity` に渡していた。

中の `evalBestFromSeven` はホールカードを**全部自由に組み合わせて**最善役を探すので、
実際には作れない手まで数える。

### 実測

`♥2 ♥3 ♦K` の場に `♥4 ♥5 ♦K` を持つ局面:

| | 勝率 |
|---|---|
| 修正前 (3枚をそのまま) | **79.1%** |
| 実際に残せる2枚の上限 (3通りの最大) | 54.3% |
| **水増し** | **24.8 ポイント** |

3枚を同時に使えば「フラッシュドロー + ストレートドロー + K のペア」を全部見られるが、
実際には2枚しか残らないのでどれか一つを諦めることになる。

しかも誤差が乗るのは、**まさにベット判断の要であるフロップのベッティング中**。

## 起票内容の訂正

受け入れ条件は「通常の Pineapple / Irish Poker の挙動に影響しない」としているが、
**通常の Pineapple にも同じ水増しがある。** 通常版は捨てるのがフロップ*前*という
だけで、プリフロップのベッティング中は3枚持っている。Irish Poker は4枚。

捨てるタイミングは変種ごとに違うが、「まだ捨てていない札を勝率に数える」という誤りは
共通なので、**変種フラグではなく枚数を見て**絞ることにした。3変種すべてが直る。

## 残す2枚の選び方

CPU の捨て方 (`cpuDiscard`) と `GetHumanDiscardPreviews` の「推奨」が使っている
`bestRankWithBoard` そのものを通す。**別実装にすると、画面上の「推奨」と勝率の数字が
食い違う** — 勧められた捨て方とは別の2枚で計算した勝率を見せることになる。

## テスト

**選ぶ側は決定的に検査する。** 勝率はモンテカルロなので、2つの推定値を細かい差で
比べるテストは配りでなく乱数で落ちる（最初にそう書いて 6 回中 3 回落ちたので作り直した）。

- `bestKeepAfterDiscard`: 3枚→最強の2枚、2枚→素通し、Irish の4枚→2枚
- 統合側は水増しが消えたことだけを、**24.8 ポイントの誤差に対し 10 ポイントの余裕**で見る
  (σ≒1.1 ポイントなので揺れでは落ちない)。6 回連続で安定を確認

**変異テスト（実測）**:

| 変異 | 落ちたテスト |
|---|---|
| 絞り込みを外す（修正前の状態） | 1（3回とも） |
| 最強でなく最弱の2枚を残す | 2 |

Closes #5489