### PR TITLE
feat(blackjack): accept side bets and multi-hand in the CLI bet command

### DIFF
--- a/frontend/src/utils/cli/commands/blackjackCommands.test.ts
+++ b/frontend/src/utils/cli/commands/blackjackCommands.test.ts
@@ -125,6 +125,13 @@ describe('parseBlackjackCommand bet with side bets and multiple hands', () => {
     }
   });
 
+  // レビュー指摘。5つ目のトークンを黙って捨てると、打ち間違いに気づかないまま
+  // 意図と違うベットが成立する。
+  it('refuses a fifth token instead of ignoring it', () => {
+    expect('error' in parseBlackjackCommand('b 100 20 30 2 oops')).toBe(true);
+    expect('error' in parseBlackjackCommand('b 100 20 30 2 5')).toBe(true);
+  });
+
   it('documents the extended form in the help text', () => {
     expect(BLACKJACK_HELP.some((l) => /ppBet|handCount/.test(l))).toBe(true);
   });

--- a/frontend/src/utils/cli/commands/blackjackCommands.test.ts
+++ b/frontend/src/utils/cli/commands/blackjackCommands.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseBlackjackCommand } from './blackjackCommands';
+import { BLACKJACK_HELP, parseBlackjackCommand } from './blackjackCommands';
 
 describe('parseBlackjackCommand', () => {
   it('parses hit', () => {
@@ -83,5 +83,49 @@ describe('parseBlackjackCommand', () => {
   it('is case insensitive', () => {
     expect(parseBlackjackCommand('HIT')).toEqual({ args: ['hit'] });
     expect(parseBlackjackCommand('B 100')).toEqual({ args: ['bet', 100] });
+  });
+});
+
+// #5474: サーバ (BlackJackCuiController) は `amount ppBet t3Bet handCount` の
+// 4引数を受けるのに、CLI モードのパーサーは金額1つしか読まなかった。同じページの
+// ベットフォームと独立 CUI では使えるサイドベットと複数ハンドが、CLI だけ使えない。
+describe('parseBlackjackCommand bet with side bets and multiple hands', () => {
+  it('passes the side bets and the hand count through', () => {
+    expect(parseBlackjackCommand('b 100 20 30 2')).toEqual({
+      args: ['bet', 100, undefined, { perfectPairsBet: 20, twentyOnePlus3Bet: 30, handCount: 2 }],
+    });
+  });
+
+  // **省略した引数は送らない。** 0 を送ると「0 を賭ける」と「賭けない」が
+  // サーバ側で区別できなくなる。
+  it('sends no options at all when only the amount is given', () => {
+    expect(parseBlackjackCommand('b 100')).toEqual({ args: ['bet', 100] });
+  });
+
+  it('fills in only the side bets that were given', () => {
+    expect(parseBlackjackCommand('b 100 20')).toEqual({
+      args: ['bet', 100, undefined, { perfectPairsBet: 20 }],
+    });
+    expect(parseBlackjackCommand('b 100 20 30')).toEqual({
+      args: ['bet', 100, undefined, { perfectPairsBet: 20, twentyOnePlus3Bet: 30 }],
+    });
+  });
+
+  // 数字でない引数を黙って捨てない。捨てると `b 100 xx 30` が
+  // 「21+3 に 30」でなく別の意味で通ってしまう。
+  it('refuses a non-numeric extra argument instead of dropping it', () => {
+    for (const bad of ['b 100 xx', 'b 100 20 yy', 'b 100 20 30 zz']) {
+      expect('error' in parseBlackjackCommand(bad)).toBe(true);
+    }
+  });
+
+  it('refuses a negative side bet or hand count', () => {
+    for (const bad of ['b 100 -1', 'b 100 20 -5', 'b 100 20 30 0']) {
+      expect('error' in parseBlackjackCommand(bad)).toBe(true);
+    }
+  });
+
+  it('documents the extended form in the help text', () => {
+    expect(BLACKJACK_HELP.some((l) => /ppBet|handCount/.test(l))).toBe(true);
   });
 });

--- a/frontend/src/utils/cli/commands/blackjackCommands.ts
+++ b/frontend/src/utils/cli/commands/blackjackCommands.ts
@@ -103,6 +103,9 @@ export function parseBlackjackCommand(input: string): CliParseResult<BjArgs> {
       // サーバ (BlackJackCuiController) は amount / ppBet / t3Bet / handCount の
       // 4引数を受ける。金額しか読まないと、同じページのベットフォームと独立 CUI で
       // 使えるサイドベットと複数ハンドが CLI だけ使えない (#5474)。
+      // **余った引数を黙って捨てない。** `b 100 20 30 2 oops` が通ると、
+      // 打ち間違いに気づかないまま意図と違うベットが成立する。
+      if (args.length > 4) return { error: BET_USAGE };
       const options: BlackJackBetOptions = {};
       const extras: [keyof BlackJackBetOptions, number][] = [
         ['perfectPairsBet', 0],

--- a/frontend/src/utils/cli/commands/blackjackCommands.ts
+++ b/frontend/src/utils/cli/commands/blackjackCommands.ts
@@ -1,8 +1,12 @@
 import type { blackjackApi } from '../../../api/gameApi';
+import type { BlackJackBetOptions } from '../../../api/games/blackjack';
 import { parseIntArg, splitCommand, suggestCommand } from '../commandParserBase';
 import type { CliParseResult } from '../types';
 
 type BjArgs = Parameters<typeof blackjackApi.exec>;
+
+/** Usage line for the bet command, shared by every rejection path. */
+const BET_USAGE = 'Usage: b <amount> [ppBet] [t3Bet] [handCount]';
 
 const VALID_COMMANDS = [
   'h',
@@ -95,8 +99,30 @@ export function parseBlackjackCommand(input: string): CliParseResult<BjArgs> {
     case 'b':
     case 'bet': {
       const parsed = parseIntArg(args, 0);
-      if ('error' in parsed) return { error: 'Usage: b <amount>' };
-      return { args: ['bet', parsed.value] };
+      if ('error' in parsed) return { error: BET_USAGE };
+      // サーバ (BlackJackCuiController) は amount / ppBet / t3Bet / handCount の
+      // 4引数を受ける。金額しか読まないと、同じページのベットフォームと独立 CUI で
+      // 使えるサイドベットと複数ハンドが CLI だけ使えない (#5474)。
+      const options: BlackJackBetOptions = {};
+      const extras: [keyof BlackJackBetOptions, number][] = [
+        ['perfectPairsBet', 0],
+        ['twentyOnePlus3Bet', 0],
+        ['handCount', 1],
+      ];
+      for (let i = 0; i < extras.length; i++) {
+        const [key, min] = extras[i] as [keyof BlackJackBetOptions, number];
+        if (args.length <= i + 1) break;
+        const extra = parseIntArg(args, i + 1);
+        // **数字でない引数を黙って捨てない。** 捨てると `b 100 xx 30` が
+        // 「21+3 に 30」ではない別の意味で通ってしまう。
+        if ('error' in extra) return { error: BET_USAGE };
+        if (extra.value < min) return { error: BET_USAGE };
+        options[key] = extra.value;
+      }
+      // **省略した引数は送らない。** 0 を送ると「0 を賭ける」と「賭けない」が
+      // サーバ側で区別できない。
+      if (Object.keys(options).length === 0) return { args: ['bet', parsed.value] };
+      return { args: ['bet', parsed.value, undefined, options] };
     }
     case 'sd':
     case 'setdeckcount': {
@@ -145,7 +171,7 @@ export const BLACKJACK_HELP: string[] = [
   'i/insurance - Take insurance',
   'di          - Decline insurance',
   'sur/surrender- Surrender',
-  'b <amount>  - Place bet',
+  'b <amount> [ppBet] [t3Bet] [handCount] - Place bet (side bets / multi-hand)',
   'hint        - Toggle strategy hint',
   'sd <n>      - Set deck count',
   'scc <0-3>   - Set CPU count',


### PR DESCRIPTION
## 背景

`BlackJackCuiController.Exec` の `b`/`bet` は `amount ppBet t3Bet handCount` の
4引数を解釈して `Bet(amount, ppBet, t3Bet, handCount)` を呼ぶ。**サーバは
Perfect Pairs / 21+3 のサイドベットと複数ハンド同時プレイに対応済み**で、
同じページのベットフォームもそれを使う。

CLI モードのパーサー `parseBlackjackCommand` だけが `parseIntArg(args, 0)` で
金額1つしか読まず、`{ args: ['bet', parsed.value] }` としか呼べなかった。

## 変更

`b <amount> [ppBet] [t3Bet] [handCount]` を解釈して
`exec('bet', amount, undefined, { perfectPairsBet, twentyOnePlus3Bet, handCount })`
を呼ぶ。`useCliGame` は `execRef.current(...parsed.args)` と展開するので、
4番目の引数はそのまま API に届く。

**省略した引数は送らない。** 0 を送ると「0 を賭ける」と「賭けない」がサーバ側で
区別できない。引数が金額だけなら options オブジェクトごと付けない（従来と完全に同じ呼び出し）。

**数字でない引数を黙って捨てない。** 捨てると `b 100 xx 30` が「21+3 に 30」では
ない別の意味で通ってしまう。下限（サイドベットは 0 以上、ハンド数は 1 以上）も弾く。

## テスト

- `b 100 20 30 2` が3項目すべてを渡す
- `b 100` は options を付けない（従来どおり）
- `b 100 20` / `b 100 20 30` は与えられた分だけ埋める
- `b 100 xx` `b 100 20 yy` `b 100 20 30 zz` を拒否
- `b 100 -1` `b 100 20 -5` `b 100 20 30 0` を拒否
- ヘルプに拡張構文が載っている

**変異テスト（実測）**:

| 変異 | 落ちたテスト |
|---|---|
| 不正な追加引数を捨てて続行 | 1 |
| 常に options を付ける | 3 |
| 下限チェックを外す | 1 |

Closes #5474