### PR TITLE
feat(indianrummy): show the card-point legend next to the deadwood

### DIFF
--- a/frontend/src/i18n/locales/en/indianrummy.json
+++ b/frontend/src/i18n/locales/en/indianrummy.json
@@ -63,5 +63,6 @@
     "scoreTable": "Player scores are shown here. Lowest cumulative total wins.",
     "resetButton": "Press the reset button to start a new game."
   },
-  "pureSequenceMissing": "No pure seq."
+  "pureSequenceMissing": "No pure seq.",
+  "pointsLegend": "Points: A, 10, J, Q, K = 10 / 2-9 = face value / wild = 0"
 }

--- a/frontend/src/i18n/locales/ja/indianrummy.json
+++ b/frontend/src/i18n/locales/ja/indianrummy.json
@@ -63,5 +63,6 @@
     "scoreTable": "各プレイヤーのスコアが表示されます。累計最少が勝利です。",
     "resetButton": "リセットボタンで新しいゲームを始められます。"
   },
-  "pureSequenceMissing": "純シーケンス無し"
+  "pureSequenceMissing": "純シーケンス無し",
+  "pointsLegend": "点数: A・10・J・Q・K = 10点 / 2〜9 = 数字どおり / ワイルド = 0点"
 }

--- a/frontend/src/pages/IndianRummyPage.test.tsx
+++ b/frontend/src/pages/IndianRummyPage.test.tsx
@@ -692,3 +692,18 @@ describe('IndianRummyPage', () => {
     expect(screen.queryByTestId('indianrummy-hand-status')).not.toBeInTheDocument();
   });
 });
+
+// #5501: 表示されるのは合計の未メルド点数だけで、なぜその数字になるのかを
+// 個々のカードから逆算する手掛かりが無かった。
+describe('IndianRummyPage points legend', () => {
+  it('shows the card-point legend next to the deadwood readout', async () => {
+    mockExec.mockResolvedValue(discardPhaseState);
+    renderWithProviders(<IndianRummyPage />);
+    const legend = await screen.findByTestId('indianrummy-points-legend');
+    // **A が 10 点であることが読み取れること。** ここが標準のジンラミー系と違う。
+    expect(legend.textContent).toMatch(/A/);
+    expect(legend.textContent).toMatch(/10/);
+    // ワイルドが 0 点であることも同じ行で言う (tutorial.wildJoker と矛盾しない)。
+    expect(legend.textContent).toMatch(/0/);
+  });
+});

--- a/frontend/src/pages/IndianRummyPage.tsx
+++ b/frontend/src/pages/IndianRummyPage.tsx
@@ -426,6 +426,12 @@ function IndianRummyPageContent() {
                 <span className={`ml-2 ${humanPlayer.hasPureSequence ? 'text-ds-success' : 'text-ds-warning'}`}>
                   {humanPlayer.hasPureSequence ? t('pureSequenceBadge') : t('pureSequenceMissing')}
                 </span>
+                {/* **A も 10 点。** ジンラミー系に慣れたプレイヤーほど A=1 を
+                    期待するので、合計だけ見せられると数字を逆算できない。
+                    ワイルドが 0 点であることも同時に言う (#5501)。 */}
+                <div className="text-xs" data-testid="indianrummy-points-legend">
+                  {t('pointsLegend')}
+                </div>
               </div>
             )}
 

--- a/frontend/src/utils/indianRummyDeclare.test.ts
+++ b/frontend/src/utils/indianRummyDeclare.test.ts
@@ -217,3 +217,28 @@ describe('evaluateIndianRummyDeclare', () => {
     expect(p.penalty).toBe(INDIAN_RUMMY_DEADWOOD_CAP);
   });
 });
+
+// #5501: 手札に出るのは合計のデッドウッドだけで、点数基準そのものはどこにも
+// 書かれていなかった。**A も 10 点**という、ジンラミー系に慣れたプレイヤーほど
+// 意外に感じる仕様なので、画面に凡例を出した。その凡例が主張する内容を、
+// 実装から機械的に確かめる — 関数を変えたら凡例が嘘になる。
+describe('indianRummyCardPoints backs the on-screen legend', () => {
+  const WILD = 5;
+  const card = (value: number, design = 'SPADE'): Card => ({ design, value }) as Card;
+
+  it('scores A, 10, J, Q and K as ten', () => {
+    for (const v of [1, 10, 11, 12, 13]) {
+      expect(indianRummyCardPoints(card(v), WILD)).toBe(10);
+    }
+  });
+
+  it('scores 2 through 9 at face value', () => {
+    for (const v of [2, 3, 4, 6, 7, 8, 9]) {
+      expect(indianRummyCardPoints(card(v), WILD)).toBe(v);
+    }
+  });
+
+  it('scores a wild at zero', () => {
+    expect(indianRummyCardPoints(card(WILD), WILD)).toBe(0);
+  });
+});


### PR DESCRIPTION
## 背景

`indianRummyCardPoints` はワイルド以外について **A も 10/J/Q/K と同じ 10 点**として
扱う（2〜9 はピップ値）。標準的なジンラミー系（多くは A=1 点）に慣れたプレイヤーには
意外な仕様。

画面に出るのは合計の未メルド点数 (`declarePreview.unmelded`) だけで、
**なぜその数字になるのかを個々のカードから逆算する手掛かりが無い。**
チュートリアルにも点数基準は一度も出てこない。

## 変更

デッドウッド表示 (`indianrummy-hand-status`) の直下に凡例を出す:

> 点数: A・10・J・Q・K = 10点 / 2〜9 = 数字どおり / ワイルド = 0点

ワイルドが 0 点であることも同じ行で言うので、`tutorial.wildJoker` と矛盾しない
（受け入れ条件 3）。

## 凡例が実装と一致していることを確かめる

文言を足すだけでは、あとから点数計算が変わったときに黙って嘘になる。
`indianRummyCardPoints` に対して**凡例が主張する3点をそれぞれ assert** した:
A/10/J/Q/K は 10、2〜9 は数字どおり、ワイルドは 0。

**変異テスト（実測）**:

| 変異 | 落ちたテスト |
|---|---|
| A を 1 点にする（凡例が嘘になる） | 4 |
| 凡例そのものを消す | 1 |

Closes #5501