### PR TITLE
feat(memory): explain what each CPU difficulty changes

### DIFF
--- a/frontend/src/i18n/locales/en/memory.json
+++ b/frontend/src/i18n/locales/en/memory.json
@@ -18,7 +18,12 @@
       "slow": "2s"
     },
     "pairCount": "Pairs",
-    "pairCountOption": "{{pairs}} pairs ({{cards}} cards)"
+    "pairCountOption": "{{pairs}} pairs ({{cards}} cards)",
+    "difficultyOption": "{{level}} ({{memory}})",
+    "memoryEasy": "forgets often",
+    "memoryNormal": "forgets sometimes",
+    "memoryHard": "rarely forgets",
+    "difficultyTooltip": "Difficulty changes how well the CPU remembers: the chance it recalls a card it has seen, and the chance it forgets one each turn."
   },
   "scores": "Scores",
   "cardFaceDown": "Card {{position}} (face down)",

--- a/frontend/src/i18n/locales/ja/memory.json
+++ b/frontend/src/i18n/locales/ja/memory.json
@@ -18,7 +18,12 @@
       "slow": "2秒"
     },
     "pairCount": "ペア数",
-    "pairCountOption": "{{pairs}}ペア（{{cards}}枚）"
+    "pairCountOption": "{{pairs}}ペア（{{cards}}枚）",
+    "difficultyOption": "{{level}}（{{memory}}）",
+    "memoryEasy": "よく忘れる",
+    "memoryNormal": "ときどき忘れる",
+    "memoryHard": "ほとんど忘れない",
+    "difficultyTooltip": "難易度は CPU の記憶力を変えます。めくったカードを覚えている確率と、手番ごとに忘れる確率が難易度で変わります。"
   },
   "scores": "スコア",
   "cardFaceDown": "{{position}}枚目のカード（裏向き）",

--- a/frontend/src/pages/MemoryPage.test.tsx
+++ b/frontend/src/pages/MemoryPage.test.tsx
@@ -729,3 +729,27 @@ describe('MemoryPage', () => {
     expect(screen.getByTestId('mem-flip-announce')).toHaveTextContent('');
   });
 });
