### PR TITLE
feat(bridge): say when the dummy's turn is really the human's

### DIFF
--- a/internal/adapter/presenter/BridgeCuiPresenter.go
+++ b/internal/adapter/presenter/BridgeCuiPresenter.go
@@ -173,8 +173,17 @@ func (p *BridgeCuiPresenter) Output(b interfaces.BridgeGame, lastErr error) stri
 			sb.WriteString(i18n.T("bridge.promptBidHelp") + "\n")
 		case domain.BridgePhasePlay:
 			currentIdx := b.GetCurrentPlayerIdx()
-			sb.WriteString(i18n.Tf("bridge.promptPlay",
-				"name", cuiPlayerName(b.GetPlayer(currentIdx), currentIdx)) + "\n")
+			// **ダミーの手番は人間が打つ。** IsHumanTurn はそれを判定しているのに
+			// CUI は一度も呼ばず、人間が操作すべき局面で CPU の名前を出していた
+			// (#5516)。Web は yourTurnDummy で明示している。判定はドメインに任せる
+			// -- ここで declarer/dummy を突き合わせ直すと、片方だけ変わったときにずれる。
+			if currentIdx == b.GetDummyIdx() && b.IsHumanTurn() {
+				sb.WriteString(i18n.Tf("bridge.promptPlayDummy",
+					"seat", cuiPlayerName(b.GetPlayer(currentIdx), currentIdx)) + "\n")
+			} else {
+				sb.WriteString(i18n.Tf("bridge.promptPlay",
+					"name", cuiPlayerName(b.GetPlayer(currentIdx), currentIdx)) + "\n")
+			}
 			sb.WriteString(i18n.T("bridge.promptPlayHelp") + "\n")
 		case domain.BridgePhaseTrickEnd:
 			sb.WriteString(i18n.T("bridge.promptTrickEnd") + "\n")

--- a/internal/adapter/presenter/BridgeCuiPresenter_test.go
+++ b/internal/adapter/presenter/BridgeCuiPresenter_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -619,4 +620,60 @@ func TestBridgeCuiPresenter_GuidesTheBidding(t *testing.T) {
 	both := p.Output(build(true, true, true), nil)
 	assert.Contains(t, both, "リダブルできます")
 	assert.NotContains(t, both, "相手のコントラクトにダブルできます")
+}
+
+// #5516: IsHumanTurn はダミーの手番かつ人間がデクレアラーなら true を返すのに、
+// CUI はそれを一度も呼ばず、常に currentIdx の名前を出す。**人間が操作すべき
+// 局面で CPU の名前が出る。** Web は yourTurnDummy で明示している。
+func TestBridgeCuiPresenter_DummyTurnReadsAsTheHumansTurn(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+	p := new(presenter.BridgeCuiPresenter)
+
+	// 人間 (0) がデクレアラー、ダミーは 2。手番はダミー。
+	newDummyTurn := func() *domain.Bridge {
+		b := domain.NewDefaultBridge()
+		b.Reset()
+		b.SetPhase(domain.BridgePhasePlay)
+		b.SetDeclarerIdx(0)
+		b.SetDummyIdx(2)
+		b.SetCurrentPlayerIdx(2)
+		return b
+	}
+
+	t.Run("names the human, not the dummy seat's CPU", func(t *testing.T) {
+		b := newDummyTurn()
+		require.True(t, b.IsHumanTurn(), "前提: ドメインは人間の手番と判定している")
+		out := p.Output(b, nil)
+		assert.Contains(t, out, i18n.Tf("bridge.promptPlayDummy", "seat", "CPU 2"))
+	})
+
+	// **ダミー席というだけでは足りない。** CPU がデクレアラーなら、ダミーの手番でも
+	// 打つのは CPU。席だけで判定すると、人間と無関係な局面で「あなたの手番です」と出る。
+	t.Run("stays quiet on a dummy seat when a CPU is the declarer", func(t *testing.T) {
+		b := domain.NewDefaultBridge()
+		b.Reset()
+		b.SetPhase(domain.BridgePhasePlay)
+		b.SetDeclarerIdx(1) // CPU がデクレアラー
+		b.SetDummyIdx(3)
+		b.SetCurrentPlayerIdx(3) // ダミー席の手番
+		require.False(t, b.IsHumanTurn(), "前提: 人間の手番ではない")
+		assert.NotContains(t, p.Output(b, nil),
+			strings.Split(i18n.T("bridge.promptPlayDummy"), "{{")[0])
+	})
+
+	// **通常の手番表示は変えない。** CPU が本当に打つ番では従来どおり。
+	t.Run("leaves an ordinary CPU turn alone", func(t *testing.T) {
+		b := domain.NewDefaultBridge()
+		b.Reset()
+		b.SetPhase(domain.BridgePhasePlay)
+		b.SetDeclarerIdx(1)
+		b.SetDummyIdx(3)
+		b.SetCurrentPlayerIdx(1)
+		require.False(t, b.IsHumanTurn())
+		// 席名に依らず、ダミー用の文言の骨格が出ていないこと。
+		assert.NotContains(t, p.Output(b, nil),
+			strings.Split(i18n.T("bridge.promptPlayDummy"), "{{")[0])
+	})
 }

