### PR TITLE
feat(klondike): show how the Vegas score is calculated

### DIFF
--- a/frontend/src/i18n/locales/en/klondike.json
+++ b/frontend/src/i18n/locales/en/klondike.json
@@ -54,5 +54,6 @@
     "bestTime": "Best {{time}}",
     "fewestMoves": "{{moves}} moves",
     "newBest": "New personal best!"
-  }
+  },
+  "vegasFormula": "Vegas scoring: start at {{buyIn}}, then +{{perCard}} for every card sent to a foundation"
 }

--- a/frontend/src/i18n/locales/ja/klondike.json
+++ b/frontend/src/i18n/locales/ja/klondike.json
@@ -54,5 +54,6 @@
     "bestTime": "ベスト {{time}}",
     "fewestMoves": "最少 {{moves}}手",
     "newBest": "自己ベスト更新！"
-  }
+  },
+  "vegasFormula": "ベガス方式: 買い切り {{buyIn}} 点から始まり、組札に1枚送るごとに +{{perCard}} 点"
 }

--- a/frontend/src/pages/KlondikePage.test.tsx
+++ b/frontend/src/pages/KlondikePage.test.tsx
@@ -1150,3 +1150,26 @@ describe('KlondikePage', () => {
     });
   });
 });
+
+// #5493: Vegas を選んだプレイヤーは、なぜスコアがマイナスから始まるのか・1枚あたり
+// 何点かを知る手段が無かった。ヘッダーは生の数字だけで、チュートリアルにも
+// スコアリングの説明が無い。
+describe('KlondikePage Vegas formula', () => {
+  it('spells out the formula while Vegas scoring is on', async () => {
+    mockExec.mockResolvedValue({ ...playingState, scoringMode: 1 });
+    renderWithProviders(<KlondikePage />);
+    const note = await screen.findByTestId('kl-vegas-formula');
+    // 数値は KlondikeVegas から補間される。文言に直接書くと定数と乖離する。
+    expect(note.textContent).toContain('-52');
+    expect(note.textContent).toContain('5');
+  });
+
+  // **None モードでは出さない。** ベガス方式の説明が常時出ていると、
+  // スコアの付かないモードでも点が入ると読める。
+  it('says nothing when scoring is off', async () => {
+    mockExec.mockResolvedValue({ ...playingState, scoringMode: 0 });
+    renderWithProviders(<KlondikePage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryByTestId('kl-vegas-formula')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/KlondikePage.tsx
+++ b/frontend/src/pages/KlondikePage.tsx
@@ -33,7 +33,7 @@ import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { KlondikeResponse } from '../types/card';
-import { KlondikePhase, KlondikeScoringMode } from '../types/phases';
+import { KlondikePhase, KlondikeScoringMode, KlondikeVegas } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { KLONDIKE_HELP, parseKlondikeCommand } from '../utils/cli/commands/klondikeCommands';
@@ -87,6 +87,9 @@ const KL_TUTORIAL_STEPS: TutorialStep[] = [
 /** Renders the Klondike solitaire game page with tableau, stock/waste, and foundation. */
 export const KlondikePage = withTutorial(KlondikePageContent, 'klondike', KL_TUTORIAL_STEPS);
 /** Inner content of the Klondike page, wrapped by TutorialProvider. */
+/** Interpolation values for the Vegas formula text, kept next to the constants. */
+const VEGAS_FORMULA_VALUES = { buyIn: KlondikeVegas.BUY_IN, perCard: KlondikeVegas.PER_CARD };
+
 function KlondikePageContent() {
   const {
     t,
@@ -296,7 +299,7 @@ function KlondikePageContent() {
             {t('moveCount')}: {state.moveCount}
           </span>
           {isVegas && (
-            <span className="ml-3">
+            <span className="ml-3" title={t('vegasFormula', VEGAS_FORMULA_VALUES)} data-testid="kl-vegas-score">
               {t('score')}: {state.score}
             </span>
           )}
@@ -716,6 +719,15 @@ function KlondikePageContent() {
                 <option value={0}>{t('scoringNone')}</option>
                 <option value={1}>{t('scoringVegas')}</option>
               </select>
+              {/* **Vegas を選んだプレイヤーは計算式を知る手段が無かった。** ヘッダーには
+                  生の数字しか出ず、チュートリアルにもスコアリングの説明が無い (#5493)。
+                  数字は KlondikeVegas から取る -- domain 側の定数と突き合わせる Go の
+                  テストがあるので、片方だけ変えると落ちる。 */}
+              {isVegas && (
+                <div data-testid="kl-vegas-formula" className="w-full text-game-text-muted text-xs">
+                  {t('vegasFormula', VEGAS_FORMULA_VALUES)}
+                </div>
+              )}
               {/* Per-variant stats: win rate + best time / fewest moves (#3031). */}
               <div data-testid="kl-stats-panel" className="w-full text-game-text-muted text-xs">
                 {t('stats.winRate', { rate: klondikeWinRate(currentStat) })} ({currentStat.wins}/{currentStat.plays})

--- a/frontend/src/types/phases.ts
+++ b/frontend/src/types/phases.ts
@@ -182,6 +182,18 @@ export const KlondikeScoringMode = {
   VEGAS: 1,
 } as const;
 
+/**
+ * Klondike Vegas scoring constants (sync: internal/domain/Klondike.go).
+ *
+ * `GetScore` computes `BUY_IN + PER_CARD * foundationCards`. A Go test asserts
+ * these numbers against the domain constants **and** against the wording in the
+ * locale files, so the formula shown on screen cannot drift from the one played.
+ */
+export const KlondikeVegas = {
+  BUY_IN: -52,
+  PER_CARD: 5,
+} as const;
+
 /** Canfield phase constants (sync: internal/domain/Canfield.go). */
 export const CanfieldPhase = {
   PLAYING: 0,

--- a/internal/domain/Klondike.go
+++ b/internal/domain/Klondike.go
@@ -586,13 +586,23 @@ func (k *Klondike) UndoN(n int) error {
 	return undoN(k, n)
 }
 
-// GetScore スコア取得 (ベガス式: -52 + 5 * ファンデーション枚数)
+// KlondikeVegasBuyIn はベガス式の買い切り額 (負の初期スコア)。
+// KlondikeVegasPerCard は組札に1枚送るごとの得点。
+//
+// **UI の説明文と同じ数字であることをテストで固定している** -- 片方だけ変えると
+// 画面に嘘の計算式が出る (#5493)。
+const (
+	KlondikeVegasBuyIn   = -52
+	KlondikeVegasPerCard = 5
+)
+
+// GetScore スコア取得 (ベガス式: 買い切り + 1枚あたり得点 * ファンデーション枚数)
 func (k *Klondike) GetScore() int {
 	total := 0
 	for i := 0; i < KlondikeFoundationCnt; i++ {
 		total += len(k.foundation[i])
 	}
-	return -52 + 5*total
+	return KlondikeVegasBuyIn + KlondikeVegasPerCard*total
 }
 
 // GetScoringMode スコアリングモード取得

--- a/internal/infrastructure/games/klondike_vegas_formula_test.go
+++ b/internal/infrastructure/games/klondike_vegas_formula_test.go
@@ -1,0 +1,78 @@
+package games_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+)
+
+// TestKlondikeVegasFormulaMatchesTheLocales guards the on-screen explanation of
+// the Vegas score against the domain constants that actually compute it.
+//
+// `GetScore` returns `KlondikeVegasBuyIn + KlondikeVegasPerCard * cards`, and
+// the Klondike page prints that formula so a player choosing "Vegas" can tell
+// why the score starts negative (#5493). **The text and the arithmetic live in
+// different languages in different directories**, so nothing stops one from
+// being edited alone -- and a scoring rule that disagrees with the number on
+// screen is worse than no explanation at all.
+//
+// The page interpolates the numbers from `KlondikeVegas` in
+// `frontend/src/types/phases.ts`, so this checks that file too: the locale
+// strings only carry the placeholders.
+func TestKlondikeVegasFormulaMatchesTheLocales(t *testing.T) {
+	root := filepath.Join("..", "..", "..")
+
+	t.Run("the TypeScript constants match the domain", func(t *testing.T) {
+		src, err := os.ReadFile(filepath.Join(root, "frontend", "src", "types", "phases.ts"))
+		if err != nil {
+			t.Fatalf("read phases.ts: %v", err)
+		}
+		text := string(src)
+		for _, want := range []struct {
+			field string
+			value int
+		}{
+			{"BUY_IN", domain.KlondikeVegasBuyIn},
+			{"PER_CARD", domain.KlondikeVegasPerCard},
+		} {
+			line := want.field + ": " + strconv.Itoa(want.value) + ","
+			if !strings.Contains(text, line) {
+				t.Errorf("frontend/src/types/phases.ts should carry `%s` (KlondikeVegas.%s must equal the domain constant)",
+					line, want.field)
+			}
+		}
+	})
+
+	// 文言側は数値を書かず、プレースホルダだけを持つこと。数値を直接書くと、
+	// 定数を直しても文言が古いまま残る。
+	t.Run("the locale strings interpolate rather than hardcode", func(t *testing.T) {
+		for _, loc := range []string{"ja", "en"} {
+			path := filepath.Join(root, "frontend", "src", "i18n", "locales", loc, "klondike.json")
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			var d map[string]any
+			if err := json.Unmarshal(raw, &d); err != nil {
+				t.Fatalf("parse %s: %v", path, err)
+			}
+			text, ok := d["vegasFormula"].(string)
+			if !ok {
+				t.Fatalf("%s has no vegasFormula string", path)
+			}
+			for _, ph := range []string{"{{buyIn}}", "{{perCard}}"} {
+				if !strings.Contains(text, ph) {
+					t.Errorf("%s vegasFormula must interpolate %s, got %q", loc, ph, text)
+				}
+			}
+			if strings.Contains(text, strconv.Itoa(-domain.KlondikeVegasBuyIn)) {
+				t.Errorf("%s vegasFormula hardcodes the buy-in; interpolate it instead: %q", loc, text)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## 背景

`GetScore` は固定式:

```go
return -52 + 5*total   // 買い切り -52 点、組札1枚あたり +5 点
```

`KlondikePage.tsx` はヘッダーに `{t('score')}: {state.score}` と**生の数字だけ**を出し、
クリア画面も合計を出すのみ。`KL_TUTORIAL_STEPS` にもスコアリングの説明が無く、
**「Vegas」を選んだプレイヤーはなぜマイナスから始まるのかを知る手段が全く無かった。**

## 変更

- 数値を `KlondikeVegasBuyIn` / `KlondikeVegasPerCard` に切り出す
- スコアリングモードのセレクタの下（＝Vegas を選ぶその場所）に計算式を出す
- ヘッダーのスコアにも `title` を付ける
- **None モードでは出さない** — 常時出ていると、点の付かないモードでも入ると読める

## 数値の二重管理を防ぐ

式は Go、文言は JSON、補間値は TS と**3か所に散る**。片方だけ編集するのを止める
ものが何も無く、実際の計算と食い違う説明は説明が無いより悪い。

- 文言には数値を書かず `{{buyIn}}` / `{{perCard}}` のプレースホルダだけを置く
- ページは `KlondikeVegas` (TS 定数) から補間する
- **Go のテストが `phases.ts` と両ロケールを読んで domain 定数と突き合わせる**

**変異テスト（実測）**:

| 変異 | 検知 |
|---|---|
| domain の buy-in だけ -60 に変える | ✔ `phases.ts` が古いと報告 |
| ロケール文言に数値を直書きする | ✔ 3件（プレースホルダ欠落 + 直書き）|
| ページの `isVegas` ガードを外す | ✔ None モードのテストが落ちる |

Closes #5493