### PR TITLE
feat(ginrummy): explain what each CPU difficulty actually does

### DIFF
--- a/frontend/src/i18n/locales/en/ginrummy.json
+++ b/frontend/src/i18n/locales/en/ginrummy.json
@@ -16,7 +16,8 @@
     "policyEasy": "knocks at {{knockLimit}} deadwood or less / takes the discard 1 time in {{easyOneIn}}",
     "policyNormal": "knocks at {{knockNormal}} or less / takes the discard when it gains more than {{gainNormal}}",
     "policyHard": "knocks at {{knockHard}} or less, or on gin / takes the discard on any gain",
-    "policyTooltip": "Difficulty changes when the CPU knocks and when it takes the discard. Numbers are deadwood points."
+    "policyTooltip": "Difficulty changes when the CPU knocks and when it takes the discard. Numbers are deadwood points.",
+    "difficultyWithPolicy": "{{level}} ({{policy}})"
   },
   "round": "Round {{n}}",
   "drawPile": "Draw pile: {{count}} cards",

--- a/frontend/src/i18n/locales/en/ginrummy.json
+++ b/frontend/src/i18n/locales/en/ginrummy.json
@@ -12,7 +12,11 @@
     "pointLimit": "Point Limit",
     "easy": "Easy",
     "normal": "Normal",
-    "hard": "Hard"
+    "hard": "Hard",
+    "policyEasy": "knocks at {{knockLimit}} deadwood or less / takes the discard 1 time in {{easyOneIn}}",
+    "policyNormal": "knocks at {{knockNormal}} or less / takes the discard when it gains more than {{gainNormal}}",
+    "policyHard": "knocks at {{knockHard}} or less, or on gin / takes the discard on any gain",
+    "policyTooltip": "Difficulty changes when the CPU knocks and when it takes the discard. Numbers are deadwood points."
   },
   "round": "Round {{n}}",
   "drawPile": "Draw pile: {{count}} cards",

--- a/frontend/src/i18n/locales/ja/ginrummy.json
+++ b/frontend/src/i18n/locales/ja/ginrummy.json
@@ -12,7 +12,11 @@
     "pointLimit": "目標スコア",
     "easy": "Easy",
     "normal": "Normal",
-    "hard": "Hard"
+    "hard": "Hard",
+    "policyEasy": "デッドウッド{{knockLimit}}以下で即ノック / 捨て札は1/{{easyOneIn}}で拾う",
+    "policyNormal": "デッドウッド{{knockNormal}}以下でノック / 捨て札は{{gainNormal}}点超改善で拾う",
+    "policyHard": "デッドウッド{{knockHard}}以下かジンでノック / 捨て札は少しでも改善すれば拾う",
+    "policyTooltip": "難易度で変わるのは CPU のノック判断と捨て札の拾い方です。数字はデッドウッド点。"
   },
   "round": "ラウンド {{n}}",
   "drawPile": "山札: {{count}}枚",

--- a/frontend/src/i18n/locales/ja/ginrummy.json
+++ b/frontend/src/i18n/locales/ja/ginrummy.json
@@ -16,7 +16,8 @@
     "policyEasy": "デッドウッド{{knockLimit}}以下で即ノック / 捨て札は1/{{easyOneIn}}で拾う",
     "policyNormal": "デッドウッド{{knockNormal}}以下でノック / 捨て札は{{gainNormal}}点超改善で拾う",
     "policyHard": "デッドウッド{{knockHard}}以下かジンでノック / 捨て札は少しでも改善すれば拾う",
-    "policyTooltip": "難易度で変わるのは CPU のノック判断と捨て札の拾い方です。数字はデッドウッド点。"
+    "policyTooltip": "難易度で変わるのは CPU のノック判断と捨て札の拾い方です。数字はデッドウッド点。",
+    "difficultyWithPolicy": "{{level}}（{{policy}}）"
   },
   "round": "ラウンド {{n}}",
   "drawPile": "山札: {{count}}枚",

--- a/frontend/src/pages/GinRummyPage.test.tsx
+++ b/frontend/src/pages/GinRummyPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, ginrummyApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
+import i18n from '../i18n';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { GinRummyResponse } from '../types/card';
 import { GinRummyCpu } from '../types/phases';
