### PR TITLE
fix(freecell): stop using zone identifiers as i18n keys

### DIFF
--- a/frontend/src/i18n/locales/en/freecell.json
+++ b/frontend/src/i18n/locales/en/freecell.json
@@ -33,6 +33,11 @@
     "moveToFoundation": "A card can be moved to the foundation",
     "freeCellsFilling": "Free cells are almost full — try to clear some",
     "useEmptyColumn": "An empty column is available — use it for reorganization",
-    "useFreeCells": "Consider moving a card to a free cell to open up moves"
+    "useFreeCells": "Consider moving a card to a free cell to open up moves",
+    "zone": {
+      "tableau": "Tableau",
+      "freecell": "Free Cell",
+      "foundation": "Foundation"
+    }
   }
 }

--- a/frontend/src/i18n/locales/ja/freecell.json
+++ b/frontend/src/i18n/locales/ja/freecell.json
@@ -33,6 +33,11 @@
     "moveToFoundation": "組札に移動できるカードがあります",
     "freeCellsFilling": "フリーセルがほぼ満杯です — 空けることを検討しましょう",
     "useEmptyColumn": "空の列があります — 整理に活用しましょう",
-    "useFreeCells": "フリーセルにカードを移動して手を広げましょう"
+    "useFreeCells": "フリーセルにカードを移動して手を広げましょう",
+    "zone": {
+      "tableau": "タブロー",
+      "freecell": "フリーセル",
+      "foundation": "ファンデーション"
+    }
   }
 }

--- a/frontend/src/pages/FreeCellPage.test.tsx
+++ b/frontend/src/pages/FreeCellPage.test.tsx
@@ -459,6 +459,38 @@ describe('FreeCellPage', () => {
     await waitFor(() => expect(screen.getByText(/フリーセル.*→.*タブロー 3/)).toBeInTheDocument());
   });
 
+  // #5494: ゾーン識別子 ("tableau"/"freecell"/"foundation") をそのまま i18n キーに
+  // 使っていた。ドメイン側がゾーン名を変えたり足したりすると翻訳キーが静かに壊れ、
+  // コンパイルでは検出できない。専用キーへ移す前に**今の文字列を1文字単位で固定**する。
+  it('renders the hint line exactly as before the zone keys moved', async () => {
+    renderWithProviders(<FreeCellPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+
+    mockExec.mockResolvedValue(withHintFromColState);
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    const line = await screen.findByTestId('fc-hint-line');
+    expect(line.textContent).toBe('ヒント: タブロー 2 → ファンデーション');
+  });
+
+  // **未知のゾーンでも翻訳キー文字列を画面に出さない。** ドメインが新しいゾーンを
+  // 返し始めたとき、生の "reserve" が出るほうが "frontendHint.zone.reserve" が
+  // 出るよりまだ読める。
+  it('falls back to the raw zone name for an unknown zone', async () => {
+    renderWithProviders(<FreeCellPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+
+    mockExec.mockResolvedValue({
+      ...playingState,
+      hint: { fromZone: 'reserve', fromCol: 1, cardIndex: 0, toZone: 'foundation', toCol: -1 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    const line = await screen.findByTestId('fc-hint-line');
+    expect(line.textContent).toBe('ヒント: reserve 1 → ファンデーション');
+    expect(line.textContent).not.toContain('frontendHint');
+  });
+
   it('hint display shows fromCol when fromCol is non-negative', async () => {
     renderWithProviders(<FreeCellPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());

--- a/frontend/src/pages/FreeCellPage.tsx
+++ b/frontend/src/pages/FreeCellPage.tsx
@@ -79,6 +79,24 @@ const FC_TUTORIAL_STEPS: TutorialStep[] = [
 /** Renders the FreeCell solitaire game page with tableau, free cells, and foundation. */
 export const FreeCellPage = withTutorial(FreeCellPageContent, 'freecell', FC_TUTORIAL_STEPS);
 /** Inner content of the FreeCell page, wrapped by TutorialProvider. */
+/**
+ * Render one side of a hint as "<zone> <col>", or just the zone when the hint
+ * carries no column.
+ *
+ * **ゾーン識別子を i18n キーに使わない。** ドメインが返す "tableau" などをそのまま
+ * `t()` に渡していたので、ゾーン名を変えたり足したりすると翻訳キーが静かに壊れ、
+ * コンパイルでも型でも検出できなかった (#5494)。姉妹の Solitaire 系ページ
+ * (FlowerGarden ほか) と同じ frontendHint.* 名前空間に寄せる。
+ *
+ * 未知のゾーンはキーではなく識別子そのものを返す -- 生の "tableau" が出るほうが、
+ * 翻訳キー文字列が画面に出るより読める。
+ */
+function formatHintZone(t: (key: string, opts?: Record<string, unknown>) => string, zone: string, col: number): string {
+  const label =
+    zone === 'tableau' || zone === 'freecell' || zone === 'foundation' ? t(`frontendHint.zone.${zone}`) : zone;
+  return col >= 0 ? `${label} ${col}` : label;
+}
+
 function FreeCellPageContent() {
   const {
     t,
@@ -488,12 +506,9 @@ function FreeCellPageContent() {
 
             {/* Hint display */}
             {hint && (
-              <div className="text-ds-warning text-sm mb-2">
-                {/* Zone identifiers (tableau/freecell/foundation) double as i18n
-                    keys, so they localize instead of showing raw English. */}
-                {t('hintAvailable')}: {t(hint.fromZone)}
-                {hint.fromCol >= 0 ? ` ${hint.fromCol}` : ''} → {t(hint.toZone)}
-                {hint.toCol >= 0 ? ` ${hint.toCol}` : ''}
+              <div className="text-ds-warning text-sm mb-2" data-testid="fc-hint-line">
+                {t('hintAvailable')}: {formatHintZone(t, hint.fromZone, hint.fromCol)} →{' '}
+                {formatHintZone(t, hint.toZone, hint.toCol)}
               </div>
             )}
             <div className="flex justify-center">


### PR DESCRIPTION
## 背景

`FreeCellPage.tsx` のヒント表示は `t(hint.fromZone)` のように、**API が返すゾーン
識別子をそのまま i18n キーとして使っていた。**

姉妹ゲーム (FlowerGarden / FortyAndEight / FortyThieves ほか) は `formatHintZone` と
`frontendHint.*` 名前空間を介しており、ドメインの識別子が翻訳キーになることはない。
FreeCell だけがこの結合を持っていて、ゾーン名を変更・追加すると**翻訳キーが静かに
壊れる**（型でもコンパイルでも検出できない）。

## 変更

`formatHintZone` を置き、`frontendHint.zone.*` 経由にした。

**表示文字列は1文字も変えていない。** 移す前に現在の出力
（`ヒント: タブロー 2 → ファンデーション`）を完全一致でテストに固定し、
そのテストを緑のままリファクタした。ロケールの値も既存の文言をそのまま流用している。

未知のゾーンは**キーではなく識別子そのもの**を返す。ドメインが新しいゾーンを返し
始めたとき、生の `reserve` が出るほうが `frontendHint.zone.reserve` が画面に出るより
読める。

## 気づいた点（このPRでは変更していない）

FreeCell の foundation は「ファンデーション」で、他の Solitaire 系ページは「組札」。
受け入れ条件が「既存の表示テキストが変わらない」なので**揃えていない**。統一するなら
別途判断が要る。

## テスト

- **完全一致の回帰テスト**（リファクタ前に追加し、前後で同じ文字列）
- 未知のゾーンで翻訳キー文字列が画面に出ないこと
- 既存のヒント表示テスト 2 件はそのまま緑

Closes #5494