### PR TITLE
feat(speed): keep the centre piles focusable before a card is selected

### DIFF
--- a/frontend/src/i18n/locales/en/speed.json
+++ b/frontend/src/i18n/locales/en/speed.json
@@ -41,5 +41,6 @@
     "drawPile": "Draw pile: cards are automatically drawn when you play",
     "flipButton": "Flip button: press when stuck to turn over new center cards"
   },
-  "centerPileCard": "Center pile {{n}}: {{card}}"
+  "centerPileCard": "Center pile {{n}}: {{card}}",
+  "centerPileNeedsSelection": "select a card from your hand first"
 }

--- a/frontend/src/i18n/locales/ja/speed.json
+++ b/frontend/src/i18n/locales/ja/speed.json
@@ -41,5 +41,6 @@
     "drawPile": "山札：カードを出すと自動で補充されます",
     "flipButton": "めくるボタン：膠着時に押してカードをめくります"
   },
-  "centerPileCard": "台札{{n}}: {{card}}"
+  "centerPileCard": "台札{{n}}: {{card}}",
+  "centerPileNeedsSelection": "手札を1枚選んでから出してください"
 }

--- a/frontend/src/pages/SpeedPage.test.tsx
+++ b/frontend/src/pages/SpeedPage.test.tsx
@@ -194,8 +194,11 @@ describe('SpeedPage', () => {
     renderWithProviders(<SpeedPage />);
     await screen.findByText('手札');
     // Center piles top with ♦5 and ♠9 → the labels name the card to play onto.
-    expect(screen.getByRole('button', { name: '台札1: ♦ 5' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '台札2: ♠ 9' })).toBeInTheDocument();
+    //
+    // 手札未選択のあいだはラベルに「まだ押せない理由」が続く (#5517) ので、
+    // 完全一致ではなく前方一致で見る。**確かめたいのは札名が入っていること。**
+    expect(screen.getByRole('button', { name: /^台札1: ♦ 5/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^台札2: ♠ 9/ })).toBeInTheDocument();
   });
 
   it('auto-plays a card via smart-click when only one valid pile exists', async () => {
@@ -574,5 +577,45 @@ describe('SpeedPage elapsed / best time', () => {
     expect(screen.getByTestId('speed-clear-time')).not.toHaveTextContent('ベスト更新');
     expect(localStorage.getItem('speed_best_time_1')).toBe('1000');
     vi.useRealTimers();
+  });
+});
+
+// #5517: 場札ボタンは手札を1枚選ぶまで HTML の disabled でタブ順から外れており、
+// **スクリーンリーダー利用者は場札2枚の存在自体を発見できない。** Cribbage の
+// ペグ制限札や Oh Hell の制限ビッドは aria-disabled + title で常にフォーカス
+// 可能にしている。
+describe('SpeedPage centre piles stay reachable', () => {
+  const centrePiles = () =>
+    screen.getAllByRole('button').filter((b) => /^台札\d/.test(b.getAttribute('aria-label') ?? ''));
+
+  it('keeps the piles focusable before a card is selected', async () => {
+    mockExec.mockResolvedValue(playState);
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(centrePiles().length).toBeGreaterThan(0));
+
+    for (const pile of centrePiles()) {
+      // **native disabled はフォーカスを奪う。** aria-disabled で伝える。
+      expect(pile).not.toBeDisabled();
+      expect(pile).toHaveAttribute('aria-disabled', 'true');
+    }
+  });
+
+  // **押しても何も起きない。** フォーカスできることと、操作が通ることは別。
+  it('does nothing when clicked with no card selected', async () => {
+    mockExec.mockResolvedValue(playState);
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(centrePiles().length).toBeGreaterThan(0));
+
+    mockExec.mockClear();
+    fireEvent.click(centrePiles()[0]);
+    expect(mockExec).not.toHaveBeenCalledWith('play', expect.anything(), expect.anything());
+  });
+
+  // 理由が読み上げられること。ラベルが素のままだと、なぜ押せないのか分からない。
+  it('explains why the pile cannot be played yet', async () => {
+    mockExec.mockResolvedValue(playState);
+    renderWithProviders(<SpeedPage />);
+    await waitFor(() => expect(centrePiles().length).toBeGreaterThan(0));
+    expect(centrePiles()[0].getAttribute('aria-label')).toMatch(/選/);
   });
 });

--- a/frontend/src/pages/SpeedPage.test.tsx
+++ b/frontend/src/pages/SpeedPage.test.tsx
@@ -608,6 +608,10 @@ describe('SpeedPage centre piles stay reachable', () => {
 
     mockExec.mockClear();
     fireEvent.click(centrePiles()[0]);
+    // **クリック直後の not.toHaveBeenCalled は常に通る** (呼び出しは非同期)。
+    // 通るはずの操作を1つ挟んで、そこまで進んでもなお play が飛んでいないことを見る。
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
     expect(mockExec).not.toHaveBeenCalledWith('play', expect.anything(), expect.anything());
   });
 