--- a/internal/i18n/locales/en/bridge.json
+++ b/internal/i18n/locales/en/bridge.json
@@ -40,5 +40,6 @@
   "hintReasonSupportPartner": "support partner",
   "hintReasonCompetitiveBid": "competitive bid",
   "bidHistory": "Auction: {{bids}}",
-  "bidHistoryEntry": "{{name}}: {{bid}}"
+  "bidHistoryEntry": "{{name}}: {{bid}}",
+  "promptPlayDummy": "Your turn — play from the dummy's hand ({{seat}})"
 }

--- a/internal/i18n/locales/ja/bridge.json
+++ b/internal/i18n/locales/ja/bridge.json
@@ -40,5 +40,6 @@
   "hintReasonSupportPartner": "パートナーをサポート",
   "hintReasonCompetitiveBid": "競り合い",
   "bidHistory": "オークション: {{bids}}",
-  "bidHistoryEntry": "{{name}}:{{bid}}"
+  "bidHistoryEntry": "{{name}}:{{bid}}",
+  "promptPlayDummy": "あなたの手番です（ダミー {{seat}} の手札から出してください）"
 }


### PR DESCRIPTION
## 背景

`Bridge.IsHumanTurn()` は「`currentPlayerIdx == dummyIdx` かつ人間がデクレアラー」の
とき **true** を返す（人間がダミーの手札から出す局面）。インターフェースにも公開
されているが、`BridgeCuiPresenter` も `BridgeCuiController` も**一度も呼んでいない。**

その結果 `promptPlay` は常に `cuiPlayerName(currentIdx)` を出し、**人間が操作すべき
局面で CPU の名前がそのまま表示される。** Web GUI は同じ場面で `yourTurnDummy` を
出しており、CUI だけがこの分かりにくさを引き継いでいた。

## 変更

ダミー席の手番かつ `IsHumanTurn()` のとき、専用の文言に切り替える。

**判定はドメインに任せる。** ここで declarer/dummy を突き合わせ直すと、片方だけ
変わったときにずれる。

## テスト

- 人間がデクレアラー + ダミーの手番 → 専用文言が出る
- **CPU がデクレアラー + ダミーの手番 → 出ない**（席だけでは足りないことの検証）
- 通常の CPU の手番 → 従来どおり

**変異テスト（実測）**:

| 変異 | 落ちたテスト |
|---|---|
| `IsHumanTurn()` を外して席だけで判定 | 1 |
| 専用文言を出さない（元の状態） | 1 |

最初は「CPU がデクレアラー」のケースを書いておらず、**席だけの判定でも変異が
生き残った**。条件の両半分を撃つケースを足してある。

Closes #5516