### PR TITLE
feat(ninetynine): mark the trick winner on the table

### DIFF
--- a/frontend/src/i18n/locales/en/ninetynine.json
+++ b/frontend/src/i18n/locales/en/ninetynine.json
@@ -89,5 +89,6 @@
     "discardLowest": "Discard your lowest card"
   },
   "hintRequested": "Hint available",
-  "noHint": "No hint available"
+  "noHint": "No hint available",
+  "trickWinnerBadge": "WIN"
 }

--- a/frontend/src/i18n/locales/ja/ninetynine.json
+++ b/frontend/src/i18n/locales/ja/ninetynine.json
@@ -89,5 +89,6 @@
     "discardLowest": "一番低いカードを捨てましょう"
   },
   "hintRequested": "ヒントがあります",
-  "noHint": "ヒントはありません"
+  "noHint": "ヒントはありません",
+  "trickWinnerBadge": "勝ち"
 }

--- a/frontend/src/pages/NinetyNinePage.test.tsx
+++ b/frontend/src/pages/NinetyNinePage.test.tsx
@@ -444,3 +444,47 @@ describe('NinetyNinePage', () => {
     });
   });
 });
+
+// #5515: サーバは leadPlayerIdx を常に返し、型にも入っていて、TrickDisplay は
+// winnerIdx バッジを出す機能を持っているのに、**このページだけ渡していない。**
+// 姉妹の Oh Hell は同じ形で出している。
+describe('NinetyNinePage trick winner badge', () => {
+  it('marks the trick winner once the trick ends', async () => {
+    mockExec.mockResolvedValue({ ...trickEndState, leadPlayerIdx: 1 });
+    renderWithProviders(<NinetyNinePage />);
+    const badge = await screen.findByTestId('trick-winner-badge');
+    expect(badge).toBeInTheDocument();
+  });
+
+  // **勝者は leadPlayerIdx。** 次のトリックのリードが直前の勝者なので、
+  // 固定値を出していれば札の位置が動かない。バッジの付いた札で見分ける。
+  it('follows leadPlayerIdx rather than a fixed seat', async () => {
+    const badgedCardAlt = async () => {
+      const badge = await screen.findByTestId('trick-winner-badge');
+      const cell = badge.closest('[data-trick-winner]');
+      return cell?.querySelector('img')?.getAttribute('alt') ?? null;
+    };
+
+    mockExec.mockResolvedValue({ ...trickEndState, leadPlayerIdx: 0 });
+    const { unmount } = renderWithProviders(<NinetyNinePage />);
+    const first = await badgedCardAlt();
+    expect(first).toBeTruthy();
+    unmount();
+
+    mockExec.mockResolvedValue({ ...trickEndState, leadPlayerIdx: 1 });
+    renderWithProviders(<NinetyNinePage />);
+    expect(await badgedCardAlt()).not.toBe(first);
+  });
+
+  // **プレイ中は出さない。** まだ決着していないトリックに勝者を付けると、
+  // リードした人が勝ったように読める。
+  //
+  // 場に札が出ている状態で確かめる -- currentTrick が空のフィクスチャだと、
+  // バッジを出す実装でも出ないので何も検証できない。
+  it('stays quiet while the trick is still being played', async () => {
+    mockExec.mockResolvedValue({ ...trickEndState, phase: 1, leadPlayerIdx: 1 });
+    renderWithProviders(<NinetyNinePage />);
+    await waitFor(() => expect(screen.getAllByRole('img').length).toBeGreaterThan(0));
+    expect(screen.queryByTestId('trick-winner-badge')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/NinetyNinePage.tsx
+++ b/frontend/src/pages/NinetyNinePage.tsx
@@ -332,6 +332,12 @@ function NinetyNinePageContent() {
                   cardWidth={cardWidth}
                   label={t('currentTrick')}
                   dataTutorial="nn-trick-display"
+                  // **サーバは勝者を送っていた。** leadPlayerIdx は常に返っていて型にも
+                  // 入っており、TrickDisplay もバッジを出せるのに、このページだけ渡して
+                  // いなかった (#5515)。次のトリックのリードが直前の勝者なので、Oh Hell と
+                  // 同じ形で使える。決着前は付けない -- リードした人が勝ったように読める。
+                  winnerIdx={isTrickEnd ? state.leadPlayerIdx : undefined}
+                  winnerLabel={t('trickWinnerBadge')}
                 />
               </div>
 


### PR DESCRIPTION
## 背景

- サーバは `NinetyNineWebPresenter` で `LeadPlayerIdx` を**常に**返している
- 型定義にも `leadPlayerIdx: number` が入っている
- `TrickDisplay` は `winnerIdx` / `winnerLabel` でバッジを出す機能を持っている
- 姉妹の `OhHellPage` は `winnerIdx={isTrickEnd ? state.leadPlayerIdx : undefined}` で実際に使っている

**このページだけ渡しておらず、届いているデータをそのまま捨てていた。**

## 変更

Oh Hell と同じ形で `winnerIdx` / `winnerLabel` を渡す。`trickWinnerBadge` を
`ninetynine` 名前空間に追加（無かった）。

**決着前は付けない。** まだ決着していないトリックに勝者を付けると、リードした人が
勝ったように読める。

## テスト

- トリック終了でバッジが出る
- **`leadPlayerIdx` に追従する**（固定値なら札の位置が動かない）
- プレイ中は出ない

3つ目は最初 `currentTrick` が空のフィクスチャで書いていて、**バッジを出す実装でも
出ないので何も検証できていなかった**（変異が生き残って気づいた）。場に札が出ている
状態に直してある。

**変異テスト（実測）**:

| 変異 | 落ちたテスト |
|---|---|
| 勝者を固定席 0 にする | 1 |
| フェーズを見ずに常に出す | 1 |

Closes #5515