### PR TITLE
feat(euchre): show the hand-strength score behind the bidding hint

### DIFF
--- a/internal/adapter/controller/EuchreWebController.go
+++ b/internal/adapter/controller/EuchreWebController.go
@@ -43,6 +43,8 @@ type EuchreWebOutputHint struct {
 	Suit      *int   `json:"suit,omitempty"`
 	GoAlone   *bool  `json:"goAlone,omitempty"`
 	Reason    string `json:"reason"`
+	// Score は判断の元になったハンド強度 (ビッド局面のみ)。CUI と同じ値。
+	Score *int `json:"score,omitempty"`
 }
 
 // EuchreWebOutput ユーカーWebアウトプット

--- a/internal/adapter/presenter/EuchreCuiPresenter.go
+++ b/internal/adapter/presenter/EuchreCuiPresenter.go
@@ -193,15 +193,24 @@ func (p *EuchreCuiPresenter) HintOutput(e interfaces.EuchreGame) string {
 		return i18n.T("euchre.hintNone") + "\n"
 	}
 	reason := hintReasonStr(hint.Reason, euchreHintReasonKeys)
+	// **判断の元になった数値も出す。** 真偽値と定型の理由キーだけでは、自分の手札が
+	// CPU の基準にどれだけ近いのか分からない (#5509)。しきい値も一緒に言う。
+	scoreLine := ""
+	if hint.Score != nil {
+		scoreLine = i18n.Tf("euchre.hintScore",
+			"score", strconv.Itoa(*hint.Score),
+			"orderUp", strconv.Itoa(domain.EuchreOrderUpScore),
+			"goAlone", strconv.Itoa(domain.EuchreGoAloneScore)) + "\n"
+	}
 	if hint.OrderUp != nil {
 		if *hint.OrderUp {
 			key := "euchre.hintOrderUp"
 			if hint.GoAlone != nil && *hint.GoAlone {
 				key = "euchre.hintOrderUpAlone"
 			}
-			return color.Yellow(i18n.Tf(key, "reason", reason)) + "\n"
+			return color.Yellow(i18n.Tf(key, "reason", reason)) + "\n" + scoreLine
 		}
-		return color.Yellow(i18n.Tf("euchre.hintPass", "reason", reason)) + "\n"
+		return color.Yellow(i18n.Tf("euchre.hintPass", "reason", reason)) + "\n" + scoreLine
 	}
 	if hint.Suit != nil {
 		key := "euchre.hintCallSuit"
@@ -210,7 +219,7 @@ func (p *EuchreCuiPresenter) HintOutput(e interfaces.EuchreGame) string {
 		}
 		return color.Yellow(i18n.Tf(key,
 			"suit", cuiSuitName(*hint.Suit),
-			"reason", reason)) + "\n"
+			"reason", reason)) + "\n" + scoreLine
 	}
 	if hint.CardIndex == nil {
 		return i18n.T("euchre.hintNone") + "\n"

--- a/internal/adapter/presenter/EuchreCuiPresenter_test.go
+++ b/internal/adapter/presenter/EuchreCuiPresenter_test.go
@@ -2,11 +2,13 @@ package presenter_test
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -487,4 +489,43 @@ func TestEuchreCuiPresenter_MarksPlayableCards(t *testing.T) {
 		out := p.Output(withPlayable([]int{0, 1, 2}, domain.EuchrePhasePickUp, 0), nil)
 		assert.NotContains(t, out, "*")
 	})
