### PR TITLE
feat(jokerpoker): show the current made hand in the CUI

### DIFF
--- a/internal/adapter/presenter/VideoPokerCuiPresenter.go
+++ b/internal/adapter/presenter/VideoPokerCuiPresenter.go
@@ -47,6 +47,19 @@ func (vpp *VideoPokerCuiPresenter) Output(vp interfaces.VideoPokerGame, lastErr 
 		sb.WriteString(vpp.paytableStr(vp.GetVariantName()))
 	}
 
+	// **いま何の役になっているかをドロー中に出す。** Web は vp-made-hand で
+	// リアルタイムに見せているのに、CUI は手札とホールド推奨しか出しておらず、
+	// 配当対象かどうかはプレイヤーが自分で判定するしかなかった (#5508)。
+	// 評価はバリアント自身の GetResult を通すので、3変種とも下限がずれない。
+	if vp.GetPhase() == domain.VideoPokerPhaseDraw {
+		if key := vp.GetCurrentHandKey(); key != "" {
+			sb.WriteString(i18n.Tf("videopoker.madeHandLine",
+				"handName", vpp.translateHandKey(key)) + "\n")
+		} else {
+			sb.WriteString(i18n.T("videopoker.madeHandNone") + "\n")
+		}
+	}
+
 	sb.WriteString("----------\n")
 
 	if lastErr != nil {
@@ -115,11 +128,20 @@ func (vpp *VideoPokerCuiPresenter) handNameForWin(vp interfaces.VideoPokerGame) 
 	if key == "" {
 		return vp.GetHandName()
 	}
+	if name := vpp.translateHandKey(key); name != "" {
+		return name
+	}
+	return vp.GetHandName()
+}
+
+// translateHandKey は安定キーを pokerhand.* で訳す。訳が無ければ空文字を返す
+// -- 生のキーを画面に出さないため。
+func (vpp *VideoPokerCuiPresenter) translateHandKey(key string) string {
 	full := "pokerhand." + key
 	if name := i18n.T(full); name != full {
 		return name
 	}
-	return vp.GetHandName()
+	return ""
 }
 
 // phaseStr フェーズ文字列

