### PR TITLE
feat(crazyeights): mark the winner's row in the score table

### DIFF
--- a/frontend/src/i18n/locales/en/crazyeights.json
+++ b/frontend/src/i18n/locales/en/crazyeights.json
@@ -76,5 +76,6 @@
     "play_wild": "an 8 lets you change the suit",
     "play_valid": "a legal play",
     "choose_longest_suit": "your longest suit"
-  }
+  },
+  "winnerBadge": "(winner)"
 }

--- a/frontend/src/i18n/locales/ja/crazyeights.json
+++ b/frontend/src/i18n/locales/ja/crazyeights.json
@@ -76,5 +76,6 @@
     "play_wild": "8 でスートを変えられる",
     "play_valid": "出せる札",
     "choose_longest_suit": "手札に一番多いスート"
-  }
+  },
+  "winnerBadge": "(勝者)"
 }

--- a/frontend/src/pages/CrazyEightsPage.test.tsx
+++ b/frontend/src/pages/CrazyEightsPage.test.tsx
@@ -885,3 +885,47 @@ describe('CrazyEightsPage', () => {
     expect(screen.queryByTestId('ce-server-hint')).not.toBeInTheDocument();
   });
 });
+
+// #5499: スコア表の色分けは `p.isHuman` だけで、**誰が勝ったかは行に出ていなかった**。
+// winnerIdx はサーバから届いていて GameMessageBox の文には反映されているのに、表は
+// 使っていない。CUI は勝者名を color.Green のバナーで出しており、CUI のほうが
+// 「誰が勝ったか」を明確に伝えていた。
+describe('CrazyEightsPage winner highlight', () => {
+  it('marks the human winner row', async () => {
+    mockExec.mockResolvedValue(gameEndState); // winnerIdx: 0 = human
+    renderWithProviders(<CrazyEightsPage />);
+    const row = await screen.findByTestId('ce-score-row-0');
+    expect(row).toHaveAttribute('data-winner', 'true');
+    // スクリーンリーダーにも勝者だと分かること。色だけでは伝わらない。
+    expect(row.textContent).toContain('勝者');
+  });
+
+  // **CPU が勝った場合も同じように出る。** 人間かどうかの色分けと混ざっていると、
+  // 「自分の行が強調されている」のか「勝者の行が強調されている」のか区別できない。
+  it('marks a CPU winner row too', async () => {
+    mockExec.mockResolvedValue({ ...gameEndState, winnerIdx: 2 });
+    renderWithProviders(<CrazyEightsPage />);
+    const row = await screen.findByTestId('ce-score-row-2');
+    expect(row).toHaveAttribute('data-winner', 'true');
+    // 人間の行 (0) には付かない。
+    expect(screen.getByTestId('ce-score-row-0')).not.toHaveAttribute('data-winner', 'true');
+  });
+
+  // **決着前は出さない。** 途中経過の首位を勝者として見せると誤解を招く。
+  it('marks nothing while the game is still running', async () => {
+    mockExec.mockResolvedValue(playPhaseState); // winnerIdx: -1
+    renderWithProviders(<CrazyEightsPage />);
+    const row = await screen.findByTestId('ce-score-row-0');
+    expect(row).not.toHaveAttribute('data-winner', 'true');
+  });
+
+  // 今のサーバはこの状態を作らない (winnerIdx が入るのは checkGameEnd の中だけで、
+  // そこで gameEndFlag も立つ)。**将来ラウンド勝者に winnerIdx を流用しても、
+  // ゲームの勝者として表示されないようにする**ためのガード。
+  it('does not treat a winnerIdx without a game end as the game winner', async () => {
+    mockExec.mockResolvedValue({ ...playPhaseState, winnerIdx: 1 });
+    renderWithProviders(<CrazyEightsPage />);
+    const row = await screen.findByTestId('ce-score-row-1');
+    expect(row).not.toHaveAttribute('data-winner', 'true');
+  });
+});

--- a/frontend/src/pages/CrazyEightsPage.tsx
+++ b/frontend/src/pages/CrazyEightsPage.tsx
@@ -362,13 +362,34 @@ function CrazyEightsPageContent() {
                       </tr>
                     </thead>
                     <tbody>
-                      {state.players.map((p) => (
-                        <tr key={p.id} className={p.isHuman ? 'text-ds-accent' : ''}>
-                          <td>{playerName(p.id, p.isHuman)}</td>
-                          <td className="text-center">{p.roundScore}</td>
-                          <td className="text-center">{p.cumulativeScore}</td>
-                        </tr>
-                      ))}
+                      {state.players.map((p) => {
+                        // **勝者は「自分かどうか」とは別の軸。** 行の色分けは
+                        // isHuman だけで、誰が勝ったかは表に出ていなかった
+                        // (winnerIdx は届いていて文章にだけ反映されていた)。CUI は
+                        // 勝者名を緑のバナーで出しており、そちらのほうが明確だった (#5499)。
+                        // 決着前は出さない -- 途中経過の首位を勝者と読ませない。
+                        const isWinner = isGameEnd && p.id === state.winnerIdx;
+                        return (
+                          <tr
+                            key={p.id}
+                            data-testid={`ce-score-row-${p.id}`}
+                            data-winner={isWinner ? 'true' : undefined}
+                            className={`${p.isHuman ? 'text-ds-accent' : ''}${
+                              isWinner ? ' bg-ds-success/15 font-bold' : ''
+                            }`}
+                          >
+                            <td>
+                              {playerName(p.id, p.isHuman)}
+                              {/* 色だけでは伝わらないので、勝者はテキストでも示す。 */}
+                              {isWinner && (
+                                <span className="ml-1 text-ds-success text-xs font-bold">{t('winnerBadge')}</span>
+                              )}
+                            </td>
+                            <td className="text-center">{p.roundScore}</td>
+                            <td className="text-center">{p.cumulativeScore}</td>
+                          </tr>
+                        );
+                      })}
                     </tbody>
                   </table>
                 </div>


### PR DESCRIPTION
## 背景

スコアテーブルの行の色分けは `p.isHuman ? 'text-ds-accent' : ''` だけで、
**誰が勝ったかは表に出ていない。**

`state.winnerIdx` はサーバから届いていて `GameMessageBox` の文
(`buildWinnerWebMessage`) には反映されているのに、表は使っていなかった。
一方 `CrazyEightsCuiPresenter` は勝者名を `color.Green` のバナーで出しており、
**CUI のほうが「誰が勝ったか」を明確に伝えていた。**

## 変更

決着後、勝者の行に背景色 + 太字 + テキストバッジを付ける。

**勝者は「自分かどうか」とは別の軸。** 人間の色分け (`text-ds-accent`) と混ざると、
自分の行が強調されているのか勝者の行が強調されているのか区別できない。
**色だけでは伝わらない**ので、テキストでも示す（受け入れ条件 3）。

## テスト

- 人間が勝者のとき / **CPU が勝者のとき**の両方（受け入れ条件 2）
- CPU 勝利時に人間の行には付かないこと
- 決着前は付かないこと
- **`winnerIdx` があっても決着していなければ付かないこと** — 今のサーバはこの状態を
  作らない (`winnerIdx` が入るのは `checkGameEnd` の中だけで、そこで `gameEndFlag` も
  立つ) が、将来ラウンド勝者に流用したときにゲームの勝者として表示されないためのガード

**変異テスト（実測）**:

| 変異 | 落ちたテスト |
|---|---|
| 決着のゲートを外す | 1 |
| 勝者判定を `p.isHuman` にする | 1 |
| テキストバッジを消して色だけにする | 1 |

Closes #5499