### PR TITLE
feat(irishpoker): announce the discard preview to screen readers

### DIFF
--- a/frontend/src/i18n/locales/en/irishpoker.json
+++ b/frontend/src/i18n/locales/en/irishpoker.json
@@ -25,7 +25,9 @@
     "previewHand": "Tentative hand",
     "candidateHand": "If also discarded",
     "limitReached": "You can select up to {{count}} card(s). Deselect one first.",
-    "limitDescription": "You can select at most {{count}} card(s) to discard."
+    "limitDescription": "You can select at most {{count}} card(s) to discard.",
+    "previewAria": "Keeping: {{cards}}",
+    "previewAriaWithHand": "Keeping: {{cards}}. Hand: {{hand}}"
   },
   "rebuy": {
     "prompt": "Rebuy? ({{chips}} chips, {{used}}/{{max}} used)",

--- a/frontend/src/i18n/locales/en/pineapple.json
+++ b/frontend/src/i18n/locales/en/pineapple.json
@@ -25,7 +25,9 @@
     "featurePair": "Pair",
     "featureSuited": "Suited",
     "featureConnector": "Connector",
-    "featureHighcard": "High card"
+    "featureHighcard": "High card",
+    "previewAria": "Keeping: {{cards}}",
+    "previewAriaWithHand": "Keeping: {{cards}}. Hand: {{hand}}"
   },
   "rebuy": {
     "prompt": "Rebuy? ({{chips}} chips, {{used}}/{{max}} used)",

--- a/frontend/src/i18n/locales/ja/irishpoker.json
+++ b/frontend/src/i18n/locales/ja/irishpoker.json
@@ -25,7 +25,9 @@
     "previewHand": "暫定役",
     "candidateHand": "この札も捨てると",
     "limitReached": "選択できるのは{{count}}枚までです。先に選択を解除してください",
-    "limitDescription": "ディスカードで選択できるのは最大{{count}}枚です"
+    "limitDescription": "ディスカードで選択できるのは最大{{count}}枚です",
+    "previewAria": "残す2枚: {{cards}}",
+    "previewAriaWithHand": "残す2枚: {{cards}}。成立する役: {{hand}}"
   },
   "rebuy": {
     "prompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済)",

--- a/frontend/src/i18n/locales/ja/pineapple.json
+++ b/frontend/src/i18n/locales/ja/pineapple.json
@@ -25,7 +25,9 @@
     "featurePair": "ペア",
     "featureSuited": "スーテッド",
     "featureConnector": "コネクター",
-    "featureHighcard": "ハイカード"
+    "featureHighcard": "ハイカード",
+    "previewAria": "残す2枚: {{cards}}",
+    "previewAriaWithHand": "残す2枚: {{cards}}。成立する役: {{hand}}"
   },
   "rebuy": {
     "prompt": "リバイしますか? ({{chips}}チップ, {{used}}/{{max}}回使用済)",

--- a/frontend/src/pages/PineapplePage.test.tsx
+++ b/frontend/src/pages/PineapplePage.test.tsx
@@ -434,6 +434,85 @@ describe('PineapplePage', () => {
     expect(preview).toHaveTextContent('ワンペア');
   });
 
+  // #5490: 残す2枚と役はディスカード確定前の重要なフィードバックなのに、
+  // 同じフッター内の上限超過通知 (pn-discard-limit-announce) が aria-live を
+  // 持つのに対し、こちらは無音だった。
+  it('announces the kept cards and the hand to a screen reader', async () => {
+    const irishDiscardState: PineappleResponse = {
+      ...discardState,
+      initialDealCount: 4,
+      players: [
+        {
+          ...discardState.players[0],
+          cards: [
+            { design: 'SPADE', value: 1 },
+            { design: 'HEART', value: 1 },
+            { design: 'DIAMOND', value: 5 },
+            { design: 'CLOVER', value: 8 },
+          ],
+        },
+        cpuPlayer(1),
+        cpuPlayer(2),
+        cpuPlayer(3),
+      ],
+      communityCards: [
+        { design: 'SPADE', value: 10 },
+        { design: 'HEART', value: 5 },
+        { design: 'DIAMOND', value: 8 },
+      ],
+      discardDone: [false, true, true, true],
+    };
+    mockIrishExec.mockResolvedValue(irishDiscardState);
+    renderWithProviders(<PineapplePage variant="irishpoker" />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByAltText('♦ 5').closest('button') as HTMLButtonElement);
+    fireEvent.click(screen.getByAltText('♣ 8').closest('button') as HTMLButtonElement);
+
+    const live = await screen.findByTestId('irishpoker-discard-preview-announce');
+    expect(live).toHaveAttribute('role', 'status');
+    expect(live).toHaveAttribute('aria-live', 'polite');
+    expect(live).toHaveClass('sr-only');
+    // **残す2枚と役の両方を読ませる。** どちらが欠けても選択を確認できない。
+    expect(live.textContent).toContain('♠ A');
+    expect(live.textContent).toContain('♥ A');
+    expect(live.textContent).toContain('ワンペア');
+  });
+
+  // 1枚しか選んでいない間は出さない。確定した選択だけを読み上げる。
+  it('stays silent until the second discard is chosen', async () => {
+    const irishDiscardState: PineappleResponse = {
+      ...discardState,
+      initialDealCount: 4,
+      players: [
+        {
+          ...discardState.players[0],
+          cards: [
+            { design: 'SPADE', value: 1 },
+            { design: 'HEART', value: 1 },
+            { design: 'DIAMOND', value: 5 },
+            { design: 'CLOVER', value: 8 },
+          ],
+        },
+        cpuPlayer(1),
+        cpuPlayer(2),
+        cpuPlayer(3),
+      ],
+      communityCards: [
+        { design: 'SPADE', value: 10 },
+        { design: 'HEART', value: 5 },
+        { design: 'DIAMOND', value: 8 },
+      ],
+      discardDone: [false, true, true, true],
+    };
+    mockIrishExec.mockResolvedValue(irishDiscardState);
+    renderWithProviders(<PineapplePage variant="irishpoker" />);
+    await waitFor(() => expect(screen.getByTestId('discard-controls')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByAltText('♦ 5').closest('button') as HTMLButtonElement);
+    expect(screen.queryByTestId('irishpoker-discard-preview-announce')).not.toBeInTheDocument();
+  });
+
   it('annotates each remaining Irish Poker card once the first discard is chosen', async () => {
     const irishDiscardState: PineappleResponse = {
       ...discardState,

--- a/frontend/src/pages/PineapplePage.tsx
+++ b/frontend/src/pages/PineapplePage.tsx
@@ -696,6 +696,26 @@ function PineapplePageContent({ variant }: { variant: PineappleVariant }) {
               <div className="mb-2 text-center" data-testid="discard-controls" data-tutorial="pn-discard-controls">
                 {discardPreview && (
                   <div className="mb-2 text-sm" data-testid="irishpoker-discard-preview">
+                    {/* **見えている行は読み上げ向きではない。** ラベル・札・役が
+                        別々の要素に割れていて、順に読まれても対応が取れない。1文に
+                        まとめた sr-only の live region を別に置く。上限超過通知
+                        (pn-discard-limit-announce) だけが aria-live を持っていて、
+                        こちらは無音だった (#5490)。視覚表示は変えていない。 */}
+                    <div
+                      className="sr-only"
+                      role="status"
+                      aria-live="polite"
+                      data-testid="irishpoker-discard-preview-announce"
+                    >
+                      {discardPreview.handKey
+                        ? t('discard.previewAriaWithHand', {
+                            cards: discardPreview.kept.map((c) => cardAlt(c)).join(', '),
+                            hand: t(`hand.${discardPreview.handKey}`),
+                          })
+                        : t('discard.previewAria', {
+                            cards: discardPreview.kept.map((c) => cardAlt(c)).join(', '),
+                          })}
+                    </div>
                     <span className="text-ds-text-muted">{`${t('discard.keepLabel')}: `}</span>
                     <span className="text-ds-text-primary font-semibold">
                       {discardPreview.kept.map((c) => cardAlt(c)).join('  ')}


### PR DESCRIPTION
## 背景

Irish Poker は4枚のホールカードから2枚を捨てる。2枚選び終えると
`irishpoker-discard-preview` が「残す2枚」と、可能ならその2枚で成立する役を出す。
**ディスカード確定前に自分の選択を確認できる唯一のフィードバック**なのに、
`role`/`aria-live` が付いていない。

同じフッター内の上限超過通知 `pn-discard-limit-announce` は `aria-live="polite"` を
持っているので、この画面の中でここだけが無音だった。

## 変更

1文にまとめた **sr-only の `role="status" aria-live="polite"`** を別に置く。

**見えている行は読み上げ向きではない。** 「残り2枚:」「♠ A ♥ A」「役: ワンペア」が
別々の要素に割れていて、順に読まれても対応が取れない。役が判定できない盤面
(コミュニティが3枚未満) では役抜きの文言に切り替える。

- **視覚表示は変更していない**（受け入れ条件 3 の趣旨）
- Crazy Pineapple の `candidatePreviews` (1枚捨て) は別の表示なので影響しない
- 1枚しか選んでいない間は preview 自体が出ないので、読み上げも起きない

## テスト

- `role="status"` / `aria-live="polite"` / `sr-only` が付いている
- **残す2枚と役の両方**が読み上げ文に含まれる（どちらが欠けても選択を確認できない）
- 1枚目だけ選んだ状態では読み上げ領域が存在しない

なお、テストのフィクスチャではエースを **value 1** にした。サーバが送るのがこの値で、
`valueName` も 1 を 'A' に変換する。14 のままだと `cardAlt` が「♠ 14」を返し、
**実際の画面には現れない文字列に対してテストが通ってしまう。**

**変異テスト（実測）**:

| 変異 | 落ちたテスト |
|---|---|
| `aria-live` を外す | 1 |
| 役名を落として札だけ読ませる | 1 |
| `sr-only` を外して画面にも出す | 1 |

ja/en 両ロケール、`pineapple` と `irishpoker` 両ネームスペースに追加
（ページは variant ごとに別ネームスペースを引く）。

Closes #5490