### PR TITLE
feat(napoleon): show the target score during play

### DIFF
--- a/frontend/src/i18n/locales/en/napoleon.json
+++ b/frontend/src/i18n/locales/en/napoleon.json
@@ -120,5 +120,6 @@
     "resetButton": "Press the reset button to start a new game."
   },
   "hintRequested": "Hint available",
-  "noHint": "No hint available"
+  "noHint": "No hint available",
+  "pointLimitLine": "Target: game ends at ±{{limit}} points"
 }

--- a/frontend/src/i18n/locales/ja/napoleon.json
+++ b/frontend/src/i18n/locales/ja/napoleon.json
@@ -120,5 +120,6 @@
     "resetButton": "リセットボタンで新しいゲームを始められます。"
   },
   "hintRequested": "ヒントがあります",
-  "noHint": "ヒントはありません"
+  "noHint": "ヒントはありません",
+  "pointLimitLine": "目標: ±{{limit}}点で決着"
 }

--- a/frontend/src/pages/NapoleonPage.test.tsx
+++ b/frontend/src/pages/NapoleonPage.test.tsx
@@ -1157,3 +1157,23 @@ describe('NapoleonPage', () => {
     }
   });
 });
+
+// #5504: 目標点数は開始前の設定でしか見えず、対局中は Settings を開き直さない限り
+// あと何点で決着するのか分からなかった。
+describe('NapoleonPage point limit', () => {
+  it('shows the configured target during play', async () => {
+    mockExec.mockResolvedValue({ ...playPhaseState, config: { ...playPhaseState.config, pointLimit: 75 } });
+    renderWithProviders(<NapoleonPage />);
+    const line = await screen.findByTestId('np-point-limit');
+    expect(line.textContent).toContain('75');
+  });
+
+  // **設定値を出していること。** 定数を書いているだけなら、変えても表示が動かない。
+  it('follows a settings change', async () => {
+    mockExec.mockResolvedValue({ ...playPhaseState, config: { ...playPhaseState.config, pointLimit: 30 } });
+    renderWithProviders(<NapoleonPage />);
+    const line = await screen.findByTestId('np-point-limit');
+    expect(line.textContent).toContain('30');
+    expect(line.textContent).not.toContain('75');
+  });
+});

--- a/frontend/src/pages/NapoleonPage.tsx
+++ b/frontend/src/pages/NapoleonPage.tsx
@@ -473,6 +473,14 @@ function NapoleonPageContent() {
                     ))
                 )}
 
+                {/* **あと何点で決着するのかが対局中どこにも出ていなかった。**
+                    目標点数は開始前の設定でしか見えず、思い出すには Settings を
+                    開き直すしかなかった (#5504)。設定値はレスポンスに載っているので
+                    そのまま出す。 */}
+                <div className="text-ds-text-muted text-xs mt-2" data-testid="np-point-limit">
+                  {t('pointLimitLine', { limit: state.config.pointLimit })}
+                </div>
+
                 {/* Score table */}
                 {isMobile ? (
                   <details

--- a/internal/adapter/presenter/NapoleonCuiPresenter.go
+++ b/internal/adapter/presenter/NapoleonCuiPresenter.go
@@ -78,6 +78,11 @@ func (p *NapoleonCuiPresenter) Output(n interfaces.NapoleonGame, lastErr error) 
 			"trick", strconv.Itoa(n.GetTrickNumber())))
 		b.WriteString("\n")
 
+		// **あと何点で決着するのかを対局中に出す。** 目標点数は設定でしか見えず、
+		// round/trick は出るのに到達条件だけが出ていなかった (#5504)。
+		b.WriteString(i18n.Tf("napoleon.pointLimitLine",
+			"limit", strconv.Itoa(n.GetConfig().PointLimit)) + "\n")
+
 		if n.GetTrumpSuit() > 0 {
 			b.WriteString(i18n.Tf("napoleon.trump", "suit", napoleonSuitGlyphs[n.GetTrumpSuit()]))
 			b.WriteString("\n")

--- a/internal/adapter/presenter/NapoleonCuiPresenter_test.go
+++ b/internal/adapter/presenter/NapoleonCuiPresenter_test.go
@@ -620,3 +620,33 @@ func TestNapoleonCuiPresenter_English(t *testing.T) {
 		assert.Contains(t, result, "p <idx>")
 	})
 }
