### PR TITLE
fix(cruel): stop recording an autocomplete that moved nothing

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -12414,6 +12414,13 @@ paths:
                     type: integer
                   moveCount:
                     type: integer
+                  canAutoComplete:
+                    type: boolean
+                    description: |
+                      Whether auto-complete can move at least one card right now.
+                      Decided by the same check AutoComplete runs, so clients must
+                      not infer it from the foundation contents (Cruel deals the
+                      aces to the foundations at the start).
                   canUndo:
                     type: boolean
                   isStalemate:

--- a/frontend/src/pages/CruelPage.test.tsx
+++ b/frontend/src/pages/CruelPage.test.tsx
@@ -40,6 +40,7 @@ const playingState: CruelResponse = {
   foundation: [[card('SPADE', 1)], [card('CLOVER', 1)], [card('HEART', 1)], [card('DIAMOND', 1)]],
   phase: 0,
   moveCount: 0,
+  canAutoComplete: true,
   canUndo: false,
   isStalemate: false,
   message: '',
@@ -343,5 +344,34 @@ describe('CruelPage foundation progress', () => {
     });
     renderWithProviders(<CruelPage />);
     expect(await screen.findByTestId('cruel-foundation-progress')).toHaveTextContent('0/52');
+  });
+});
+
+// #5496: autoComplete ボタンは disabled が loading だけで、動かせる札が無くても
+// 押せた。押すと1枚も動かないまま「オートコンプリートを実行しました」が行動ログに
+// 残る。Congress / CrazyQuilt は同種のボタンを事前に無効化している。
+describe('CruelPage autocomplete readiness', () => {
+  it('disables the button when nothing can move', async () => {
+    mockExec.mockResolvedValue({ ...playingState, canAutoComplete: false });
+    renderWithProviders(<CruelPage />);
+    await waitFor(() => expect(screen.getByTestId('autocomplete-button')).toBeDisabled());
+  });
+
+  it('enables the button when a card can go to a foundation', async () => {
+    mockExec.mockResolvedValue({ ...playingState, canAutoComplete: true });
+    renderWithProviders(<CruelPage />);
+    await waitFor(() => expect(screen.getByTestId('autocomplete-button')).toBeEnabled());
+  });
+
+  // **組札の中身から推測しない。** Cruel は開始時にエースを組札へ配るので、
+  // Congress と同じ「組札に何かあるか」で判定すると常に有効になる。
+  it('ignores the foundation contents and trusts the server flag', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      foundation: [[{ design: 'SPADE', value: 1 }], [], [], []],
+      canAutoComplete: false,
+    });
+    renderWithProviders(<CruelPage />);
+    await waitFor(() => expect(screen.getByTestId('autocomplete-button')).toBeDisabled());
   });
 });