--- a/frontend/src/pages/SpeedPage.tsx
+++ b/frontend/src/pages/SpeedPage.tsx
@@ -234,22 +234,41 @@ function SpeedPageContent() {
 
             {/* Center piles — clickable for play (normal) or flip (stuck) */}
             <div className="relative flex items-center justify-center gap-6" data-tutorial="sp-center-piles">
-              {state.centerPiles.map((card, pi) => (
-                <button
-                  type="button"
-                  key={pi}
-                  onClick={isStuck ? handleFlip : () => handlePlay(pi)}
-                  disabled={isStuck ? loading : !isPlayPhase || selectedCardIndices.length !== 1 || loading}
-                  className={`transition-transform hover:scale-105 disabled:opacity-50 ${focusRingCard}${isStuck && !loading ? ' animate-pulse cursor-pointer' : ''}`}
-                  aria-label={
-                    isStuck
-                      ? t('flipCenterPile', { n: pi + 1 })
-                      : t('centerPileCard', { n: pi + 1, card: cardAlt(card) })
-                  }
-                >
-                  {card && <AnimatedCard card={card} width={cardWidth * 1.2} />}
-                </button>
-              ))}
+              {state.centerPiles.map((card, pi) => {
+                // **native disabled はタブ順から外す。** 手札を1枚選ぶまで場札が
+                // 消えるので、スクリーンリーダー利用者は場札の存在自体を発見できな
+                // かった (#5517)。Cribbage のペグ制限札や Oh Hell の制限ビッドと同じ
+                // く aria-disabled で「今は押せない理由」を伝え、フォーカスは残す。
+                // クリックは下の early return で無効化する。
+                const notPlayable = !isStuck && (!isPlayPhase || selectedCardIndices.length !== 1);
+                return (
+                  <button
+                    type="button"
+                    key={pi}
+                    onClick={
+                      isStuck
+                        ? handleFlip
+                        : () => {
+                            if (notPlayable) return;
+                            handlePlay(pi);
+                          }
+                    }
+                    disabled={loading}
+                    aria-disabled={notPlayable || undefined}
+                    title={notPlayable ? t('centerPileNeedsSelection') : undefined}
+                    className={`transition-transform hover:scale-105 disabled:opacity-50 ${focusRingCard}${isStuck && !loading ? ' animate-pulse cursor-pointer' : ''}${notPlayable ? ' opacity-50 cursor-not-allowed' : ''}`}
+                    aria-label={
+                      isStuck
+                        ? t('flipCenterPile', { n: pi + 1 })
+                        : notPlayable
+                          ? `${t('centerPileCard', { n: pi + 1, card: cardAlt(card) })} (${t('centerPileNeedsSelection')})`
+                          : t('centerPileCard', { n: pi + 1, card: cardAlt(card) })
+                    }
+                  >
+                    {card && <AnimatedCard card={card} width={cardWidth * 1.2} />}
+                  </button>
+                );
+              })}
               {isStuck && (
                 // Centering container: keeps the popup glued to the center
                 // even while animate-bounce drives its own transform on the


### PR DESCRIPTION
## 背景

場札ボタンは

```tsx
disabled={isStuck ? loading : !isPlayPhase || selectedCardIndices.length !== 1 || loading}
```

としており、**手札を1枚選ぶまで HTML の `disabled` でタブ順から完全に外れる。**
スクリーンリーダー利用者は、場札2枚の存在自体をタブ操作で発見できない。

このコードベースには「押せないが理由を伝えたい」操作を `aria-disabled` + `title` で
**常にフォーカス可能**にする確立済みパターンがある（Cribbage のペグ制限札 #1865、
Oh Hell の制限ビッド、Ninety-Nine の埋め枚数不足ボタン）。Speed だけが素の
`disabled` を使っていた。

## 変更

- native の `disabled` は**ローディング中だけ**
- 押せないことは `aria-disabled`、理由は `title` と aria-label 末尾で伝える
- クリックは `onClick` 側の early return で無効化

## テスト

- 未選択でも場札がフォーカス可能（`not.toBeDisabled()` + `aria-disabled="true"`）
- 未選択でクリックしても `play` が飛ばない
- ラベルから理由が読める

既存の「aria-label に札名が入る」テストは、未選択時に理由が続くようになったため
**完全一致から前方一致に変えた**。確かめたいのは札名が入っていることなので、
検証の意図は保っている。

**変異テスト（実測）**:

| 変異 | 結果 |
|---|---|
| native `disabled` を戻す | ✔ 1 件 fail |
| ラベルから理由を落とす | ✔ 1 件 fail |
| `onClick` の early return を消す | ✘ 落ちない |

3つ目が落ちないのは、`useSpeedGame.handlePlay` 自身が
`selectedCardIndices.length !== 1` で早期 return しているためです。**未選択の
クリックは二重に守られている**ので、テストはどちらの層でも通ります。early return
を残しているのは `!isPlayPhase` 側（フックが見ていない条件）のためです。

Closes #5517