### PR TITLE
feat(baccarat): show the payout table in the CUI

### DIFF
--- a/internal/adapter/presenter/BaccaratCuiPresenter.go
+++ b/internal/adapter/presenter/BaccaratCuiPresenter.go
@@ -76,6 +76,24 @@ func (bp *BaccaratCuiPresenter) Output(b interfaces.BaccaratGame, lastErr error)
 		sb.WriteString(i18n.MarkErrorLine(color.Red(lastErr.Error())) + "\n")
 	}
 
+	// **配当を知らないままベットタイプを選ばせない。** Web はベット前に payoutRef
+	// パネルで倍率を出しているのに、CUI には出す手段が無かった (#5497)。BlackJack が
+	// #4677 で入れたのと同じ形。倍率はドメインの定数から作る -- 文言に直接書くと、
+	// コミッション率や配当率を変えたときに嘘の表が残る。
+	//
+	// 結果表示中は重ねない。決着した卓に配当表を並べると、いま起きたことが読み取り
+	// にくくなる。次のベット前にまた出る。
+	if !b.GetGameEndFlag() {
+		sb.WriteString(color.Bold(i18n.T("baccarat.payoutRefTitle")) + "\n")
+		sb.WriteString("  " + i18n.T("baccarat.payoutRefPlayer") + "\n")
+		sb.WriteString("  " + i18n.Tf("baccarat.payoutRefBanker",
+			"commission", strconv.Itoa(domain.BaccaratCommissionRate)) + "\n")
+		sb.WriteString("  " + i18n.Tf("baccarat.payoutRefTie",
+			"rate", strconv.Itoa(domain.BaccaratTiePayoutRate)) + "\n")
+		sb.WriteString("  " + i18n.Tf("baccarat.payoutRefPair",
+			"rate", strconv.Itoa(domain.BacPairPayoutRate)) + "\n")
+	}
+
 	if b.GetGameEndFlag() {
 		sb.WriteString(i18n.Tf("baccarat.betLine",
 			"amount", strconv.Itoa(b.GetBetAmount()),

--- a/internal/adapter/presenter/BaccaratCuiPresenter_test.go
+++ b/internal/adapter/presenter/BaccaratCuiPresenter_test.go
@@ -1,6 +1,7 @@
 package presenter
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupBaccaratCuiMockDefaults(m *interfaces.MockBaccaratGame) {
@@ -404,5 +406,34 @@ func TestBaccaratCuiPresenter_ActionLogOutput(t *testing.T) {
 		m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜はありません")
+	})
+}
+
+// #5497: Web はベット前に payoutRef パネルで配当倍率を出しているのに、CUI には
+// 配当を出すコマンドも表示も無く、プレイヤーは倍率を知らないままベットタイプを
+// 選ぶことになる。BlackJack は #4677 で同じ対応が入っている。
+func TestBaccaratCuiPresenter_PayoutTable(t *testing.T) {
+	bp := new(BaccaratCuiPresenter)
+
+	t.Run("lists every payout during the betting phase", func(t *testing.T) {
+		b := domain.NewDefaultBaccarat()
+		out := bp.Output(b, nil)
+		assert.Contains(t, out, i18n.T("baccarat.payoutRefTitle"))
+		// 倍率はドメインの定数から作る。文言に直接書くと定数と乖離する。
+		assert.Contains(t, out, i18n.Tf("baccarat.payoutRefTie",
+			"rate", strconv.Itoa(domain.BaccaratTiePayoutRate)))
+		assert.Contains(t, out, i18n.Tf("baccarat.payoutRefPair",
+			"rate", strconv.Itoa(domain.BacPairPayoutRate)))
+		assert.Contains(t, out, i18n.Tf("baccarat.payoutRefBanker",
+			"commission", strconv.Itoa(domain.BaccaratCommissionRate)))
+		assert.Contains(t, out, i18n.T("baccarat.payoutRefPlayer"))
+	})
+
+	// **結果表示中は重ねない。** 決着した卓に配当表を並べると、いま起きたことが
+	// 読み取りにくくなる。次のベット前にまた出る。
+	t.Run("stays quiet while a finished round is on screen", func(t *testing.T) {
+		b := domain.NewDefaultBaccarat()
+		b.SetGameEndFlag(true)
+		assert.NotContains(t, bp.Output(b, nil), i18n.T("baccarat.payoutRefTitle"))
 	})
 }

--- a/internal/i18n/locales/en/baccarat.json
+++ b/internal/i18n/locales/en/baccarat.json
@@ -25,5 +25,10 @@
   "historyStreak": "Current streak: {{side}} x{{count}}",
   "sidePlayer": "Player",
   "sideBanker": "Banker",
-  "helpExampleBet": "  b 100 0              bet 100 on the Player"
+  "helpExampleBet": "  b 100 0              bet 100 on the Player",
+  "payoutRefTitle": "Payouts",
+  "payoutRefPlayer": "Player win (1:1)",
+  "payoutRefBanker": "Banker win (1:1, {{commission}}% commission)",
+  "payoutRefTie": "Tie ({{rate}}:1)",
+  "payoutRefPair": "Pair (player/banker) ({{rate}}:1)"
 }

--- a/internal/i18n/locales/ja/baccarat.json
+++ b/internal/i18n/locales/ja/baccarat.json
@@ -25,5 +25,10 @@
   "historyStreak": "現在 {{side}} が {{count}} 連勝中",
   "sidePlayer": "プレイヤー",
   "sideBanker": "バンカー",
-  "helpExampleBet": "  b 100 0              100 をプレイヤーに賭ける"
+  "helpExampleBet": "  b 100 0              100 をプレイヤーに賭ける",
+  "payoutRefTitle": "配当表",
+  "payoutRefPlayer": "プレイヤー勝利 (1:1)",
+  "payoutRefBanker": "バンカー勝利 (1:1、コミッション {{commission}}%)",
+  "payoutRefTie": "タイ ({{rate}}:1)",
+  "payoutRefPair": "ペア (プレイヤー/バンカー) ({{rate}}:1)"
 }