--- a/internal/adapter/presenter/VideoPokerCuiPresenter_test.go
+++ b/internal/adapter/presenter/VideoPokerCuiPresenter_test.go
@@ -15,6 +15,7 @@ import (
 func setupVideoPokerCuiMockDefaults(m *interfaces.MockVideoPokerGame) {
 	m.On("GetChips").Return(1000).Maybe()
 	m.On("GetPhase").Return(domain.VideoPokerPhaseBet).Maybe()
+	m.On("GetCurrentHandKey").Return("").Maybe()
 	m.On("GetHand").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetGameEndFlag").Return(false).Maybe()
 	m.On("GetBetAmount").Return(0).Maybe()
@@ -23,6 +24,7 @@ func setupVideoPokerCuiMockDefaults(m *interfaces.MockVideoPokerGame) {
 	m.On("GetHandRank").Return(0).Maybe()
 	m.On("GetHandName").Return("").Maybe()
 	m.On("GetHandKey").Return("").Maybe()
+	m.On("GetCurrentHandKey").Return("").Maybe()
 	m.On("GetHeldIndices").Return([domain.VideoPokerHandSize]bool{}).Maybe()
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 	m.On("GetVariantName").Return("videopoker").Maybe()
@@ -51,6 +53,7 @@ func TestVideoPokerCuiPresenter_Output_BetPhase_JokerPokerPaytable(t *testing.T)
 	m.ExpectedCalls = nil
 	m.On("GetChips").Return(1000).Maybe()
 	m.On("GetPhase").Return(domain.VideoPokerPhaseBet).Maybe()
+	m.On("GetCurrentHandKey").Return("").Maybe()
 	m.On("GetHand").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetGameEndFlag").Return(false).Maybe()
 	m.On("GetVariantName").Return("jokerpoker").Maybe()
@@ -72,6 +75,7 @@ func TestVideoPokerCuiPresenter_Output_BetPhase_Paytable_EnLocale(t *testing.T) 
 	m.ExpectedCalls = nil
 	m.On("GetChips").Return(1000).Maybe()
 	m.On("GetPhase").Return(domain.VideoPokerPhaseBet).Maybe()
+	m.On("GetCurrentHandKey").Return("").Maybe()
 	m.On("GetHand").Return(([]*domain.Card)(nil)).Maybe()
 	m.On("GetGameEndFlag").Return(false).Maybe()
 	m.On("GetVariantName").Return("jokerpoker").Maybe()
@@ -86,6 +90,7 @@ func TestVideoPokerCuiPresenter_Output_DrawPhase_WithHand(t *testing.T) {
 	m := new(interfaces.MockVideoPokerGame)
 	m.On("GetChips").Return(997).Maybe()
 	m.On("GetPhase").Return(domain.VideoPokerPhaseDraw).Maybe()
+	m.On("GetCurrentHandKey").Return("").Maybe()
 	m.On("GetHand").Return([]*domain.Card{
 		domain.NewCard(domain.CardDesignSpade, 1, false),
 		domain.NewCard(domain.CardDesignHeart, 11, false),
@@ -113,6 +118,7 @@ func TestVideoPokerCuiPresenter_Output_ResultPhase_Win(t *testing.T) {
 	m := new(interfaces.MockVideoPokerGame)
 	m.On("GetChips").Return(1025).Maybe()
 	m.On("GetPhase").Return(domain.VideoPokerPhaseResult).Maybe()
+	m.On("GetCurrentHandKey").Return("").Maybe()
 	m.On("GetHand").Return([]*domain.Card{
 		domain.NewCard(domain.CardDesignSpade, 7, false),
 		domain.NewCard(domain.CardDesignClover, 7, false),
@@ -127,6 +133,7 @@ func TestVideoPokerCuiPresenter_Output_ResultPhase_Win(t *testing.T) {
 	m.On("GetHandRank").Return(domain.PokerHandFourOfAKind).Maybe()
 	m.On("GetHandName").Return("Four of a Kind").Maybe()
 	m.On("GetHandKey").Return("fourOfAKind").Maybe()
+	m.On("GetCurrentHandKey").Return("").Maybe()
 	m.On("GetHeldIndices").Return([domain.VideoPokerHandSize]bool{true, true, true, true, false}).Maybe()
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 	m.On("GetVariantName").Return("videopoker").Maybe()
@@ -145,6 +152,7 @@ func TestVideoPokerCuiPresenter_Output_ResultPhase_Win_DeucesWildTranslated(t *t
 		m := new(interfaces.MockVideoPokerGame)
 		m.On("GetChips").Return(1025).Maybe()
 		m.On("GetPhase").Return(domain.VideoPokerPhaseResult).Maybe()
+		m.On("GetCurrentHandKey").Return("").Maybe()
 		m.On("GetHand").Return([]*domain.Card{
 			domain.NewCard(domain.CardDesignSpade, 2, false),
 			domain.NewCard(domain.CardDesignSpade, 10, false),
@@ -159,6 +167,7 @@ func TestVideoPokerCuiPresenter_Output_ResultPhase_Win_DeucesWildTranslated(t *t
 		m.On("GetHandRank").Return(domain.PokerHandRoyalFlush).Maybe()
 		m.On("GetHandName").Return(handName).Maybe()
 		m.On("GetHandKey").Return(handKey).Maybe()
+		m.On("GetCurrentHandKey").Return("").Maybe()
 		m.On("GetHeldIndices").Return([domain.VideoPokerHandSize]bool{}).Maybe()
 		m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil)).Maybe()
 		m.On("GetVariantName").Return(variant).Maybe()
@@ -205,6 +214,7 @@ func TestVideoPokerCuiPresenter_Output_ResultPhase_Lose(t *testing.T) {
 	m := new(interfaces.MockVideoPokerGame)
 	m.On("GetChips").Return(999).Maybe()
 	m.On("GetPhase").Return(domain.VideoPokerPhaseResult).Maybe()
+	m.On("GetCurrentHandKey").Return("").Maybe()
 	m.On("GetHand").Return([]*domain.Card{
 		domain.NewCard(domain.CardDesignSpade, 2, false),
 		domain.NewCard(domain.CardDesignClover, 5, false),
@@ -261,6 +271,7 @@ func TestVideoPokerCuiPresenter_Output_JokerHighlighted(t *testing.T) {
 	m := new(interfaces.MockVideoPokerGame)
 	m.On("GetChips").Return(1000).Maybe()
 	m.On("GetPhase").Return(domain.VideoPokerPhaseDraw).Maybe()
+	m.On("GetCurrentHandKey").Return("").Maybe()
 	m.On("GetGameEndFlag").Return(false).Maybe()
 	m.On("GetHeldIndices").Return([domain.VideoPokerHandSize]bool{}).Maybe()
 	m.On("GetVariantName").Return("jokerpoker").Maybe()
@@ -283,6 +294,7 @@ func TestVideoPokerCuiPresenter_Output_DeucesWildTwosHighlighted(t *testing.T) {
 	m := new(interfaces.MockVideoPokerGame)
 	m.On("GetChips").Return(1000).Maybe()
 	m.On("GetPhase").Return(domain.VideoPokerPhaseDraw).Maybe()
+	m.On("GetCurrentHandKey").Return("").Maybe()
 	m.On("GetGameEndFlag").Return(false).Maybe()
 	m.On("GetHeldIndices").Return([domain.VideoPokerHandSize]bool{}).Maybe()
 	m.On("GetVariantName").Return("deuceswild").Maybe()
@@ -307,6 +319,7 @@ func TestVideoPokerCuiPresenter_Output_PlainVariantTwoNotHighlighted(t *testing.
 	m := new(interfaces.MockVideoPokerGame)
 	m.On("GetChips").Return(1000).Maybe()
 	m.On("GetPhase").Return(domain.VideoPokerPhaseDraw).Maybe()
+	m.On("GetCurrentHandKey").Return("").Maybe()
 	m.On("GetGameEndFlag").Return(false).Maybe()
 	m.On("GetHeldIndices").Return([domain.VideoPokerHandSize]bool{}).Maybe()
 	m.On("GetVariantName").Return("videopoker").Maybe()
@@ -334,6 +347,7 @@ func TestVideoPokerCuiPresenter_HintOutput(t *testing.T) {
 	drawGame := func(variant string, hand []*domain.Card) *interfaces.MockVideoPokerGame {
 		m := new(interfaces.MockVideoPokerGame)
 		m.On("GetPhase").Return(domain.VideoPokerPhaseDraw)
+		m.On("GetCurrentHandKey").Return("").Maybe()
 		m.On("GetVariantName").Return(variant)
 		m.On("GetHand").Return(hand)
 		return m
@@ -517,6 +531,62 @@ func TestVideoPokerCuiPresenter_HintOutput(t *testing.T) {
 	t.Run("no hint outside the draw phase", func(t *testing.T) {
 		m := new(interfaces.MockVideoPokerGame)
 		m.On("GetPhase").Return(domain.VideoPokerPhaseBet)
+		m.On("GetCurrentHandKey").Return("").Maybe()
 		assert.Contains(t, p.HintOutput(m), i18n.T("videopoker.hintNone"))
+	})
+}
+
+// #5508: Web はドロー中の5枚が配当対象の役かをリアルタイムに出すのに、CUI は
+// 手札とホールド推奨しか出しておらず、配当対象かはプレイヤーが自分で判定するしか
+// なかった。
+func TestVideoPokerCuiPresenter_MadeHandLine(t *testing.T) {
+	p := new(VideoPokerCuiPresenter)
+
+	withKey := func(phase int, key string) *interfaces.MockVideoPokerGame {
+		m := new(interfaces.MockVideoPokerGame)
+		m.On("GetChips").Return(997).Maybe()
+		m.On("GetPhase").Return(phase).Maybe()
+		m.On("GetHand").Return([]*domain.Card{
+			domain.NewCard(domain.CardDesignSpade, 5, false),
+			domain.NewCard(domain.CardDesignHeart, 5, false),
+			domain.NewCard(domain.CardDesignClover, 5, false),
+			domain.NewCard(domain.CardDesignDiamond, 9, false),
+			domain.NewCard(domain.CardDesignSpade, 12, false),
+		}).Maybe()
+		m.On("GetHeldIndices").Return([5]bool{}).Maybe()
+		m.On("GetBetAmount").Return(3).Maybe()
+		m.On("GetGameEndFlag").Return(false).Maybe()
+		m.On("GetResult").Return(0).Maybe()
+		m.On("GetPayout").Return(0).Maybe()
+		m.On("GetHandName").Return("").Maybe()
+		m.On("GetHandKey").Return("").Maybe()
+		m.On("GetVariantName").Return("jokerpoker").Maybe()
+		m.On("GetCurrentHandKey").Return(key).Maybe()
+		return m
+	}
+
+	t.Run("names the current hand during the draw phase", func(t *testing.T) {
+		out := p.Output(withKey(domain.VideoPokerPhaseDraw, "threeOfAKind"), nil)
+		assert.Contains(t, out, i18n.Tf("videopoker.madeHandLine", "handName", i18n.T("pokerhand.threeOfAKind")))
+		// **生のキーを出さない。** 訳が無いときに "threeOfAKind" が画面に出るのは論外。
+		assert.NotContains(t, out, "pokerhand.")
+	})
+
+	// **配当対象外でも黙らない。** 表示が消えると、評価されていないのか
+	// 届いていないのか区別できない。
+	t.Run("says there is no paying hand when the key is empty", func(t *testing.T) {
+		out := p.Output(withKey(domain.VideoPokerPhaseDraw, ""), nil)
+		assert.Contains(t, out, i18n.T("videopoker.madeHandNone"))
+	})
+
+	// ベット中・結果表示中には出さない。手札が無い/決着済みの局面で
+	// 「現在の役」を出しても意味が無い。
+	t.Run("stays quiet outside the draw phase", func(t *testing.T) {
+		for _, phase := range []int{domain.VideoPokerPhaseBet, domain.VideoPokerPhaseResult} {
+			out := p.Output(withKey(phase, "threeOfAKind"), nil)
+			assert.NotContains(t, out, i18n.T("videopoker.madeHandNone"), "phase %d", phase)
+			assert.NotContains(t, out,
+				i18n.Tf("videopoker.madeHandLine", "handName", i18n.T("pokerhand.threeOfAKind")), "phase %d", phase)
+		}
 	})
 }

--- a/internal/domain/VideoPoker.go
+++ b/internal/domain/VideoPoker.go
@@ -251,6 +251,28 @@ func (vp *VideoPoker) GetHandRank() int { return vp.handRank }
 // GetHandName ハンド名
 func (vp *VideoPoker) GetHandName() string { return vp.handName }
 
+// GetCurrentHandKey はいま手元にある5枚が配当対象の役かを、ロケール非依存の
+// 安定キーで返す (配当が付かないなら空文字)。
+//
+// ドロー中に「現在の役」を出すためのもの。Web は evaluateJokerPokerMadeHand で
+// 同じことをしているのに、CUI は手札とホールド推奨しか出していなかった (#5508)。
+//
+// **評価はバリアント自身の GetResult を通す。**別に書くと、ワイルドの扱いや配当の
+// 下限がバリアントごとにずれる。ベット額は royal のジャックポット段だけに効き、
+// キーには影響しない。
+//
+// **状態を一切変えない。**チップも結果も動かさないので、描画のたびに呼んでよい。
+func (vp *VideoPoker) GetCurrentHandKey() string {
+	if len(vp.hand) != 5 {
+		return ""
+	}
+	// 配当の付かない手は GetResult が名前を返さないので、キーも空になる
+	// (videoPokerHandKey の default)。**その規約はテストで固定してある** --
+	// 破れたら「払われない役名」が現在の役として出てしまう。
+	_, _, handName := vp.config.GetResult(vp.hand, vp.betAmount)
+	return videoPokerHandKey(handName)
+}
+
 // GetHandKey は役の安定キー（ロケール非依存）を返す。役なし時は空文字。
 func (vp *VideoPoker) GetHandKey() string { return vp.handKey }
 

--- a/internal/domain/VideoPoker_test.go
+++ b/internal/domain/VideoPoker_test.go
@@ -577,3 +577,124 @@ func TestVideoPoker_Payout_WheelStraight(t *testing.T) {
 	assert.Equal(t, 4, vp.GetPayout())
 	assert.Equal(t, "Straight", vp.GetHandName())
 }
+
+// #5508: Web はドロー中の5枚が配当対象の役かをリアルタイムに出すのに、CUI は
+// 手札とホールド推奨しか出さず、いまの役には一切触れない。評価そのものは
+// config.GetResult が持っているので、賭けずに問い合わせられればよい。
+func TestVideoPoker_GetCurrentHandKey(t *testing.T) {
+	card := func(design, value int) *Card { return NewCard(design, value, false) }
+
+	newJokerPoker := func(hand []*Card) *VideoPoker {
+		vp := NewJokerPokerVideoPoker()
+		vp.Reset()
+		vp.SetHand(hand)
+		return vp
+	}
+
+	t.Run("names a paying hand", func(t *testing.T) {
+		vp := newJokerPoker([]*Card{
+			card(CardDesignSpade, 5), card(CardDesignHeart, 5),
+			card(CardDesignClover, 5), card(CardDesignDiamond, 9),
+			card(CardDesignSpade, 12),
+		})
+		assert.Equal(t, "threeOfAKind", vp.GetCurrentHandKey())
+	})
+
+	// **Kings or Better 未満は空。** 配当の付かない手を役名で呼ぶと、払われると読める。
+	t.Run("returns an empty key below the pay minimum", func(t *testing.T) {
+		vp := newJokerPoker([]*Card{
+			card(CardDesignSpade, 11), card(CardDesignHeart, 11),
+			card(CardDesignClover, 3), card(CardDesignDiamond, 7),
+			card(CardDesignSpade, 9),
+		})
+		assert.Empty(t, vp.GetCurrentHandKey(), "J のペアは Joker Poker では配当対象外")
+	})
+
+	t.Run("counts the joker as wild", func(t *testing.T) {
+		vp := newJokerPoker([]*Card{
+			card(CardDesignSpade, 5), card(CardDesignHeart, 5),
+			NewCard(CardDesignJoker, 0, true),
+			card(CardDesignDiamond, 9), card(CardDesignSpade, 12),
+		})
+		assert.Equal(t, "threeOfAKind", vp.GetCurrentHandKey())
+	})
+
+	// **状態を変えない。** ドロー中に何度呼ばれても、チップも結果も動かない。
+	t.Run("does not pay out or change the game state", func(t *testing.T) {
+		vp := newJokerPoker([]*Card{
+			card(CardDesignSpade, 5), card(CardDesignHeart, 5),
+			card(CardDesignClover, 5), card(CardDesignDiamond, 9),
+			card(CardDesignSpade, 12),
+		})
+		chips, phase := vp.GetChips(), vp.GetPhase()
+		for i := 0; i < 3; i++ {
+			vp.GetCurrentHandKey()
+		}
+		assert.Equal(t, chips, vp.GetChips())
+		assert.Equal(t, phase, vp.GetPhase())
+		assert.Zero(t, vp.GetPayout())
+	})
+
+	// 5枚そろっていないときは空。
+	t.Run("returns an empty key for a partial hand", func(t *testing.T) {
+		vp := newJokerPoker([]*Card{card(CardDesignSpade, 5)})
+		assert.Empty(t, vp.GetCurrentHandKey())
+	})
+}
+
+// #5508 の受け入れ条件: Web の evaluateJokerPokerMadeHand と同じ入力で同じ役キーを
+// 返すこと。**両者は別言語の別実装**なので、代表的な手で突き合わせておく。
+// (frontend/src/utils/jokerPokerMadeHand.test.ts に同じ期待値が置いてある)
+func TestVideoPoker_CurrentHandKeyMatchesTheWebEvaluator(t *testing.T) {
+	card := func(design, value int) *Card { return NewCard(design, value, false) }
+	joker := func() *Card { return NewCard(CardDesignJoker, 0, true) }
+
+	for _, tc := range []struct {
+		name string
+		hand []*Card
+		want string
+	}{
+		{"natural royal", []*Card{card(CardDesignSpade, 1), card(CardDesignSpade, 13),
+			card(CardDesignSpade, 12), card(CardDesignSpade, 11), card(CardDesignSpade, 10)}, "naturalRoyalFlush"},
+		{"wild royal", []*Card{joker(), card(CardDesignSpade, 13),
+			card(CardDesignSpade, 12), card(CardDesignSpade, 11), card(CardDesignSpade, 10)}, "wildRoyalFlush"},
+		{"five of a kind", []*Card{card(CardDesignSpade, 7), card(CardDesignHeart, 7),
+			card(CardDesignClover, 7), card(CardDesignDiamond, 7), joker()}, "fiveOfAKind"},
+		{"kings or better", []*Card{card(CardDesignSpade, 13), card(CardDesignHeart, 13),
+			card(CardDesignClover, 3), card(CardDesignDiamond, 7), card(CardDesignSpade, 9)}, "kingsOrBetter"},
+		// **J のペアは Joker Poker では払わない。** Jacks or Better との違い。
+		{"jacks pay nothing here", []*Card{card(CardDesignSpade, 11), card(CardDesignHeart, 11),
+			card(CardDesignClover, 3), card(CardDesignDiamond, 7), card(CardDesignSpade, 9)}, ""},
+	} {
+		vp := NewJokerPokerVideoPoker()
+		vp.Reset()
+		vp.SetHand(tc.hand)
+		assert.Equal(t, tc.want, vp.GetCurrentHandKey(), tc.name)
+	}
+}
+
+// GetCurrentHandKey は「配当の付かない手には名前が付かない」という GetResult の
+// 規約に乗っている。**破れたら、払われない役名が「現在の役」として出る。**
+// 3バリアントとも、配当0の手でキーが空になることを固定しておく。
+func TestVideoPoker_NoPayingHandYieldsNoKey(t *testing.T) {
+	card := func(design, value int) *Card { return NewCard(design, value, false) }
+	// どのバリアントでも配当の付かない手 (バラバラのハイカード、2 もジョーカーも無し)。
+	junk := []*Card{
+		card(CardDesignSpade, 9), card(CardDesignHeart, 7),
+		card(CardDesignClover, 5), card(CardDesignDiamond, 3),
+		card(CardDesignSpade, 12),
+	}
+
+	for name, vp := range map[string]*VideoPoker{
+		"jacksOrBetter": NewDefaultVideoPoker(),
+		"deucesWild":    NewDeucesWildVideoPoker(),
+		"jokerPoker":    NewJokerPokerVideoPoker(),
+	} {
+		vp.Reset()
+		vp.SetHand(junk)
+		_, multiplier, handName := vp.config.GetResult(junk, vp.GetBetAmount())
+		assert.Zero(t, multiplier, name)
+		assert.Empty(t, handName, name+": 配当0の手に名前を付けている")
+		assert.Empty(t, vp.GetCurrentHandKey(), name)
+	}
+}

--- a/internal/domain/interfaces/videopoker.go
+++ b/internal/domain/interfaces/videopoker.go
@@ -34,6 +34,8 @@ type VideoPokerGame interface {
 	GetHandName() string
 	// GetHandKey 役の安定キー（ロケール非依存）を取得する
 	GetHandKey() string
+	// GetCurrentHandKey いま手元の5枚が配当対象の役かを安定キーで返す (無ければ "")
+	GetCurrentHandKey() string
 	// GetHeldIndices ホールドインデックスを取得する
 	GetHeldIndices() [domain.VideoPokerHandSize]bool
 	// GetVariantName バリアント名を取得する

--- a/internal/domain/interfaces/videopoker_mock.go
+++ b/internal/domain/interfaces/videopoker_mock.go
@@ -80,6 +80,9 @@ func (m *MockVideoPokerGame) GetHandKey() string {
 	return args.String(0)
 }
 
+// GetCurrentHandKey モック
+func (m *MockVideoPokerGame) GetCurrentHandKey() string { return m.Called().String(0) }
+
 func (m *MockVideoPokerGame) GetHeldIndices() [domain.VideoPokerHandSize]bool {
 	args := m.Called()
 	return args.Get(0).([domain.VideoPokerHandSize]bool)

--- a/internal/i18n/locales/en/videopoker.json
+++ b/internal/i18n/locales/en/videopoker.json
@@ -43,5 +43,7 @@
   "ptJacksOrBetter": "Jacks or Better",
   "ptKingsOrBetter": "Kings or Better",
   "holdRoyalDraw": "Hold four to a royal flush",
-  "helpExampleBet": "  b 5                  bet five coins and deal"
+  "helpExampleBet": "  b 5                  bet five coins and deal",
+  "madeHandLine": "Current hand: {{handName}}",
+  "madeHandNone": "Current hand: no paying hand"
 }

--- a/internal/i18n/locales/ja/videopoker.json
+++ b/internal/i18n/locales/ja/videopoker.json
@@ -43,5 +43,7 @@
   "ptJacksOrBetter": "ジャックス・オア・ベター",
   "ptKingsOrBetter": "キングス・オア・ベター",
   "holdRoyalDraw": "ロイヤルフラッシュへの4枚を残す",
-  "helpExampleBet": "  b 5                  5 コイン賭けて配る"
+  "helpExampleBet": "  b 5                  5 コイン賭けて配る",
+  "madeHandLine": "現在の役: {{handName}}",
+  "madeHandNone": "現在の役: 役なし（配当対象外）"
 }


### PR DESCRIPTION
## 背景

Web の `VideoPokerGameContent.tsx` はドロー中、5枚が配当対象の役かを `vp-made-hand`
としてリアルタイムに出す。`VideoPokerCuiPresenter.Output` は手札とホールド推奨は
出すものの、**いま何の役になっているかには一切触れない。**

Go 側の `evalWildHand` は非公開で、presenter からは呼べない状態だった。

## 変更

`VideoPoker.GetCurrentHandKey()` を追加する。

**評価はバリアント自身の `GetResult` を通す。** 別に書くと、ワイルドの扱いや配当の
下限がバリアントごとにずれる。おかげで `jokerpoker` だけでなく `videopoker` /
`deuceswild` でも同じ行が出る（3変種とも下限が正しい）。

**状態を一切変えない。** チップも結果も動かさないので、描画のたびに呼んでよい。

配当対象外でも黙らず「役なし（配当対象外）」と出す。表示が消えると、評価されて
いないのか届いていないのか区別できない。

## 受け入れ条件「Web と同じ役キーを返す」

両者は**別言語の別実装**なので、代表的な手（ナチュラル/ワイルドロイヤル、
ファイブカード、Kings or Better、J のペア=配当なし）で突き合わせるテストを置いた。

## 「配当0の手には名前が付かない」という規約

`GetCurrentHandKey` は `GetResult` が配当0の手に名前を返さないことに乗っている。
最初は `multiplier <= 0` のガードも書いたが、**変異テストで一度も落ちなかった** ——
どの経路も空文字を返すので到達しない。ガードを消して、代わりに**規約そのものを
3バリアントで固定するテスト**にした。破れたら「払われない役名」が現在の役として
出るので、そこが本当の防御点。

**変異テスト（実測）**:

| 変異 | 落ちたテスト |
|---|---|
| 配当0の手に名前を付ける（規約違反） | 2 |
| ドロー以外のフェーズでも出す | 2 |
| 安定キーを訳さず生で出す | 1 |

Closes #5508