@@ -1056,5 +1057,19 @@ describe('GinRummyPage difficulty policies', () => {
     for (const label of labels) {
       expect(label).toMatch(/ノック/);
     }
+  });
+});
+
+// レビュー指摘 (#5863)。括弧を JSX で書くと、全角がそのまま英語表示にも混ざる。
+// ロケール側に持たせたことを、英語に切り替えて確かめる。
+describe('GinRummyPage difficulty label punctuation', () => {
+  it('uses the locale-owned wrapper rather than hardcoded full-width parens', async () => {
+    const prev = i18n.language;
+    await i18n.changeLanguage('en');
+    const label = i18n.t('ginrummy:settings.difficultyWithPolicy', { level: 'Easy', policy: 'knocks early' });
+    expect(label).not.toMatch(/[（）]/);
+    expect(label).toContain('(');
+    await i18n.changeLanguage(prev);
+    expect(i18n.t('ginrummy:settings.difficultyWithPolicy', { level: 'Easy', policy: 'x' })).toMatch(/（/);
   });
 });

--- a/frontend/src/pages/GinRummyPage.test.tsx
+++ b/frontend/src/pages/GinRummyPage.test.tsx
@@ -4,6 +4,7 @@ import { actionLogApi, ginrummyApi } from '../api/gameApi';
 import { NETWORK_ERROR_MESSAGE } from '../constants/messages';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { GinRummyResponse } from '../types/card';