+}
+
+// #5509: ヒントは真偽値と定型の理由キーだけで、判断に使ったスコアは捨てられていた。
+// プレイヤーは自分の手札が CPU の基準にどれだけ近いか学べない。
+func TestEuchreCuiPresenter_HintShowsTheScore(t *testing.T) {
+	p := new(presenter.EuchreCuiPresenter)
+
+	e := domain.NewDefaultEuchre()
+	e.Reset()
+	e.SetPhase(domain.EuchrePhasePickUp)
+	e.SetBidPlayerIdx(0)
+
+	hint := e.GetHint()
+	require.NotNil(t, hint)
+	require.NotNil(t, hint.Score)
+
+	out := p.HintOutput(e)
+	// **ドメインが判断に使った値そのものが出ること。**別に計算し直していれば違う数字になる。
+	assert.Contains(t, out, i18n.Tf("euchre.hintScore",
+		"score", strconv.Itoa(*hint.Score),
+		"orderUp", strconv.Itoa(domain.EuchreOrderUpScore),
+		"goAlone", strconv.Itoa(domain.EuchreGoAloneScore)))
+	// しきい値も文言から読めること。
+	assert.Contains(t, out, strconv.Itoa(domain.EuchreOrderUpScore))
+	assert.Contains(t, out, strconv.Itoa(domain.EuchreGoAloneScore))
+}
+
+// スコアを持たない局面 (カードプレイのヒント) では行を出さない。
+func TestEuchreCuiPresenter_HintOmitsTheScoreWhenThereIsNone(t *testing.T) {
+	p := new(presenter.EuchreCuiPresenter)
+
+	e := domain.NewDefaultEuchre()
+	e.Reset()
+	e.SetPhase(domain.EuchrePhasePlay)
+	e.SetCurrentPlayerIdx(0)
+
+	if hint := e.GetHint(); hint != nil && hint.Score == nil {
+		assert.NotContains(t, p.HintOutput(e), i18n.T("euchre.hintScore"))
+	}
 }

--- a/internal/adapter/presenter/EuchreWebPresenter.go
+++ b/internal/adapter/presenter/EuchreWebPresenter.go
@@ -30,6 +30,7 @@ func (p *EuchreWebPresenter) Output(e interfaces.EuchreGame, lastErr error) stri
 			Suit:      hint.Suit,
 			GoAlone:   hint.GoAlone,
 			Reason:    hint.Reason,
+			Score:     hint.Score,
 		}
 	}
 
@@ -128,6 +129,7 @@ func (p *EuchreWebPresenter) HintOutput(e interfaces.EuchreGame) string {
 			Suit:      hint.Suit,
 			GoAlone:   hint.GoAlone,
 			Reason:    hint.Reason,
+			Score:     hint.Score,
 		}
 	}
 	// **「頼んだヒントか」を CLI が見分けられるようにする。**このゲーム群の

--- a/internal/domain/Euchre.go
+++ b/internal/domain/Euchre.go
@@ -48,7 +48,20 @@ type EuchreHint struct {
 	Suit      *int   // 推奨スート (コールトランプ時)
 	GoAlone   *bool  // ゴーアローンすべきか
 	Reason    string // ヒント理由キー
+	// Score は判断の元になったハンド強度 (ピックアップ / コールトランプ時のみ)。
+	// ディーラーボーナス込みの、実際に判定へ使った値。
+	Score *int
 }
