### PR TITLE
feat(cribbage): show the final round's score breakdown at game end

### DIFF
--- a/internal/adapter/presenter/CribbageCuiPresenter.go
+++ b/internal/adapter/presenter/CribbageCuiPresenter.go
@@ -91,6 +91,11 @@ func (p *CribbageCuiPresenter) Output(g interfaces.CribbageGame, lastErr error) 
 		cuiErrorBlock(b, lastErr)
 
 		if g.GetGameEndFlag() {
+			// **最終ラウンドの内訳を見せてから終わる。** ここで早期 return して
+			// いたので writeShowDetails に到達せず、`n` を連打すると内訳を一度も
+			// 見ないままバナーだけが出ていた (#5512)。Web は isGameEnd でも内訳表を
+			// 出している。バナーは今までどおり最後に置く。
+			p.writeShowDetails(b, g)
 			winnerIdx := g.GetWinnerIdx()
 			banner := i18n.Tf("cribbage.gameEnd",
 				"name", cuiPlayerName(g.GetPlayer(winnerIdx), winnerIdx))

--- a/internal/adapter/presenter/CribbageCuiPresenter_test.go
+++ b/internal/adapter/presenter/CribbageCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupCribbageCuiMock() *interfaces.MockCribbageGame {
@@ -340,4 +342,47 @@ func TestCribbageCuiPresenter_HintOutput(t *testing.T) {
 		m.On("GetHint").Return(&domain.CribbageHint{Type: "play"})
 		assert.Contains(t, p.HintOutput(m), "ヒントはありません")
 	})
+}
+
+// #5512: ゲーム終了時は勝者バナーの手前で早期 return しており、writeShowDetails に
+// 到達しない。**`n` を連打すると、最終ラウンドの内訳を一度も見ないまま終わる。**
+// Web は (isShowPhase || isRoundEnd || isGameEnd) で内訳表を出している。
+func TestCribbageCuiPresenter_ShowsTheBreakdownAtGameEnd(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+	p := new(presenter.CribbageCuiPresenter)
+
+	withEnd := func() *interfaces.MockCribbageGame {
+		m, _ := setupCribbageCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetGameEndFlag")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetWinnerIdx")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetHandScoreDetails")
+		m.On("GetGameEndFlag").Return(true)
+		m.On("GetWinnerIdx").Return(0)
+		m.On("GetPhase").Return(domain.CribbagePhaseRoundEnd)
+		m.On("GetHandScoreDetails").Return([3]*domain.CribbageScoreDetail{
+			{Total: 8, Fifteens: 4, Pairs: 2, Runs: 2, Flush: 0, Nobs: 0},
+			{Total: 5, Fifteens: 2, Pairs: 0, Runs: 3, Flush: 0, Nobs: 0},
+			{Total: 3, Fifteens: 2, Pairs: 0, Runs: 0, Flush: 0, Nobs: 1},
+		})
+		return m
+	}
+
+	out := p.Output(withEnd(), nil)
+
+	// 最終ラウンドの内訳が3行とも出ること。
+	for _, want := range []struct{ label, total string }{
+		{i18n.T("cribbage.showLabelPone"), "8"},
+		{i18n.T("cribbage.showLabelDealer"), "5"},
+		{i18n.T("cribbage.showLabelCrib"), "3"},
+	} {
+		assert.Contains(t, out, want.label)
+		assert.Contains(t, out, want.total)
+	}
+
+	// **勝者バナーは今までどおり出る。** 内訳を足したせいで消えていないこと。
+	// 勝者名は presenter 内部のヘルパで作るので、ここでは文言の骨格だけ確かめる。
+	assert.Contains(t, out, strings.Split(i18n.T("cribbage.gameEnd"), "{{")[0])
 }


### PR DESCRIPTION
## 背景

`CribbageCuiPresenter.Output` はゲーム終了時に

```go
if g.GetGameEndFlag() {
    ...勝者バナー...
    return
}
```

と**早期 return** しており、`writeShowDetails` に到達しない。ラウンド終了
(`CribbagePhaseRoundEnd`) の間は内訳が出るので、**`n` / `next` を連打すると
最終ラウンドの 15の目・ペア・ラン・フラッシュ・His Nobs を一度も見ないまま
終了バナーだけが出て終わる。**

Web の `CribbagePage.tsx` は `(isShowPhase || isRoundEnd || isGameEnd)` で
内訳テーブルを出している。

## 変更

バナーの**前**に `writeShowDetails` を呼ぶ。バナーの内容と位置（最後）は
変えていない（受け入れ条件 2）。

## テスト

- 終了時の出力に3行（pone / dealer / crib）の内訳が出ること
- **勝者バナーが消えていないこと**

**変異テスト（実測）**:

| 変異 | 落ちたテスト |
|---|---|
| 内訳の呼び出しを消す（元の状態） | 6 |
| バナーを空文字にする | 5 |

Closes #5512