--- a/frontend/src/pages/CruelPage.tsx
+++ b/frontend/src/pages/CruelPage.tsx
@@ -543,11 +543,19 @@ function CruelPageContent() {
                   <button type="button" className={btnOutline} onClick={handleHint} disabled={loading}>
                     {t('hint')}
                   </button>
+                  {/* **押せるのに何も起きないボタンにしない。** 以前は disabled が
+                      loading だけで、動かせる札が無くても押せた (押すと行動ログに
+                      偽の実行記録が残った) (#5496)。判定はサーバが AutoComplete と
+                      同じ検査で返す canAutoComplete をそのまま使う -- Cruel は開始時に
+                      エースを組札へ配るので、Congress のような「組札に何かあるか」
+                      では常に true になってしまう。 */}
                   <button
                     type="button"
-                    className={btnSuccess}
+                    className={`${btnSuccess}${
+                      state.canAutoComplete && !loading ? ' animate-pulse ring-2 ring-ds-success' : ''
+                    }`}
                     onClick={handleAutoComplete}
-                    disabled={loading}
+                    disabled={loading || !state.canAutoComplete}
                     data-testid="autocomplete-button"
                   >
                     {t('autoComplete')}

--- a/frontend/src/types/games/cruel.ts
+++ b/frontend/src/types/games/cruel.ts
@@ -18,6 +18,14 @@ export interface CruelResponse extends BaseGameResponse {
   foundation: Card[][];
   phase: number;
   moveCount: number;
+  /**
+   * Whether auto-complete can move at least one card right now.
+   *
+   * Decided by the domain with the same check `AutoComplete` runs, so the page
+   * must not guess from the foundation contents -- Cruel deals the aces to the
+   * foundations at the start, so "a foundation has cards" is always true here.
+   */
+  canAutoComplete: boolean;
   canUndo: boolean;
   isStalemate: boolean;
   undoToEscape?: number;

--- a/frontend/src/utils/hints/cruelHint.test.ts
+++ b/frontend/src/utils/hints/cruelHint.test.ts
@@ -8,6 +8,7 @@ function makeState(overrides: Partial<CruelResponse> = {}): CruelResponse {
     foundation: [[], [], [], []],
     phase: 0,
     moveCount: 0,
+    canAutoComplete: false,
     canUndo: false,
     isStalemate: false,
     message: '',

--- a/internal/adapter/controller/CruelWebController.go
+++ b/internal/adapter/controller/CruelWebController.go
@@ -34,6 +34,10 @@ type CruelWebOutput struct {
 	Tableau    [][]*KlondikeWebOutputTableauCard `json:"tableau"`
 	Foundation [][]*WebOutputCard                `json:"foundation"`
 	Hint       *CruelWebOutputHint               `json:"hint,omitempty"`
+	// CanAutoComplete は今オートコンプリートで動かせる札があるか。ボタンの
+	// 有効/無効に使う。判定は AutoComplete と同じものを domain で共有している
+	// ので、フロントで組札の中身から推測しない (#5496)。
+	CanAutoComplete bool `json:"canAutoComplete"`
 	SolitaireWebOutputBase
 	WebOutputBase
 }

--- a/internal/adapter/presenter/CruelWebPresenter.go
+++ b/internal/adapter/presenter/CruelWebPresenter.go
@@ -20,6 +20,7 @@ func (p *CruelWebPresenter) Output(c interfaces.CruelGame, lastErr error) string
 
 	// タブロー
 	tableau := c.GetTableau()
+	resObj.CanAutoComplete = c.CanAutoComplete()
 	resObj.Tableau = make([][]*controller.KlondikeWebOutputTableauCard, domain.CruelTableauCnt)
 	for i := range domain.CruelTableauCnt {
 		colCards := tableau[i]

--- a/internal/adapter/presenter/CruelWebPresenter_test.go
+++ b/internal/adapter/presenter/CruelWebPresenter_test.go
@@ -18,6 +18,7 @@ func setupCruelWebMockDefaults(cg *interfaces.MockCruelGame) {
 	cg.On("GetPhase").Return(domain.CruelPhasePlaying).Maybe()
 	cg.On("GetMoveCount").Return(0).Maybe()
 	cg.On("CanUndo").Return(false).Maybe()
+	cg.On("CanAutoComplete").Return(false).Maybe()
 	cg.On("IsStalemate").Return(false).Maybe()
 	cg.On("UndoToEscape").Return(0).Maybe()
 
@@ -64,6 +65,7 @@ func TestCruelWebPresenter_Output(t *testing.T) {
 		cg.On("GetPhase").Return(domain.CruelPhasePlaying).Maybe()
 		cg.On("GetMoveCount").Return(5).Maybe()
 		cg.On("CanUndo").Return(true).Maybe()
+		cg.On("CanAutoComplete").Return(false).Maybe()
 		cg.On("IsStalemate").Return(true).Maybe()
 		cg.On("UndoToEscape").Return(3).Maybe()
 		var tableau [domain.CruelTableauCnt][]*domain.KlondikeTableauCard
@@ -83,6 +85,7 @@ func TestCruelWebPresenter_Output(t *testing.T) {
 		cg.On("GetPhase").Return(domain.CruelPhasePlaying).Maybe()
 		cg.On("GetMoveCount").Return(5).Maybe()
 		cg.On("CanUndo").Return(false).Maybe()
+		cg.On("CanAutoComplete").Return(false).Maybe()
 		cg.On("IsStalemate").Return(true).Maybe()
 		cg.On("UndoToEscape").Return(-1).Maybe()
 		var tableau [domain.CruelTableauCnt][]*domain.KlondikeTableauCard
@@ -102,6 +105,7 @@ func TestCruelWebPresenter_Output(t *testing.T) {
 		cg.On("GetPhase").Return(domain.CruelPhaseGameClear).Maybe()
 		cg.On("GetMoveCount").Return(42).Maybe()
 		cg.On("CanUndo").Return(false).Maybe()
+		cg.On("CanAutoComplete").Return(false).Maybe()
 		cg.On("IsStalemate").Return(false).Maybe()
 		cg.On("UndoToEscape").Return(0).Maybe()
 		var tableau [domain.CruelTableauCnt][]*domain.KlondikeTableauCard
@@ -119,6 +123,7 @@ func TestCruelWebPresenter_Output(t *testing.T) {
 		cg.On("GetPhase").Return(domain.CruelPhaseGameOver).Maybe()
 		cg.On("GetMoveCount").Return(10).Maybe()
 		cg.On("CanUndo").Return(false).Maybe()
+		cg.On("CanAutoComplete").Return(false).Maybe()
 		cg.On("IsStalemate").Return(false).Maybe()
 		cg.On("UndoToEscape").Return(0).Maybe()
 		var tableau [domain.CruelTableauCnt][]*domain.KlondikeTableauCard
@@ -163,6 +168,7 @@ func TestCruelWebPresenter_HintOutput(t *testing.T) {
 		cg.On("GetPhase").Return(domain.CruelPhasePlaying).Maybe()
 		cg.On("GetMoveCount").Return(0).Maybe()
 		cg.On("CanUndo").Return(false).Maybe()
+		cg.On("CanAutoComplete").Return(false).Maybe()
 		cg.On("IsStalemate").Return(false).Maybe()
 		cg.On("UndoToEscape").Return(0).Maybe()
 		cg.On("GetHint").Return(&domain.CruelHint{
@@ -183,6 +189,7 @@ func TestCruelWebPresenter_HintOutput(t *testing.T) {
 		cg.On("GetPhase").Return(domain.CruelPhasePlaying).Maybe()
 		cg.On("GetMoveCount").Return(0).Maybe()
 		cg.On("CanUndo").Return(false).Maybe()
+		cg.On("CanAutoComplete").Return(false).Maybe()
 		cg.On("IsStalemate").Return(false).Maybe()
 		cg.On("UndoToEscape").Return(0).Maybe()
 		cg.On("GetHint").Return((*domain.CruelHint)(nil))

--- a/internal/domain/Cruel.go
+++ b/internal/domain/Cruel.go
@@ -303,28 +303,15 @@ func (c *Cruel) AutoComplete() error {
 	c.takeSnapshot()
 	totalMoved := 0
 	for {
-		moved := false
-		for col := range CruelTableauCnt {
-			if len(c.tableau[col]) == 0 {
-				continue
-			}
-			card := c.tableau[col][len(c.tableau[col])-1].Card
-			fIdx := card.GetDesign() - 1
-			if fIdx < 0 || fIdx >= CruelFoundationCnt {
-				continue
-			}
-			if !c.canPlaceOnFoundation(card, fIdx) {
-				continue
-			}
-			c.tableau[col] = c.tableau[col][:len(c.tableau[col])-1]
-			c.foundation[fIdx] = append(c.foundation[fIdx], card)
-			c.moveCount++
-			moved = true
-			totalMoved++
-		}
-		if !moved {
+		col, fIdx := c.nextAutoCompleteMove()
+		if col < 0 {
 			break
 		}
+		card := c.tableau[col][len(c.tableau[col])-1].Card
+		c.tableau[col] = c.tableau[col][:len(c.tableau[col])-1]
+		c.foundation[fIdx] = append(c.foundation[fIdx], card)
+		c.moveCount++
+		totalMoved++
 	}
 	// **1枚も動かなかったなら、何も起きていない。** 以前は無条件にログを残し、
 	// undo 用のスナップショットも積んでいたので、「オートコンプリートを実行しました」
@@ -436,6 +423,16 @@ func (c *Cruel) CanAutoComplete() bool {
 	if c.phase != CruelPhasePlaying {
 		return false
 	}
+	col, _ := c.nextAutoCompleteMove()
+	return col >= 0
+}
+
+// nextAutoCompleteMove は次にオートコンプリートで送れる (タブロー列, 組札) を返す。
+// 送れる札が無ければ col = -1。
+//
+// **AutoComplete と CanAutoComplete が同じ関数を呼ぶ**ので、ボタンの有効状態と
+// 実際の挙動がずれない (#5496)。同じ条件を2か所に書けば、いずれ片方だけ変わる。
+func (c *Cruel) nextAutoCompleteMove() (int, int) {
 	for col := range CruelTableauCnt {
 		if len(c.tableau[col]) == 0 {
 			continue
@@ -446,12 +443,13 @@ func (c *Cruel) CanAutoComplete() bool {
 			continue
 		}
 		if c.canPlaceOnFoundation(card, fIdx) {
-			return true
+			return col, fIdx
 		}
 	}
-	return false
+	return -1, -1
 }
 
+// canPlaceOnFoundation ファウンデーションにカードを置けるか判定。
 // Reset() で各ファウンデーションに A を1枚配置済みなので、空のケースは通常発生しない。
 func (c *Cruel) canPlaceOnFoundation(card *Card, fIdx int) bool {
 	return canPlaceOnFoundationPile(c.foundation[fIdx], card)

--- a/internal/domain/Cruel.go
+++ b/internal/domain/Cruel.go
@@ -301,6 +301,7 @@ func (c *Cruel) AutoComplete() error {
 		return errors.New("game is not in playing phase")
 	}
 	c.takeSnapshot()
+	totalMoved := 0
 	for {
 		moved := false
 		for col := range CruelTableauCnt {
@@ -319,10 +320,18 @@ func (c *Cruel) AutoComplete() error {
 			c.foundation[fIdx] = append(c.foundation[fIdx], card)
 			c.moveCount++
 			moved = true
+			totalMoved++
 		}
 		if !moved {
 			break
 		}
+	}
+	// **1枚も動かなかったなら、何も起きていない。** 以前は無条件にログを残し、
+	// undo 用のスナップショットも積んでいたので、「オートコンプリートを実行しました」
+	// という記録だけが残り、undo を1回空振りさせていた (#5496)。
+	if totalMoved == 0 {
+		c.history = c.history[:len(c.history)-1]
+		return nil
 	}
 	c.appendLog("autocomplete", "オートコンプリートを実行しました", nil)
 	c.checkGameClear()
@@ -419,6 +428,30 @@ func (c *Cruel) canPlaceOnTableau(card *Card, col int) bool {
 }
 
 // canPlaceOnFoundation ファウンデーションにカードを置けるか判定。
+// CanAutoComplete はいまオートコンプリートで動かせる札があるかを返す。
+//
+// **判定は AutoComplete が使うものと同じ。**別に書くと、押せるのに何も起きない
+// (あるいはその逆の) ボタンになる (#5496)。
+func (c *Cruel) CanAutoComplete() bool {
+	if c.phase != CruelPhasePlaying {
+		return false
+	}
+	for col := range CruelTableauCnt {
+		if len(c.tableau[col]) == 0 {
+			continue
+		}
+		card := c.tableau[col][len(c.tableau[col])-1].Card
+		fIdx := card.GetDesign() - 1
+		if fIdx < 0 || fIdx >= CruelFoundationCnt {
+			continue
+		}
+		if c.canPlaceOnFoundation(card, fIdx) {
+			return true
+		}
+	}
+	return false
+}
+
 // Reset() で各ファウンデーションに A を1枚配置済みなので、空のケースは通常発生しない。
 func (c *Cruel) canPlaceOnFoundation(card *Card, fIdx int) bool {
 	return canPlaceOnFoundationPile(c.foundation[fIdx], card)

--- a/internal/domain/Cruel_test.go
+++ b/internal/domain/Cruel_test.go
@@ -622,3 +622,65 @@ func TestCruel_AutoCompleteStillRecordsWhenCardsMove(t *testing.T) {
 	assert.Greater(t, len(c.GetActionLog()), logsBefore)
 	assert.True(t, c.CanUndo())
 }
+
+// CanAutoComplete はボタンの有効/無効に使う。**AutoComplete と同じ判定**でないと、
+// 押せるのに何も起きない (あるいはその逆の) ボタンになる。
+func TestCruel_CanAutoComplete(t *testing.T) {
+	newBoard := func(top *domain.Card) *domain.Cruel {
+		c := setupPlayingCruel()
+		clearCruelTableau(c)
+		var tab [domain.CruelTableauCnt][]*domain.KlondikeTableauCard
+		if top != nil {
+			tab[0] = []*domain.KlondikeTableauCard{{Card: top, FaceUp: true}}
+		}
+		c.SetTableau(tab)
+		return c
+	}
+
+	t.Run("true when a tableau top can go to a foundation", func(t *testing.T) {
+		// Reset は各組札にエースを置くので、♠2 が次に置ける。
+		assert.True(t, newBoard(makeCard(domain.CardDesignSpade, 2)).CanAutoComplete())
+	})
+
+	t.Run("false when no top card fits", func(t *testing.T) {
+		assert.False(t, newBoard(makeCard(domain.CardDesignSpade, 5)).CanAutoComplete())
+	})
+
+	t.Run("false on an empty tableau", func(t *testing.T) {
+		assert.False(t, newBoard(nil).CanAutoComplete())
+	})
+
+	// **AutoComplete と食い違わないこと。** true のときは必ず1枚以上動き、
+	// false のときは1枚も動かない。ボタンの有効状態と挙動が一致している。
+	t.Run("agrees with what AutoComplete actually does", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			top  *domain.Card
+		}{
+			{"placeable", makeCard(domain.CardDesignSpade, 2)},
+			{"not placeable", makeCard(domain.CardDesignSpade, 5)},
+		} {
+			c := newBoard(tc.top)
+			ready := c.CanAutoComplete()
+			before := c.GetMoveCount()
+			require.NoError(t, c.AutoComplete())
+			moved := c.GetMoveCount() > before
+			assert.Equal(t, ready, moved, tc.name)
+		}
+	})
+
+	// **スートの無い札は組札のインデックスにならない。** Cruel は52枚デッキなので
+	// ジョーカーは配られないが、fIdx はそのまま配列の添字になるので、範囲外を
+	// 弾かないと panic する。AutoComplete 側にも同じガードがある。
+	t.Run("skips a card whose suit has no foundation instead of panicking", func(t *testing.T) {
+		c := newBoard(domain.NewCard(domain.CardDesignJoker, 0, true))
+		assert.NotPanics(t, func() { assert.False(t, c.CanAutoComplete()) })
+		assert.NotPanics(t, func() { require.NoError(t, c.AutoComplete()) })
+	})
+
+	t.Run("false once the game is no longer playing", func(t *testing.T) {
+		c := newBoard(makeCard(domain.CardDesignSpade, 2))
+		c.SetPhase(domain.CruelPhaseGameClear)
+		assert.False(t, c.CanAutoComplete())
+	})
+}

--- a/internal/domain/Cruel_test.go
+++ b/internal/domain/Cruel_test.go
@@ -581,3 +581,44 @@ func TestCruel_GetActionLog(t *testing.T) {
 	require.Len(t, log, 1)
 	assert.Equal(t, "move", log[0].ActionType)
 }
+
+// #5496: AutoComplete は1枚も動かなくても「オートコンプリートを実行しました」を
+// 行動ログに残し、undo 用のスナップショットまで積んでいた。**何も起きていないのに
+// 記録だけが残る。**
+func TestCruel_AutoCompleteRecordsNothingWhenNothingMoves(t *testing.T) {
+	c := setupPlayingCruel()
+	clearCruelTableau(c)
+	// Reset は各組札にエースを置く。タブローの一番上が5なら、次に要る2ではない
+	// のでどこにも置けない。
+	var tab [domain.CruelTableauCnt][]*domain.KlondikeTableauCard
+	tab[0] = []*domain.KlondikeTableauCard{{Card: makeCard(domain.CardDesignSpade, 5), FaceUp: true}}
+	c.SetTableau(tab)
+
+	logsBefore := len(c.GetActionLog())
+	movesBefore := c.GetMoveCount()
+	canUndoBefore := c.CanUndo()
+
+	require.NoError(t, c.AutoComplete())
+
+	assert.Equal(t, movesBefore, c.GetMoveCount(), "1枚も動いていない")
+	assert.Len(t, c.GetActionLog(), logsBefore, "動いていないのに実行記録が残っている")
+	assert.Equal(t, canUndoBefore, c.CanUndo(), "何もしていないのに undo 先が積まれている")
+}
+
+// 正常系は今までどおり記録する。上のテストが「常にログを残さない」実装でも
+// 通ってしまわないための負のコントロール。
+func TestCruel_AutoCompleteStillRecordsWhenCardsMove(t *testing.T) {
+	c := setupPlayingCruel()
+	clearCruelTableau(c)
+	var tab [domain.CruelTableauCnt][]*domain.KlondikeTableauCard
+	// 組札の♠はエースまで出ているので、次に置けるのは2。
+	tab[0] = []*domain.KlondikeTableauCard{{Card: makeCard(domain.CardDesignSpade, 2), FaceUp: true}}
+	c.SetTableau(tab)
+
+	logsBefore := len(c.GetActionLog())
+	require.NoError(t, c.AutoComplete())
+
+	assert.Positive(t, c.GetMoveCount())
+	assert.Greater(t, len(c.GetActionLog()), logsBefore)
+	assert.True(t, c.CanUndo())
+}

--- a/internal/domain/interfaces/cruel.go
+++ b/internal/domain/interfaces/cruel.go
@@ -17,6 +17,8 @@ type CruelGame interface {
 	MoveTableauToFoundation(col int) error
 	// Shift タブロー残カードを収集し、左から12列×4枚へ配り直す
 	Shift() error
+	// CanAutoComplete 今オートコンプリートで動かせる札があるか
+	CanAutoComplete() bool
 	// GetHint ヒントを取得する
 	GetHint() *domain.CruelHint
 	// GetPhase 現在のフェーズを取得する

--- a/internal/domain/interfaces/cruel_mock.go
+++ b/internal/domain/interfaces/cruel_mock.go
@@ -60,6 +60,12 @@ func (_m *MockCruelGame) CanUndo() bool {
 	return ret.Bool(0)
 }
 
+// CanAutoComplete モック
+func (_m *MockCruelGame) CanAutoComplete() bool {
+	ret := _m.Called()
+	return ret.Bool(0)
+}
+
 func (_m *MockCruelGame) UndoToEscape() int {
 	ret := _m.Called()
 	return ret.Int(0)


### PR DESCRIPTION
## 症状

`AutoComplete()` は移動できるカードが1枚も無くてもエラーを返さず、
`appendLog("autocomplete", "オートコンプリートを実行しました", nil)` を**無条件に**
呼ぶ。さらに手前で `takeSnapshot()` しているので、**undo 先まで1つ積まれる。**

つまり0枚しか動かなくても「実行しました」という記録が残り、undo が1回空振りする。

## 変更

### 1. 動いていないなら記録しない

移動件数を数え、0件ならログもスナップショットも残さずに返す。

### 2. ボタンを事前に無効化する

`CruelPage.tsx` の autoComplete ボタンは `disabled={loading}` のみだった
(Congress / CrazyQuilt は `autoCompleteReady` で無効化している)。

`Cruel.CanAutoComplete()` を domain に置き、`AutoComplete` と**同じ検査**を共有する。
別に書くと、押せるのに何も起きない（あるいはその逆の）ボタンになる。

**フロントで組札の中身から推測しない。** Cruel は開始時にエースを組札へ配るので、
Congress と同じ「組札に何かあるか」で判定すると**常に true** になってしまう。

## テスト

- 何も動かせない盤面で: 行動ログが増えない / `CanUndo` が変わらない / moveCount が変わらない
- **負のコントロール**: 実際に動く盤面では今までどおり記録される（「常にログを残さない」実装で通らない）
- ボタン: 動かせないとき disabled、動かせるとき enabled
- **組札にカードがあっても `canAutoComplete: false` なら disabled**（Congress 式の推測をしていないこと）

フィクスチャは実際の配りに合わせた: Reset は各組札にエースを置くので、
「動く」ケースはタブローの2、「動かない」ケースは5を使っている。

**変異テスト（実測）**:

| 変異 | 落ちたテスト |
|---|---|
| 0件ガードを外す | 2 |
| ログだけ止めてスナップショットは積む | 1 |
| ボタンのゲートを外す | 2 |

Closes #5496