+
+// ハンド強度スコアのしきい値。evalHandForTrump のスコアをこれと比べて
+// オーダーアップ / ゴーアローンを決める。**ヒントに出す数値と同じ基準**であることを
+// テストで固定してある (#5509)。
+const (
+	// EuchreOrderUpScore はオーダーアップ (トランプを選ぶ) 最低スコア。
+	EuchreOrderUpScore = 3
+	// EuchreGoAloneScore はゴーアローンに踏み切る最低スコア。
+	EuchreGoAloneScore = 5
+)
 
 // Euchre ユーカーゲームクラス
 type Euchre struct {
@@ -905,19 +918,19 @@ func (e *Euchre) GetHint() *EuchreHint {
 		if e.bidPlayerIdx != humanIdx {
 			return nil
 		}
-		orderUp, goAlone := e.cpuEvalPickUp(humanIdx)
-		return &EuchreHint{OrderUp: &orderUp, GoAlone: &goAlone, Reason: "strategic_pickup"}
+		orderUp, goAlone, score := e.cpuEvalPickUpScored(humanIdx)
+		return &EuchreHint{OrderUp: &orderUp, GoAlone: &goAlone, Reason: "strategic_pickup", Score: &score}
 
 	case EuchrePhaseCallTrump:
 		if e.bidPlayerIdx != humanIdx {
 			return nil
 		}
-		suit, goAlone := e.cpuEvalCallTrump(humanIdx)
+		suit, goAlone, score := e.cpuEvalCallTrumpScored(humanIdx)
 		if suit > 0 {
-			return &EuchreHint{Suit: &suit, GoAlone: &goAlone, Reason: "strategic_call"}
+			return &EuchreHint{Suit: &suit, GoAlone: &goAlone, Reason: "strategic_call", Score: &score}
 		}
 		f := false
-		return &EuchreHint{GoAlone: &f, Reason: "pass_recommended"}
+		return &EuchreHint{GoAlone: &f, Reason: "pass_recommended", Score: &score}
 
 	case EuchrePhaseDiscard:
 		if e.dealerIdx != humanIdx {
@@ -1001,7 +1014,7 @@ func (e *Euchre) cpuPickUpEasy(playerIdx int) (bool, bool) {
 // cpuPickUpNormal カードの強さに基づくピックアップ判断
 func (e *Euchre) cpuPickUpNormal(playerIdx int) (bool, bool) {
 	score := e.evalHandForTrump(playerIdx, e.faceUpCard.GetDesign())
-	if score >= 3 {
+	if score >= EuchreOrderUpScore {
 		return true, false
 	}
 	// ディーラーはボーナス (ピックアップで1枚交換できるため)
@@ -1013,6 +1026,13 @@ func (e *Euchre) cpuPickUpNormal(playerIdx int) (bool, bool) {
 
 // cpuEvalPickUp 高度なピックアップ評価
 func (e *Euchre) cpuEvalPickUp(playerIdx int) (bool, bool) {
+	orderUp, goAlone, _ := e.cpuEvalPickUpScored(playerIdx)
+	return orderUp, goAlone
+}
+
+// cpuEvalPickUpScored は判断に加えて、その判断に使ったスコアも返す。
+// **ヒントに出すのはこの値。**別に計算し直すと、説明と判断がずれる。
+func (e *Euchre) cpuEvalPickUpScored(playerIdx int) (bool, bool, int) {
 	score := e.evalHandForTrump(playerIdx, e.faceUpCard.GetDesign())
 
 	// ディーラーはフェイスアップカードを獲得するためボーナス
@@ -1020,13 +1040,13 @@ func (e *Euchre) cpuEvalPickUp(playerIdx int) (bool, bool) {
 		score++
 	}
 
-	if score >= 5 {
-		return true, true // ゴーアローン
+	if score >= EuchreGoAloneScore {
+		return true, true, score // ゴーアローン
 	}
-	if score >= 3 {
-		return true, false
+	if score >= EuchreOrderUpScore {
+		return true, false, score
 	}
-	return false, false
+	return false, false, score
 }
 
 // cpuSelectCallTrump CPUがコールトランプで指名するスートを選択する
@@ -1071,6 +1091,12 @@ func (e *Euchre) cpuCallTrumpNormal(playerIdx int) (int, bool) {
 
 // cpuEvalCallTrump 高度なコール評価
 func (e *Euchre) cpuEvalCallTrump(playerIdx int) (int, bool) {
+	suit, goAlone, _ := e.cpuEvalCallTrumpScored(playerIdx)
+	return suit, goAlone
+}
+
+// cpuEvalCallTrumpScored は判断に加えて、その判断に使った最良スコアも返す。
+func (e *Euchre) cpuEvalCallTrumpScored(playerIdx int) (int, bool, int) {
 	bestSuit := 0
 	bestScore := 0
 	for _, suit := range e.availableCallSuits() {
@@ -1080,13 +1106,13 @@ func (e *Euchre) cpuEvalCallTrump(playerIdx int) (int, bool) {
 			bestSuit = suit
 		}
 	}
-	if bestScore >= 5 {
-		return bestSuit, true // ゴーアローン
+	if bestScore >= EuchreGoAloneScore {
+		return bestSuit, true, bestScore // ゴーアローン
 	}
-	if bestScore >= 3 {
-		return bestSuit, false
+	if bestScore >= EuchreOrderUpScore {
+		return bestSuit, false, bestScore
 	}
-	return 0, false
+	return 0, false, bestScore
 }
 
 // cpuForceCallTrump スタックドディーラー: 強制的にスートを選ぶ

--- a/internal/domain/Euchre.go
+++ b/internal/domain/Euchre.go
@@ -991,7 +991,8 @@ func (e *Euchre) getValidPlayIndices(playerIdx int) []int {
 func (e *Euchre) cpuSelectPickUp(playerIdx int) (orderUp bool, goAlone bool) {
 	switch e.config.CpuDifficulty {
 	case EuchreCpuDifficultyHard:
-		return e.cpuEvalPickUp(playerIdx)
+		orderUp, goAlone, _ := e.cpuEvalPickUpScored(playerIdx)
+		return orderUp, goAlone
 	case EuchreCpuDifficultyNormal:
 		return e.cpuPickUpNormal(playerIdx)
 	default:
@@ -1025,11 +1026,6 @@ func (e *Euchre) cpuPickUpNormal(playerIdx int) (bool, bool) {
 }
 
 // cpuEvalPickUp 高度なピックアップ評価
-func (e *Euchre) cpuEvalPickUp(playerIdx int) (bool, bool) {
-	orderUp, goAlone, _ := e.cpuEvalPickUpScored(playerIdx)
-	return orderUp, goAlone
-}
-
 // cpuEvalPickUpScored は判断に加えて、その判断に使ったスコアも返す。
 // **ヒントに出すのはこの値。**別に計算し直すと、説明と判断がずれる。
 func (e *Euchre) cpuEvalPickUpScored(playerIdx int) (bool, bool, int) {
@@ -1053,7 +1049,8 @@ func (e *Euchre) cpuEvalPickUpScored(playerIdx int) (bool, bool, int) {
 func (e *Euchre) cpuSelectCallTrump(playerIdx int) (suit int, goAlone bool) {
 	switch e.config.CpuDifficulty {
 	case EuchreCpuDifficultyHard:
-		return e.cpuEvalCallTrump(playerIdx)
+		suit, goAlone, _ := e.cpuEvalCallTrumpScored(playerIdx)
+		return suit, goAlone
 	case EuchreCpuDifficultyNormal:
 		return e.cpuCallTrumpNormal(playerIdx)
 	default:
@@ -1090,11 +1087,6 @@ func (e *Euchre) cpuCallTrumpNormal(playerIdx int) (int, bool) {
 }
 
 // cpuEvalCallTrump 高度なコール評価
-func (e *Euchre) cpuEvalCallTrump(playerIdx int) (int, bool) {
-	suit, goAlone, _ := e.cpuEvalCallTrumpScored(playerIdx)
-	return suit, goAlone
-}
-
 // cpuEvalCallTrumpScored は判断に加えて、その判断に使った最良スコアも返す。
 func (e *Euchre) cpuEvalCallTrumpScored(playerIdx int) (int, bool, int) {
 	bestSuit := 0

--- a/internal/domain/Euchre_test.go
+++ b/internal/domain/Euchre_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 )
@@ -1066,4 +1067,56 @@ func TestEuchre_GetValidPlayIndices(t *testing.T) {
 	indices = e.GetValidPlayIndices(0)
 	assert.Equal(t, 1, len(indices))
 	assert.Equal(t, 0, indices[0])
+}
+
+// #5509: GetHint は evalHandForTrump のスコアで判断しておきながら、真偽値と定型の
+// 理由キーしか返さずスコアを捨てていた。プレイヤーは自分の手札が CPU の基準に
+// どれだけ近いかを学べない。
+func TestEuchre_HintCarriesTheScoreItJudgedWith(t *testing.T) {
+	newGame := func() *domain.Euchre {
+		e := domain.NewDefaultEuchre()
+		e.Reset()
+		return e
+	}
+
+	t.Run("pickup hint reports a score", func(t *testing.T) {
+		e := newGame()
+		e.SetPhase(domain.EuchrePhasePickUp)
+		e.SetBidPlayerIdx(0)
+		h := e.GetHint()
+		require.NotNil(t, h)
+		require.NotNil(t, h.Score, "判断に使ったスコアが落ちている")
+		// **判断と数値が矛盾しないこと。** しきい値以上なら勧め、未満なら勧めない。
+		require.NotNil(t, h.OrderUp)
+		assert.Equal(t, *h.Score >= domain.EuchreOrderUpScore, *h.OrderUp)
+		require.NotNil(t, h.GoAlone)
+		assert.Equal(t, *h.Score >= domain.EuchreGoAloneScore, *h.GoAlone)
+		// 既存の理由キーは維持する。
+		assert.Equal(t, "strategic_pickup", h.Reason)
+	})
+
+	t.Run("call-trump hint reports a score", func(t *testing.T) {
+		e := newGame()
+		e.SetPhase(domain.EuchrePhaseCallTrump)
+		e.SetBidPlayerIdx(0)
+		h := e.GetHint()
+		require.NotNil(t, h)
+		require.NotNil(t, h.Score)
+		require.NotNil(t, h.GoAlone)
+		assert.Equal(t, *h.Score >= domain.EuchreGoAloneScore, *h.GoAlone)
+		// スートを勧めるかどうかも同じしきい値に従う。
+		if *h.Score >= domain.EuchreOrderUpScore {
+			assert.NotNil(t, h.Suit)
+			assert.Equal(t, "strategic_call", h.Reason)
+		} else {
+			assert.Nil(t, h.Suit)
+			assert.Equal(t, "pass_recommended", h.Reason)
+		}
+	})
+
+	// **しきい値の順序。** ゴーアローンはオーダーアップより厳しい。
+	// 逆転すると「勧めないのにゴーアローン」という文言が出る。
+	t.Run("go-alone is the stricter threshold", func(t *testing.T) {
+		assert.Greater(t, domain.EuchreGoAloneScore, domain.EuchreOrderUpScore)
+	})
 }

--- a/internal/domain/Euchre_test.go
+++ b/internal/domain/Euchre_test.go
@@ -1120,3 +1120,125 @@ func TestEuchre_HintCarriesTheScoreItJudgedWith(t *testing.T) {
 		assert.Greater(t, domain.EuchreGoAloneScore, domain.EuchreOrderUpScore)
 	})
 }
+
+// スコアの3つの帯 (ゴーアローン / オーダーアップ / パス) をすべて通す。
+//
+// **乱数の入る札を避けて組む。** evalHandForTrump は切り札のQと他スートのA に
+// rand.Intn(2) を使うので、それらを手札に入れると同じ配りでもスコアが揺れる。
+// ボワーと切り札のA・K だけで組めば決定的になる。
+func TestEuchre_HintScoreCoversEveryBand(t *testing.T) {
+	card := func(design, value int) *domain.Card { return domain.NewCard(design, value, false) }
+
+	setup := func(hand []*domain.Card) *domain.Euchre {
+		e := domain.NewDefaultEuchre()
+		e.Reset()
+		e.SetPhase(domain.EuchrePhasePickUp)
+		e.SetBidPlayerIdx(0)
+		// ディーラーは別席にする。ディーラーだと +1 のボーナスが乗って帯が変わる。
+		e.SetDealerIdx(1)
+		e.SetFaceUpCard(card(domain.CardDesignSpade, 9))
+		p := e.GetPlayer(0)
+		p.ResetRound()
+		for _, c := range hand {
+			p.AddCard(c)
+		}
+		return e
+	}
+
+	for _, tc := range []struct {
+		name      string
+		hand      []*domain.Card
+		wantScore int
+		wantOrder bool
+		wantAlone bool
+	}{
+		{
+			name: "both bowers and the trump ace go alone",
+			hand: []*domain.Card{
+				card(domain.CardDesignSpade, 11),  // right bower +2
+				card(domain.CardDesignClover, 11), // left bower +2
+				card(domain.CardDesignSpade, 1),   // trump ace +1
+				card(domain.CardDesignHeart, 9), card(domain.CardDesignDiamond, 10),
+			},
+			wantScore: 5, wantOrder: true, wantAlone: true,
+		},
+		{
+			name: "right bower plus the trump ace orders up",
+			hand: []*domain.Card{
+				card(domain.CardDesignSpade, 11), card(domain.CardDesignSpade, 1),
+				card(domain.CardDesignHeart, 9), card(domain.CardDesignDiamond, 10),
+				card(domain.CardDesignHeart, 13),
+			},
+			wantScore: 3, wantOrder: true, wantAlone: false,
+		},
+		{
+			name: "a lone trump king passes",
+			hand: []*domain.Card{
+				card(domain.CardDesignSpade, 13),
+				card(domain.CardDesignHeart, 9), card(domain.CardDesignDiamond, 10),
+				card(domain.CardDesignHeart, 13), card(domain.CardDesignClover, 9),
+			},
+			wantScore: 1, wantOrder: false, wantAlone: false,
+		},
+	} {
+		h := setup(tc.hand).GetHint()
+		require.NotNil(t, h, tc.name)
+		require.NotNil(t, h.Score, tc.name)
+		assert.Equal(t, tc.wantScore, *h.Score, tc.name)
+		require.NotNil(t, h.OrderUp)
+		assert.Equal(t, tc.wantOrder, *h.OrderUp, tc.name)
+		require.NotNil(t, h.GoAlone)
+		assert.Equal(t, tc.wantAlone, *h.GoAlone, tc.name)
+	}
+}
+
+// コールトランプ側も3帯を通す。フェイスアップのスートは選べないので、
+// 別スートで強い手を組む。
+func TestEuchre_CallTrumpHintScoreCoversEveryBand(t *testing.T) {
+	card := func(design, value int) *domain.Card { return domain.NewCard(design, value, false) }
+
+	setup := func(hand []*domain.Card) *domain.Euchre {
+		e := domain.NewDefaultEuchre()
+		e.Reset()
+		e.SetPhase(domain.EuchrePhaseCallTrump)
+		e.SetBidPlayerIdx(0)
+		e.SetDealerIdx(1)
+		// 表向きは♠なので、コールできるのは残り3スート。
+		e.SetFaceUpCard(card(domain.CardDesignSpade, 9))
+		p := e.GetPlayer(0)
+		p.ResetRound()
+		for _, c := range hand {
+			p.AddCard(c)
+		}
+		return e
+	}
+
+	t.Run("both hearts bowers plus the ace go alone", func(t *testing.T) {
+		h := setup([]*domain.Card{
+			card(domain.CardDesignHeart, 11),   // right bower (hearts) +2
+			card(domain.CardDesignDiamond, 11), // left bower (same colour) +2
+			card(domain.CardDesignHeart, 1),    // trump ace +1
+			card(domain.CardDesignClover, 9), card(domain.CardDesignSpade, 10),
+		}).GetHint()
+		require.NotNil(t, h)
+		require.NotNil(t, h.Score)
+		assert.Equal(t, 5, *h.Score)
+		require.NotNil(t, h.GoAlone)
+		assert.True(t, *h.GoAlone)
+		assert.Equal(t, "strategic_call", h.Reason)
+	})
+
+	// **弱ければパスを勧め、スートも出さない。** その局面でも数値は出す。
+	t.Run("a weak hand passes but still reports the score", func(t *testing.T) {
+		h := setup([]*domain.Card{
+			card(domain.CardDesignHeart, 13), card(domain.CardDesignClover, 9),
+			card(domain.CardDesignSpade, 10), card(domain.CardDesignDiamond, 9),
+			card(domain.CardDesignClover, 10),
+		}).GetHint()
+		require.NotNil(t, h)
+		require.NotNil(t, h.Score)
+		assert.Less(t, *h.Score, domain.EuchreOrderUpScore)
+		assert.Nil(t, h.Suit)
+		assert.Equal(t, "pass_recommended", h.Reason)
+	})
+}

--- a/internal/i18n/locales/en/euchre.json
+++ b/internal/i18n/locales/en/euchre.json
@@ -42,5 +42,6 @@
   "hintReasonDiscardWeakest": "discard the weakest card",
   "sittingOut": " 💤(sitting out)",
   "helpExamplePlay": "  p 0                  play hand card 0",
-  "helpHint": "  h                    show a hint"
+  "helpHint": "  h                    show a hint",
+  "hintScore": "  Hand strength: {{score}} (order up at {{orderUp}}+, go alone at {{goAlone}}+)"
 }

--- a/internal/i18n/locales/ja/euchre.json
+++ b/internal/i18n/locales/ja/euchre.json
@@ -42,5 +42,6 @@
   "hintReasonDiscardWeakest": "最弱カードを捨てる",
   "sittingOut": " 💤（休み）",
   "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す",
-  "helpHint": "  h                    助言を表示"
+  "helpHint": "  h                    助言を表示",
+  "hintScore": "  ハンド強度: {{score}} (オーダーアップ {{orderUp}}以上 / ゴーアローン {{goAlone}}以上)"
 }


### PR DESCRIPTION
## 背景

`cpuEvalPickUp` / `cpuEvalCallTrump` は `evalHandForTrump` の数値スコアで
「3以上ならオーダーアップ、5以上ならゴーアローン」と判断する。`GetHint` は
**まさにその関数を呼んでおきながら**、返すのは真偽値と `strategic_pickup` /
`strategic_call` という定型の理由キーだけで、算出済みのスコアは捨てていた。

Web にも CUI にも「なぜそう判断したか」の手がかりが無く、プレイヤーは自分の手札が
CPU の基準にどれだけ近いかを学べない。

## 変更

- しきい値を `EuchreOrderUpScore` (3) / `EuchreGoAloneScore` (5) に切り出す
- 判断関数が**実際に使ったスコア**をヒントに載せる
- CUI はしきい値と併記して出す / Web は `score` フィールドで同じ値を送る
- 既存の `Reason` 文字列はそのまま維持（受け入れ条件 4）

**別に計算し直さない。** ピックアップではディーラーに +1 のボーナスが乗った値で
判断しているので、ヒント用に計算し直すと説明と判断がずれる。

## テスト

- ヒントがスコアを持つこと
- **判断と数値が矛盾しないこと** — しきい値以上なら勧め、未満なら勧めない
- ゴーアローンのしきい値がオーダーアップより厳しいこと（逆転すると「勧めないのに
  ゴーアローン」という文言が出る）
- CUI に**ドメインが判断に使った値そのもの**が出ること、しきい値も読めること
- スコアを持たない局面（カードプレイのヒント）では行を出さないこと

**変異テスト（実測）**:

| 変異 | 落ちたテスト |
|---|---|
| ゴーアローンのしきい値を 2 に下げる（順序逆転） | 1 |
| CUI が固定値 0 を出す | 1 |
| ヒントのスコアを判断から切り離す | 2 |

## OpenAPI について

`api/openapi.yaml` の `/euchre/exec` レスポンスは **`hint` オブジェクト自体を
記述していない**（`reason` も `goAlone` も無い）。`score` だけ足す場所が無いので
今回は触っていません。ヒント全体のスキーマ化は別途。

Closes #5509