--- a/internal/infrastructure/games/baccarat_payout_test.go
+++ b/internal/infrastructure/games/baccarat_payout_test.go
@@ -1,0 +1,59 @@
+package games_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+)
+
+// TestBaccaratWebPayoutRefMatchesTheDomain guards the Web payout panel against
+// the constants that actually pay out.
+//
+// The CUI table interpolates BaccaratTiePayoutRate / BacPairPayoutRate /
+// BaccaratCommissionRate, so it cannot drift. The Web panel
+// (`frontend/src/i18n/locales/*/baccarat.json`, `payoutRef.*`) spells the same
+// numbers as **plain text**, which is what the CUI table was written to match
+// (#5497). Change a rate and the two disagree, with nothing to notice.
+func TestBaccaratWebPayoutRefMatchesTheDomain(t *testing.T) {
+	root := filepath.Join("..", "..", "..")
+	// tie 8 -> "(8:1)", pair 11 -> "(11:1)", banker keeps 5% commission -> "0.95:1".
+	want := map[string]string{
+		"tie":        "(" + strconv.Itoa(domain.BaccaratTiePayoutRate) + ":1)",
+		"playerPair": "(" + strconv.Itoa(domain.BacPairPayoutRate) + ":1)",
+		"bankerPair": "(" + strconv.Itoa(domain.BacPairPayoutRate) + ":1)",
+		"bankerWin":  "(" + strconv.FormatFloat(1-float64(domain.BaccaratCommissionRate)/100, 'g', -1, 64) + ":1)",
+		"playerWin":  "(1:1)",
+	}
+
+	for _, loc := range []string{"ja", "en"} {
+		path := filepath.Join(root, "frontend", "src", "i18n", "locales", loc, "baccarat.json")
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		var d map[string]any
+		if err := json.Unmarshal(raw, &d); err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		ref, ok := d["payoutRef"].(map[string]any)
+		if !ok {
+			t.Fatalf("%s has no payoutRef object", path)
+		}
+		for key, fragment := range want {
+			line, ok := ref[key].(string)
+			if !ok {
+				t.Errorf("%s payoutRef.%s missing", loc, key)
+				continue
+			}
+			if !strings.Contains(line, fragment) {
+				t.Errorf("%s payoutRef.%s should state %s (from the domain constants), got %q",
+					loc, key, fragment, line)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## 背景

`BaccaratPage.tsx` はベット前に `payoutRef` パネルで Player / Banker / Tie と
ペア系サイドベットの配当を出す。**CUI にはこれを出すコマンドも表示も無い**
(`BaccaratCuiController` は `b`/`bet` と `ch`/`clearhistory` のみ)。
CUI プレイヤーは倍率を知らないままベットタイプを選ぶことになる。

BlackJack は #4677 で同じ対応が入っている。

## 変更

ベットフェーズの出力に配当表を足す。

**倍率はドメインの定数から作る** (`BaccaratTiePayoutRate` / `BacPairPayoutRate` /
`BaccaratCommissionRate`)。文言に直接書くと、率を変えたときに嘘の表が残る。

**結果表示中は重ねない。** 決着した卓に配当表を並べると、いま起きたことが読み取り
にくくなる。次のベット前にまた出る。

## Web 側の数値も定数と突き合わせる

CUI は補間するので乖離しないが、Web の `payoutRef.*` は「(8:1)」のような**素の
テキスト**で数値を持っている。CUI の表はその内容に合わせて書いたので、片方だけ
変わると黙って食い違う。ロケール2つを読んで定数と照合する Go のテストを足した。

**変異テスト（実測）**:

| 変異 | 落ちた検査 |
|---|---|
| `BaccaratTiePayoutRate` を 9 に変える | 2（ja/en の payoutRef が古いと報告）|
| 結果表示中も配当表を出す | 1 |

Closes #5497