+
+// #5504: 目標点数は開始前の設定でしか見えず、対局中は round/trick は出るのに
+// 到達条件だけが出ていなかった。**あと何点で決着するのかを知るには Settings を
+// 開き直すしかない。**
+func TestNapoleonCuiPresenter_PointLimitLine(t *testing.T) {
+	p := new(presenter.NapoleonCuiPresenter)
+
+	t.Run("shows the configured target", func(t *testing.T) {
+		n := domain.NewDefaultNapoleon()
+		n.Reset()
+		cfg := n.GetConfig()
+		cfg.PointLimit = 75
+		n.SetConfig(cfg)
+
+		assert.Contains(t, p.Output(n, nil), i18n.Tf("napoleon.pointLimitLine", "limit", "75"))
+	})
+
+	// **設定値を出していること。** 定数を書いているだけなら、変えても表示が動かない。
+	t.Run("follows a settings change", func(t *testing.T) {
+		n := domain.NewDefaultNapoleon()
+		n.Reset()
+		cfg := n.GetConfig()
+		cfg.PointLimit = 30
+		n.SetConfig(cfg)
+
+		out := p.Output(n, nil)
+		assert.Contains(t, out, i18n.Tf("napoleon.pointLimitLine", "limit", "30"))
+		assert.NotContains(t, out, i18n.Tf("napoleon.pointLimitLine", "limit", "75"))
+	})
+}

--- a/internal/i18n/locales/en/napoleon.json
+++ b/internal/i18n/locales/en/napoleon.json
@@ -46,5 +46,6 @@
   "hintReasonPlayJoker": "play the joker",
   "hintReasonDiscardLow": "discard a low card",
   "helpExamplePlay": "  p 0                  play hand card 0",
-  "helpHint": "  h                    show a hint"
+  "helpHint": "  h                    show a hint",
+  "pointLimitLine": "Target: game ends at ±{{limit}} points"
 }

--- a/internal/i18n/locales/ja/napoleon.json
+++ b/internal/i18n/locales/ja/napoleon.json
@@ -46,5 +46,6 @@
   "hintReasonPlayJoker": "ジョーカーをプレイ",
   "hintReasonDiscardLow": "低いカードを捨てる",
   "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す",
-  "helpHint": "  h                    助言を表示"
+  "helpHint": "  h                    助言を表示",
+  "pointLimitLine": "目標: ±{{limit}}点で決着"
 }


### PR DESCRIPTION
## 背景

`checkGameEnd` は誰かの `cumulativeScore` が **±`config.PointLimit`** に達した時点で
終局する。目標点数は対局開始前の `SettingsPanel` で選べるが、**対局中はどこにも
再表示されない。**

- スコア表 (`np-score-table`) は各プレイヤーの合計を出すだけ
- `NapoleonCuiPresenter.Output` は round / trick / bid / scores を出すのに `PointLimit` には触れない

つまり「あと何点で決着するのか」を知るには、Settings を開き直して自分が選んだ数値を
思い出すしかなかった。

## 変更

- **Web**: スコア表の直前に1行（BID / PLAY / ROUND_END のいずれでも出る位置）
- **CUI**: round 行の直後に1行

どちらもレスポンス / 設定の値をそのまま使うので、リセットで設定を変えれば表示も
追随する（受け入れ条件 3）。

## テスト

CUI・Web とも、**設定値を変えると表示も変わること**を確認する（75 → 30）。
定数を書いているだけの実装では落ちる。

**変異テスト（実測）**:

| 変異 | 落ちたテスト |
|---|---|
| CUI が 50 固定を出す | 2 |
| ページが 50 固定を出す | 2 |

ja / en 両ロケール（CUI・Web それぞれ）に追加。

Closes #5504