+
+// #5492: 難易度は Easy/Normal/Hard としか出ておらず、Hard がほぼ完璧に覚えている
+// (95%保持・1%減衰) のに対し Easy はよく忘れる (30%保持・15%減衰) という実際の差が
+// 説明されていなかった。強さの差が「CPU の記憶力」だと分からないと選びようがない。
+describe('MemoryPage difficulty descriptions', () => {
+  it('describes each difficulty in terms of how well the CPU remembers', async () => {
+    mockExec.mockResolvedValue(flip1State);
+    renderWithProviders(<MemoryPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    fireEvent.click(screen.getByText('設定'));
+
+    const select = screen.getByRole('combobox', { name: 'CPU難易度' });
+    const labels = Array.from(select.querySelectorAll('option')).map((o) => o.textContent ?? '');
+    expect(labels).toHaveLength(3);
+    // **3つとも説明が付いていること。** 1つでも素の "Easy" のままだと、
+    // 並べたときにその選択肢だけ意味が分からない。
+    for (const label of labels) {
+      expect(label).toMatch(/忘れ|覚え/);
+    }
+    // 順序どおりの言葉が付く (domain の retentionChance と同じ向き)。
+    expect(labels[0]).toContain('よく忘れる');
+    expect(labels[2]).toContain('ほとんど忘れない');
+  });
+});

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -306,10 +306,19 @@ function MemoryPageContent() {
                     id: 'cpuDifficulty',
                     label: t('settings.cpuDifficulty'),
                     value: memoryConfig.cpuDifficulty,
+                    // **強さの差は「CPU がどれだけ覚えているか」の差。** domain の
+                    // retentionChance / decayRate が難易度ごとに 30%/60%/95% 保持、
+                    // 15%/5%/1% 減衰と切り替わるのに、選択肢は Easy/Normal/Hard と
+                    // しか出ておらず、何が変わるのか分からなかった (#5492)。
+                    // 数値は出さない -- 実装が変われば嘘になる。順序だけを言う。
                     options: CPU_DIFFICULTY_OPTIONS.map((o) => ({
                       value: o.value,
-                      label: t(`settings.${o.label.toLowerCase()}`),
+                      label: t('settings.difficultyOption', {
+                        level: t(`settings.${o.label.toLowerCase()}`),
+                        memory: t(`settings.memory${o.label}`),
+                      }),
                     })),
+                    tooltip: t('settings.difficultyTooltip'),
                     onSelect: (v) => handleConfigChange('cpuDifficulty', v),
                   },
                   {

--- a/internal/domain/Memory_test.go
+++ b/internal/domain/Memory_test.go
@@ -451,3 +451,33 @@ func TestMemoryConfig_ClampPairCount(t *testing.T) {
 		assert.Equal(t, c.want, cfg.NormalizedPairCount(), "入力 %d", c.in)
 	}
 }
+
+// #5492: 難易度セレクタには Easy/Normal/Hard としか出ておらず、Hard がほぼ完璧に
+// 覚えている (95%保持・1%減衰) のに対し Easy はよく忘れる (30%保持・15%減衰) という
+// 実際の差が説明されていなかった。UI に説明を足すなら、**その説明が実装の順序と
+// 一致していることを機械で確かめる。**定数を入れ替えたら文言が嘘になる。
+func TestMemory_DifficultyOrderingMatchesTheDescription(t *testing.T) {
+	chance := func(d MemoryCpuDifficulty) (float64, float64) {
+		m := NewDefaultMemory()
+		cfg := m.GetConfig()
+		cfg.CpuDifficulty = d
+		m.SetConfig(cfg)
+		return m.retentionChance(), m.decayRate()
+	}
+
+	easyRet, easyDecay := chance(MemoryCpuDifficultyEasy)
+	normalRet, normalDecay := chance(MemoryCpuDifficultyNormal)
+	hardRet, hardDecay := chance(MemoryCpuDifficultyHard)
+
+	// 覚えている確率は Easy < Normal < Hard。
+	assert.Less(t, easyRet, normalRet)
+	assert.Less(t, normalRet, hardRet)
+	// 忘れる確率はその逆。
+	assert.Greater(t, easyDecay, normalDecay)
+	assert.Greater(t, normalDecay, hardDecay)
+
+	// 「Hard はほぼ忘れない」「Easy はよく忘れる」と書くための下限・上限。
+	assert.GreaterOrEqual(t, hardRet, 0.9, "Hard を『ほぼ覚えている』と書ける水準か")
+	assert.LessOrEqual(t, hardDecay, 0.05, "Hard を『ほとんど忘れない』と書ける水準か")
+	assert.LessOrEqual(t, easyRet, 0.5, "Easy を『よく忘れる』と書ける水準か")
+}

--- a/internal/i18n/locales/en/memory.json
+++ b/internal/i18n/locales/en/memory.json
@@ -2,7 +2,7 @@
   "helpTitle": "Memory / Concentration",
   "helpFlip": "  f <pos>              flip a card",
   "helpNext": "  n                    next turn",
-  "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)",
+  "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy forgets often, 1=Normal, 2=Hard rarely forgets)",
   "playerLine": "{{name}}: {{pairs}} pair(s)",
   "visitedLegend": "Legend: *? = seen before (flipped once) / ?? = unseen",
   "promptFlip1": "{{name}} — pick the first card",

--- a/internal/i18n/locales/ja/memory.json
+++ b/internal/i18n/locales/ja/memory.json
@@ -2,7 +2,7 @@
   "helpTitle": "Memory (神経衰弱)",
   "helpFlip": "  f <pos>              flip a card",
   "helpNext": "  n                    next turn",
-  "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)",
+  "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy よく忘れる, 1=Normal, 2=Hard ほとんど忘れない)",
   "playerLine": "{{name}}: {{pairs}}ペア",
   "visitedLegend": "凡例: *? = 既出（一度めくられた札） / ?? = 未確認",
   "promptFlip1": "手番: {{name}} — 1枚目を選んでください",


### PR DESCRIPTION
## 背景

`internal/domain/Memory.go` は CPU の「記憶」を確率でモデル化している:

| 難易度 | 覚えている確率 | 手番ごとに忘れる確率 |
|---|---|---|
| Easy | 30% | 15% |
| Normal | 60% | 5% |
| Hard | **95%** | **1%** |

プレイヤーが見るのは Easy / Normal / Hard の3択だけで、**Hard がほぼ完璧に覚えている
一方 Easy はよく忘れる、という実際の差は一切説明されない。**

## 変更

- 各選択肢に記憶の傾向を添える: 「Easy（よく忘れる）」「Hard（ほとんど忘れない）」
- 項目のツールチップで仕組みを一度だけ説明する
- CUI の `helpSetDifficulty` にも同じニュアンスを入れる

**数値は書かない。** 実装が変われば嘘になる。相対的な順序だけを言う（受け入れ条件 3）。

## 順序が実装と一致していることをテストで固定する

文言だけ足しても、あとから定数が入れ替われば黙って嘘になる。domain 側に
「retention は Easy < Normal < Hard、decay はその逆」を assert するテストを置いた。
さらに「Hard を『ほとんど忘れない』と書ける水準か」(retention ≥ 0.9, decay ≤ 0.05)、
「Easy を『よく忘れる』と書ける水準か」(retention ≤ 0.5) も固定してある。

**変異テスト（実測）**:

| 変異 | 落ちたテスト |
|---|---|
| `memoryRetentionEasy` を 0.99 にする（Easy がいちばん覚える） | 2 |
| `memoryDecayHard` を 0.5 にする（Hard がよく忘れる） | 2 |
| ページの選択肢を素の Easy/Normal/Hard に戻す | 1 |

ページ側のテストは **3つとも説明が付いていること**を見る。1つでも素のままだと、
並べたときにその選択肢だけ意味が分からない。

Closes #5492