+import { GinRummyCpu } from '../types/phases';
 import { GinRummyPage } from './GinRummyPage';
 
 vi.mock('../api/gameApi', () => ({
@@ -1029,5 +1030,31 @@ describe('GinRummyPage', () => {
     renderWithProviders(<GinRummyPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalled());
     expect(document.querySelectorAll('[data-layoff]')).toHaveLength(0);
+  });
+});
+
+// #5500: 難易度で変わるのは CPU のノック判断と捨て札の拾い方なのに、選択肢には
+// Easy/Normal/Hard のラベルしか出ておらず、実際の判断基準はプレイヤーから見えない。
+describe('GinRummyPage difficulty policies', () => {
+  it('summarises what each difficulty actually does', async () => {
+    mockExec.mockResolvedValue(drawPhaseState);
+    renderWithProviders(<GinRummyPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    fireEvent.click(screen.getByText('設定'));
+
+    const select = screen.getByRole('combobox', { name: 'CPU難易度' });
+    const labels = Array.from(select.querySelectorAll('option')).map((o) => o.textContent ?? '');
+    expect(labels).toHaveLength(3);
+
+    // **数値は GinRummyCpu から補間される。** ラベルに直接書くと domain と乖離する。
+    expect(labels[1]).toContain(String(GinRummyCpu.KNOCK_DEADWOOD_NORMAL));
+    expect(labels[2]).toContain(String(GinRummyCpu.KNOCK_DEADWOOD_HARD));
+    // Easy は法定上限でノックし、拾いは確率。
+    expect(labels[0]).toContain(String(GinRummyCpu.KNOCK_THRESHOLD));
+    expect(labels[0]).toContain(String(GinRummyCpu.EASY_PICK_ONE_IN));
+    // 3つとも素のラベルのままではないこと。
+    for (const label of labels) {
+      expect(label).toMatch(/ノック/);
+    }
   });
 });

--- a/frontend/src/pages/GinRummyPage.tsx
+++ b/frontend/src/pages/GinRummyPage.tsx
@@ -277,10 +277,12 @@ function GinRummyPageContent() {
                     // 突き合わせる Go のテストがあるので、片方だけ変えると落ちる。
                     options: CPU_DIFFICULTY_OPTIONS.map((o) => ({
                       value: o.value,
-                      label: `${t(`settings.${o.label.toLowerCase()}`)}（${t(
-                        `settings.policy${o.label}`,
-                        GIN_RUMMY_POLICY_VALUES,
-                      )}）`,
+                      // 括弧はロケール側に持たせる。JSX で全角括弧を書くと英語表示にも
+                      // 混ざる (Memory の difficultyOption と同じ形にそろえた)。
+                      label: t('settings.difficultyWithPolicy', {
+                        level: t(`settings.${o.label.toLowerCase()}`),
+                        policy: t(`settings.policy${o.label}`, GIN_RUMMY_POLICY_VALUES),
+                      }),
                     })),
                     tooltip: t('settings.policyTooltip', GIN_RUMMY_POLICY_VALUES),
                     onSelect: (v) => handleConfigChange('cpuDifficulty', v),

--- a/frontend/src/pages/GinRummyPage.tsx
+++ b/frontend/src/pages/GinRummyPage.tsx
@@ -27,7 +27,7 @@ import { focusRingCard, meldCardStyle, selectedCardStyle } from '../styles/cardS
 import { lgCardAreaConstraint, lgTwoColGrid } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { GinRummyResponse } from '../types/card';
-import { GinRummyPhase } from '../types/phases';
+import { GinRummyCpu, GinRummyPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { GINRUMMY_HELP, parseGinrummyCommand } from '../utils/cli/commands/ginrummyCommands';
@@ -90,6 +90,15 @@ const GR_TUTORIAL_STEPS: TutorialStep[] = [
 /** Renders the Gin Rummy game page with draw, discard, knock, and layoff phases. */
 export const GinRummyPage = withTutorial(GinRummyPageContent, 'ginrummy', GR_TUTORIAL_STEPS);
 /** Inner content of the Gin Rummy page, wrapped by TutorialProvider. */
+/** Interpolation values for the CPU policy descriptions, kept next to the constants. */
+const GIN_RUMMY_POLICY_VALUES = {
+  knockNormal: GinRummyCpu.KNOCK_DEADWOOD_NORMAL,
+  knockHard: GinRummyCpu.KNOCK_DEADWOOD_HARD,
+  gainNormal: GinRummyCpu.DISCARD_GAIN_NORMAL,
+  easyOneIn: GinRummyCpu.EASY_PICK_ONE_IN,
+  knockLimit: GinRummyCpu.KNOCK_THRESHOLD,
+};
+
 function GinRummyPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('ginrummy');
@@ -262,10 +271,18 @@ function GinRummyPageContent() {
                     id: 'cpuDifficulty',
                     label: t('settings.cpuDifficulty'),
                     value: ginRummyConfig.cpuDifficulty,
+                    // **難易度で変わるのはノックと拾いの基準。** Easy/Normal/Hard の
+                    // ラベルしか出ておらず、実際の判断基準はプレイヤーから見えな
+                    // かった (#5500)。数値は GinRummyCpu から取る -- domain 定数と
+                    // 突き合わせる Go のテストがあるので、片方だけ変えると落ちる。
                     options: CPU_DIFFICULTY_OPTIONS.map((o) => ({
                       value: o.value,
-                      label: t(`settings.${o.label.toLowerCase()}`),
+                      label: `${t(`settings.${o.label.toLowerCase()}`)}（${t(
+                        `settings.policy${o.label}`,
+                        GIN_RUMMY_POLICY_VALUES,
+                      )}）`,
                     })),
+                    tooltip: t('settings.policyTooltip', GIN_RUMMY_POLICY_VALUES),
                     onSelect: (v) => handleConfigChange('cpuDifficulty', v),
                   },
                   {

--- a/frontend/src/types/phases.ts
+++ b/frontend/src/types/phases.ts
@@ -194,6 +194,21 @@ export const KlondikeVegas = {
   PER_CARD: 5,
 } as const;
 
+/**
+ * Gin Rummy CPU policy constants (sync: internal/domain/GinRummy.go).
+ *
+ * `cpuDiscardOrKnock` / `cpuDraw` branch on difficulty with these numbers. The
+ * settings panel quotes them, and a Go test asserts this object against the
+ * domain constants so the explanation cannot drift from the behaviour.
+ */
+export const GinRummyCpu = {
+  KNOCK_DEADWOOD_NORMAL: 7,
+  KNOCK_DEADWOOD_HARD: 5,
+  DISCARD_GAIN_NORMAL: 5,
+  EASY_PICK_ONE_IN: 3,
+  KNOCK_THRESHOLD: 10,
+} as const;
+
 /** Canfield phase constants (sync: internal/domain/Canfield.go). */
 export const CanfieldPhase = {
   PLAYING: 0,

--- a/internal/domain/GinRummy.go
+++ b/internal/domain/GinRummy.go
@@ -16,6 +16,21 @@ const GinRummyHandSize = 10
 // GinRummyKnockThreshold ノック可能なデッドウッド上限
 const GinRummyKnockThreshold = 10
 
+// CPU の難易度ごとの判断基準。**画面の説明文と同じ数字であることをテストで
+// 固定している** -- 片方だけ変えると、設定パネルが嘘の方針を説明する (#5500)。
+const (
+	// GinRummyKnockDeadwoodNormal は Normal がノックに踏み切るデッドウッド上限。
+	GinRummyKnockDeadwoodNormal = 7
+	// GinRummyKnockDeadwoodHard は Hard がノックに踏み切るデッドウッド上限
+	// (ジン=0 は別扱いで常にノックする)。
+	GinRummyKnockDeadwoodHard = 5
+	// GinRummyDiscardGainNormal は Normal が捨て札を拾う最低改善幅。これを
+	// **超える**改善が要る。
+	GinRummyDiscardGainNormal = 5
+	// GinRummyEasyPickOneIn は Easy が捨て札を拾う確率の分母 (1/N)。
+	GinRummyEasyPickOneIn = 3
+)
+
 // GinRummyGinBonus ジンボーナス点
 const GinRummyGinBonus = 25
 
@@ -502,9 +517,9 @@ func (g *GinRummy) cpuDraw() {
 		case GinRummyCpuDifficultyHard:
 			shouldPickDiscard = dwWith < dwWithout
 		case GinRummyCpuDifficultyNormal:
-			shouldPickDiscard = dwWith < dwWithout-5
+			shouldPickDiscard = dwWith < dwWithout-GinRummyDiscardGainNormal
 		default:
-			shouldPickDiscard = rand.Intn(3) == 0
+			shouldPickDiscard = rand.Intn(GinRummyEasyPickOneIn) == 0
 		}
 
 		if shouldPickDiscard {
@@ -567,9 +582,9 @@ func (g *GinRummy) cpuDiscardOrKnock() {
 		shouldKnock := false
 		switch g.config.CpuDifficulty {
 		case GinRummyCpuDifficultyHard:
-			shouldKnock = bestDeadwood <= 5 || bestDeadwood == 0
+			shouldKnock = bestDeadwood <= GinRummyKnockDeadwoodHard || bestDeadwood == 0
 		case GinRummyCpuDifficultyNormal:
-			shouldKnock = bestDeadwood <= 7
+			shouldKnock = bestDeadwood <= GinRummyKnockDeadwoodNormal
 		default:
 			shouldKnock = true
 		}

--- a/internal/domain/GinRummy_test.go
+++ b/internal/domain/GinRummy_test.go
@@ -1524,3 +1524,37 @@ func TestGinRummy_LayoffTargets(t *testing.T) {
 	assert.Nil(t, g.LayoffTargets(domain.NewCard(domain.CardDesignHeart, 10, false)))
 	assert.Nil(t, g.LayoffTargets(nil))
 }
+
+// #5500 の副産物: Easy の拾い判断は 1/GinRummyEasyPickOneIn の乱数分岐で、
+// 片方の枝しか通らないと codecov に残る。**乱択なのでリトライで両方を通す**
+// (internal/CLAUDE.md の「1000回までのリトライで両分岐を覆う」手法)。
+//
+// どちらを引いたかは行動ログ (draw_discard / draw_stock) で見る。盤面の枚数は
+// 直後の捨てで戻るので、枚数からは区別できない。
+func TestGinRummy_EasyCpuTakesTheDiscardSometimesAndSometimesNot(t *testing.T) {
+	drewFromDiscard, drewFromStock := false, false
+
+	for i := 0; i < 1000 && (!drewFromDiscard || !drewFromStock); i++ {
+		g := domain.NewDefaultGinRummy()
+		g.Reset()
+		cfg := g.GetConfig()
+		cfg.CpuDifficulty = domain.GinRummyCpuDifficultyEasy
+		g.SetConfig(cfg)
+		g.SetCurrentPlayerIdx(1)
+		g.SetPhase(domain.GinRummyPhaseDraw)
+
+		before := len(g.GetActionLog())
+		g.CpuPlay()
+		for _, e := range g.GetActionLog()[before:] {
+			switch e.ActionType {
+			case "draw_discard":
+				drewFromDiscard = true
+			case "draw_stock":
+				drewFromStock = true
+			}
+		}
+	}
+
+	assert.True(t, drewFromDiscard, "Easy が捨て札を拾う枝を一度も通らなかった")
+	assert.True(t, drewFromStock, "Easy が山札から引く枝を一度も通らなかった")
+}

--- a/internal/infrastructure/games/ginrummy_cpu_policy_test.go
+++ b/internal/infrastructure/games/ginrummy_cpu_policy_test.go
@@ -1,0 +1,56 @@
+package games_test
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+)
+
+// TestGinRummyCpuPolicyConstantsMatchTheFrontend guards the difficulty
+// descriptions in the settings panel against the code that acts on them.
+//
+// `cpuDiscardOrKnock` / `cpuDraw` branch on difficulty: Easy knocks at the legal
+// limit and takes the discard at random, Normal wants a 7 and a real gain, Hard
+// waits for a 5 and takes any gain. None of that was visible to the player, and
+// the panel now quotes the numbers (#5500). **They are written twice, in two
+// languages**, so this pins the TypeScript copy to the domain.
+func TestGinRummyCpuPolicyConstantsMatchTheFrontend(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "frontend", "src", "types", "phases.ts")
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read phases.ts: %v", err)
+	}
+	text := string(src)
+
+	for _, want := range []struct {
+		field string
+		value int
+	}{
+		{"KNOCK_DEADWOOD_NORMAL", domain.GinRummyKnockDeadwoodNormal},
+		{"KNOCK_DEADWOOD_HARD", domain.GinRummyKnockDeadwoodHard},
+		{"DISCARD_GAIN_NORMAL", domain.GinRummyDiscardGainNormal},
+		{"EASY_PICK_ONE_IN", domain.GinRummyEasyPickOneIn},
+		{"KNOCK_THRESHOLD", domain.GinRummyKnockThreshold},
+	} {
+		line := want.field + ": " + strconv.Itoa(want.value) + ","
+		if !strings.Contains(text, line) {
+			t.Errorf("frontend/src/types/phases.ts should carry `%s` in GinRummyCpu (domain says %d)",
+				line, want.value)
+		}
+	}
+
+	// **順序も説明の一部。** Hard のほうが Normal より辛抱強い、という説明が
+	// 逆転していないこと。
+	if domain.GinRummyKnockDeadwoodHard >= domain.GinRummyKnockDeadwoodNormal {
+		t.Errorf("Hard should knock at a stricter deadwood than Normal (hard=%d normal=%d)",
+			domain.GinRummyKnockDeadwoodHard, domain.GinRummyKnockDeadwoodNormal)
+	}
+	if domain.GinRummyKnockDeadwoodNormal >= domain.GinRummyKnockThreshold {
+		t.Errorf("Normal should knock below the legal limit (normal=%d limit=%d)",
+			domain.GinRummyKnockDeadwoodNormal, domain.GinRummyKnockThreshold)
+	}
+}


### PR DESCRIPTION
## 背景

`cpuDiscardOrKnock` / `cpuDraw` は難易度ごとに**全く違う基準**で動く:

| | ノック | 捨て札を拾う |
|---|---|---|
| Easy | デッドウッド 10 以下（法定上限）で即 | **1/3 の運** |
| Normal | 7 以下 | 5 点を**超える**改善があるとき |
| Hard | 5 以下、またはジン | **少しでも**改善するとき |

選択肢には Easy / Normal / Hard の**ラベルしか出ておらず**、実際の判断基準は
プレイヤーからは一切見えなかった。

## 変更

判断基準の数値をドメイン定数
(`GinRummyKnockDeadwoodNormal` / `GinRummyKnockDeadwoodHard` /
`GinRummyDiscardGainNormal` / `GinRummyEasyPickOneIn`) に切り出し、
各選択肢に方針の要約を添えた。項目のツールチップで何が変わるのかも一度だけ説明する。

**数値のハードコードは1箇所**（受け入れ条件 3）。フロントは `GinRummyCpu`
(`phases.ts`) から補間し、ロケール文言はプレースホルダだけを持つ。

## 数値と説明が食い違わないようにする

数値は Go と TS の2か所に書かれるので、**Go のテストが `phases.ts` を読んで
domain 定数と突き合わせる。** ついでに「Hard のほうが Normal より辛抱強い」
「Normal は法定上限より手前でノックする」という順序も固定した — 説明文の意味は
順序に乗っているので、逆転したら説明が嘘になる。

**変異テスト（実測）**:

| 変異 | 検知 |
|---|---|
| `GinRummyKnockDeadwoodHard` を 8 に変える | ✔ phases.ts が古いと報告 |
| Hard を Normal より甘く (9) する | ✔ 順序の assert が落ちる |
| 選択肢を素の Easy/Normal/Hard に戻す | ✔ ページのテストが落ちる |

Closes #5500