### PR TITLE
feat(omahahilo): call out a scoop in the CUI result line

### DIFF
--- a/internal/adapter/presenter/OmahaCuiPresenter.go
+++ b/internal/adapter/presenter/OmahaCuiPresenter.go
@@ -205,10 +205,14 @@ func (p *OmahaCuiPresenter) Output(o interfaces.OmahaGame, lastErr error) string
 					total := strconv.Itoa(r.WonAmount)
 					switch {
 					case o.GetIsHiLo() && r.HiWonAmount > 0 && r.LowWonAmount > 0:
+						// **両取りは特別な結果。** Web は専用バッジで強調している
+						// のに、CUI は金額の内訳を出すだけでそうとは言っていなかった
+						// (#5485)。内訳は残す -- 置き換えると情報が減る。
 						b.WriteString(i18n.Tf("omaha.wonHiLoBoth",
 							"total", total,
 							"hi", strconv.Itoa(r.HiWonAmount),
 							"lo", strconv.Itoa(r.LowWonAmount)))
+						b.WriteString(" " + color.BoldYellow(i18n.T("omaha.scoop")))
 					case o.GetIsHiLo() && r.LowWonAmount > 0:
 						b.WriteString(i18n.Tf("omaha.wonLoOnly", "total", total))
 					case o.GetIsHiLo() && r.HiWonAmount > 0:

--- a/internal/adapter/presenter/OmahaCuiPresenter_test.go
+++ b/internal/adapter/presenter/OmahaCuiPresenter_test.go
@@ -1083,3 +1083,52 @@ func TestOmahaCuiPresenter_ResultBestLegendShownOnce(t *testing.T) {
 	// それでも各プレイヤーの行にはベストが出る。
 	assert.Equal(t, 2, strings.Count(out, i18n.T("omaha.resultBestLabel")))
 }
+
+// #5485: Hi と Lo の両取り (スクープ) は Web では専用バッジ + 人間なら
+// パルスアニメーションで強調されるのに、CUI は wonHiLoBoth で金額の内訳を
+// 出すだけで、それが特別な結果だとは一言も言っていなかった。
+func TestOmahaCuiPresenter_Scoop(t *testing.T) {
+	p := new(presenter.OmahaCuiPresenter)
+
+	render := func(results []domain.HoldemResult) string {
+		h := makeOmahaHiLoForPresenter()
+		h.SetPhase(domain.OmahaPhaseEnd)
+		h.SetRoundResults(results)
+		return p.Output(h, nil)
+	}
+
+	t.Run("calls out a scoop when one player takes both halves", func(t *testing.T) {
+		out := render([]domain.HoldemResult{
+			{PlayerIdx: 0, HandRank: domain.PokerHandFlush, HandName: "Flush",
+				WonAmount: 100, HiWonAmount: 60, LowWonAmount: 40},
+		})
+		assert.Contains(t, out, i18n.T("omaha.scoop"))
+		// 内訳は今までどおり残る。スクープ表示で置き換えては情報が減る。
+		assert.Contains(t, out, i18n.Tf("omaha.wonHiLoBoth", "total", "100", "hi", "60", "lo", "40"))
+	})
+
+	// **片取りでは出さない。** Hi だけ・Lo だけの勝ちをスクープと呼ぶと、
+	// 一番強い結果の意味が薄れる。
+	t.Run("stays quiet when only the high half is won", func(t *testing.T) {
+		assert.NotContains(t, render([]domain.HoldemResult{
+			{PlayerIdx: 0, HandRank: domain.PokerHandFlush, HandName: "Flush",
+				WonAmount: 60, HiWonAmount: 60},
+		}), i18n.T("omaha.scoop"))
+	})
+
+	t.Run("stays quiet when only the low half is won", func(t *testing.T) {
+		assert.NotContains(t, render([]domain.HoldemResult{
+			{PlayerIdx: 0, HandRank: domain.PokerHandHighCard, HandName: "High Card",
+				WonAmount: 40, LowWonAmount: 40},
+		}), i18n.T("omaha.scoop"))
+	})
+
+	// ロー不成立でハイが総取りしたときは「スクープ」ではない。LowWonAmount が
+	// 0 なので上の判定で弾かれる -- 金額が全額でも両取りとは呼ばない。
+	t.Run("stays quiet when the low never qualified", func(t *testing.T) {
+		assert.NotContains(t, render([]domain.HoldemResult{
+			{PlayerIdx: 0, HandRank: domain.PokerHandFlush, HandName: "Flush",
+				WonAmount: 100, HiWonAmount: 100},
+		}), i18n.T("omaha.scoop"))
+	})
+}

--- a/internal/i18n/locales/en/omaha.json
+++ b/internal/i18n/locales/en/omaha.json
@@ -56,5 +56,6 @@
   "learningEvMinus": "  -EV (equity at or below pot odds; calling is unfavorable)",
   "resultBest": " / Best: {{cards}}",
   "resultBestLabel": "Best:",
-  "resultBestLegend": "  (* = card used from the hole)"
+  "resultBestLegend": "  (* = card used from the hole)",
+  "scoop": "🏆 Scoop! took both the high and the low"
 }

--- a/internal/i18n/locales/ja/omaha.json
+++ b/internal/i18n/locales/ja/omaha.json
@@ -56,5 +56,6 @@
   "learningEvMinus": "  -EV (勝率がポットオッズ以下です。コール不利)",
   "resultBest": " / ベスト: {{cards}}",
   "resultBestLabel": "ベスト:",
-  "resultBestLegend": "  (* = 自分の手札から使った札)"
+  "resultBestLegend": "  (* = 自分の手札から使った札)",
+  "scoop": "🏆 スクープ! ハイ・ロー総取り"
 }


### PR DESCRIPTION
## 背景

Hi と Lo の両方を同じプレイヤーが取る「スクープ」は、Web (`BigOHiLoPage.tsx`) では
`bigohilo-scoop-badge` で表示され、人間が取ったときはパルスアニメーションでさらに
強調される。`bigohilo.json` にも `scoop` 名前空間の文言がある。

CUI は `wonHiLoBoth` で金額の内訳 (Hi分 / Lo分) を出すだけで、**それが特別な結果で
あることには一言も触れていない。** `internal/i18n/locales/*/omaha.json` に scoop 系の
文言も無かった。

## 変更

内訳は**残したまま**、後ろにスクープ表示を足す。置き換えると情報が減る。

**片取りでは出さない。** Hi だけ・Lo だけの勝ちをスクープと呼ぶと、一番強い結果の
意味が薄れる。ロー不成立でハイが全額を取った場合も `LowWonAmount` が 0 なので出ない
— **金額が全額でも両取りとは呼ばない。**

## テスト

- 両取りでスクープ表示が出て、内訳も残る
- Hi だけ / Lo だけでは出ない
- **ロー不成立でハイが全額** (WonAmount 100 / HiWonAmount 100 / LowWonAmount 0) でも出ない

**変異テスト（実測）**:

| 変異 | 落ちたテスト |
|---|---|
| 判定を `&&` → `\|\|` にして片取りでも出す | 3 |
| 内訳をスクープ表示で置き換える | 1 |

ja / en 両方に `scoop` を追加。

Closes #5485