### PR TITLE
test(euchre): stop the hint-score test asking twice for a coin toss

### DIFF
--- a/internal/adapter/presenter/EuchreCuiPresenter_test.go
+++ b/internal/adapter/presenter/EuchreCuiPresenter_test.go
@@ -500,6 +500,24 @@ func TestEuchreCuiPresenter_HintShowsTheScore(t *testing.T) {
 	e.Reset()
 	e.SetPhase(domain.EuchrePhasePickUp)
 	e.SetBidPlayerIdx(0)
+	e.SetDealerIdx(1) // ディーラーはフェイスアップを貰えるので +1 される。席をずらして避ける
+	e.SetFaceUpCard(domain.NewCard(domain.CardDesignSpade, 9, false))
+
+	// **配られた手札のままでは比べられない。** evalHandForTrump は切り札の Q と
+	// 非切り札の A を rand.Intn(2) で数えるので、GetHint を 2 回呼ぶと違う値が返る。
+	// 呼ぶたびに答えが変わる札を 1 枚も含まない手札に差し替える
+	// (右バウアー +2、切り札 K +1、残りは 0 点 = 3 点固定)。
+	hand := e.GetPlayer(0)
+	hand.Reset()
+	for _, c := range []*domain.Card{
+		domain.NewCard(domain.CardDesignSpade, 11, false),
+		domain.NewCard(domain.CardDesignSpade, 13, false),
+		domain.NewCard(domain.CardDesignHeart, 10, false),
+		domain.NewCard(domain.CardDesignHeart, 9, false),
+		domain.NewCard(domain.CardDesignDiamond, 10, false),
+	} {
+		hand.AddCard(c)
+	}
 
 	hint := e.GetHint()
 	require.NotNil(t, hint)
@@ -514,6 +532,8 @@ func TestEuchreCuiPresenter_HintShowsTheScore(t *testing.T) {
 	// しきい値も文言から読めること。
 	assert.Contains(t, out, strconv.Itoa(domain.EuchreOrderUpScore))
 	assert.Contains(t, out, strconv.Itoa(domain.EuchreGoAloneScore))
+	// 手札が固定なら値も固定 -- 3 点はオーダーアップのしきい値ちょうど。
+	assert.Equal(t, domain.EuchreOrderUpScore, *hint.Score)
 }
 
 // スコアを持たない局面 (カードプレイのヒント) では行を出さない。


### PR DESCRIPTION
`TestEuchreCuiPresenter_HintShowsTheScore` (added by #5509) fails ~28% of the time.
It surfaced today as a red **Backend Tests** on #5876, whose diff does not touch Euchre.

## 原因

`evalHandForTrump` は切り札の Q と非切り札の A を `rand.Intn(2)` で数える。
つまり **`GetHint()` は呼ぶたびに違う Score を返す**。テストは 1 回呼んでから
`HintOutput` を呼び (これが内部でもう一度 `GetHint` する)、2 つの数字を比べていた。
比べていたのは「同じ値が伝わったか」ではなく「2 回のコイントスが一致したか」。

## 直し方

コイントスの対象になる札を 1 枚も含まない手札に差し替えた (右バウアー +2、
切り札 K +1、残り 0 点 = 3 点固定)。ディーラー席も 0 番から動かした —
ディーラーはフェイスアップカードを貰えるぶん +1 されるため。

## 実測 (負のコントロール付き)

| 版 | `-count=200` の失敗数 |
|---|---|
| 修正前 | **56 / 200** |
| 修正後 | **0 / 200** |

## 残る問題 (別issueにします)

ヒント自身が乱数を引くので、**同じ手札でヒントを 2 回押すと違う点数・違う推奨が出る**。
1 回のレンダリング内では `HintOutput` が hint オブジェクトを 1 つ使うので矛盾はしないが、
プレイヤーから見れば助言が安定しない。ドメイン側の設計判断なのでこの PR には含めない。