### PR TITLE
feat(gofish): make the hint name the rank it is recommending

### DIFF
--- a/frontend/src/i18n/locales/en/gofish.json
+++ b/frontend/src/i18n/locales/en/gofish.json
@@ -41,8 +41,8 @@
     "resetButton": "Press reset to start a new game."
   },
   "hint": {
-    "askKnownRank": "Ask for the rank an opponent recently took",
-    "askMostCopies": "Ask for the rank you hold most copies of"
+    "askKnownRank": "Ask for rank {{rank}} — an opponent took it recently",
+    "askMostCopies": "Ask for rank {{rank}} — you hold the most copies of it"
   },
   "a11y": {
     "targetSelected": "Selected {{name}}",

--- a/frontend/src/i18n/locales/ja/gofish.json
+++ b/frontend/src/i18n/locales/ja/gofish.json
@@ -41,8 +41,8 @@
     "resetButton": "リセットボタンで新しいゲームを始められます。"
   },
   "hint": {
-    "askKnownRank": "直前に相手が取ったランクを要求推奨",
-    "askMostCopies": "最も多く持っているランクを要求推奨"
+    "askKnownRank": "直前に相手が取ったランク {{rank}} を要求推奨",
+    "askMostCopies": "最も多く持っているランク {{rank}} を要求推奨"
   },
   "a11y": {
     "targetSelected": "{{name}} を選択",

--- a/frontend/src/pages/GoFishPage.test.tsx
+++ b/frontend/src/pages/GoFishPage.test.tsx
@@ -335,6 +335,28 @@ describe('GoFishPage', () => {
     await waitFor(() => expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument());
   });
 
+  // #5518: 文言は「最も多く持っているランク」と言うのに、どの札のことか
+  // 盤面には出ていなかった。
+  it('marks the cards of the rank the hint names, and only those', async () => {
+    localStorage.setItem('hint_enabled_gofish', 'true');
+    renderWithProviders(<GoFishPage />);
+    await waitFor(() => expect(screen.getByTestId('hint-tooltip')).toBeInTheDocument());
+
+    // 手札は ♠7 ♥7 ♦3 -- 7 が2枚なので 7 の2枚だけに印が付く。
+    expect(screen.getByRole('button', { name: '♠ 7' })).toHaveAttribute('data-hint-card', 'true');
+    expect(screen.getByRole('button', { name: '♥ 7' })).toHaveAttribute('data-hint-card', 'true');
+    expect(screen.getByRole('button', { name: '♦ 3' })).not.toHaveAttribute('data-hint-card');
+    // ツールチップもランクを名指しする。
+    expect(screen.getByTestId('hint-tooltip')).toHaveTextContent('7');
+  });
+
+  it('marks nothing while the hint is switched off', async () => {
+    localStorage.setItem('hint_enabled_gofish', 'false');
+    renderWithProviders(<GoFishPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: '♠ 7' })).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: '♠ 7' })).not.toHaveAttribute('data-hint-card');
+  });
+
   it('shows books display when human has books', async () => {
     const stateWithBooks: GoFishResponse = {
       ...baseState,

--- a/frontend/src/pages/GoFishPage.tsx
+++ b/frontend/src/pages/GoFishPage.tsx
@@ -340,25 +340,35 @@ function GoFishPageContent() {
             {/* Human cards */}
             {humanPlayer && (
               <div className="flex flex-wrap gap-1 mb-2" data-tutorial="gf-player-hand">
-                {humanPlayer.cards.map((card) => (
-                  <button
-                    type="button"
-                    key={`${card.design}-${card.value}`}
-                    onClick={() => handleSelectRank(card.value)}
-                    aria-label={cardAlt(card)}
-                    aria-pressed={selectedRank === card.value}
-                    className={`transition-transform ${focusRingCard}`}
-                    style={{
-                      background: 'none',
-                      padding: 0,
-                      borderRadius: 8,
-                      ...selectedCardStyle(selectedRank === card.value),
-                      boxSizing: 'border-box',
-                    }}
-                  >
-                    <AnimatedCard card={card} width={cardWidth} />
-                  </button>
-                ))}
+                {humanPlayer.cards.map((card, i) => {
+                  // ヒントが名指ししたランクの札に印を付ける。文言だけでは
+                  // 結局プレイヤーが手札を数え直すことになる (#5518)。
+                  const isSuggested = frontendHintEnabled && (frontendHint?.targetIndices?.includes(i) ?? false);
+                  return (
+                    <button
+                      type="button"
+                      key={`${card.design}-${card.value}`}
+                      onClick={() => handleSelectRank(card.value)}
+                      aria-label={cardAlt(card)}
+                      aria-pressed={selectedRank === card.value}
+                      className={[
+                        'transition-transform',
+                        focusRingCard,
+                        isSuggested ? 'ring-2 ring-ds-warning' : '',
+                      ].join(' ')}
+                      data-hint-card={isSuggested ? 'true' : undefined}
+                      style={{
+                        background: 'none',
+                        padding: 0,
+                        borderRadius: 8,
+                        ...selectedCardStyle(selectedRank === card.value),
+                        boxSizing: 'border-box',
+                      }}
+                    >
+                      <AnimatedCard card={card} width={cardWidth} />
+                    </button>
+                  );
+                })}
               </div>
             )}
 

--- a/frontend/src/utils/hints/gofishHint.test.ts
+++ b/frontend/src/utils/hints/gofishHint.test.ts
@@ -63,6 +63,44 @@ describe('getGoFishHint', () => {
     expect(hint?.reason).toBe('hint.askMostCopies');
   });
 
+  // #5518: 文言は「最も多く持っているランク」と言うのに、どのランクかは返って
+  // いなかった。プレイヤーは助言を読んだあと自分で手札を数え直すことになる。
+  it('names the rank it holds most copies of, and points at those cards', () => {
+    const hint = getGoFishHint(makeState()); // H5 S5 D8 C3 -> 5 が2枚
+    expect(hint?.reasonParams).toEqual({ rank: '5' });
+    expect(hint?.targetIndices).toEqual([0, 1]);
+  });
+
+  it('labels a face rank by its letter, not its number', () => {
+    const state = makeState();
+    state.players[0].cards = [card('HEART', 13), card('SPADE', 13), card('DIAMOND', 8)];
+    const hint = getGoFishHint(state);
+    expect(hint?.reasonParams).toEqual({ rank: 'K' });
+    expect(hint?.targetIndices).toEqual([0, 1]);
+  });
+
+  // **同数のときの選び方を固定する。**手札の並び順に任せると、同じ盤面でも
+  // 引き直すたびに違うランクを勧めることになる。
+  it('breaks a tie by the lowest rank, whatever the hand order is', () => {
+    const state = makeState();
+    state.players[0].cards = [card('HEART', 9), card('SPADE', 9), card('DIAMOND', 4), card('CLOVER', 4)];
+    expect(getGoFishHint(state)?.reasonParams).toEqual({ rank: '4' });
+    expect(getGoFishHint(state)?.targetIndices).toEqual([2, 3]);
+
+    state.players[0].cards = [card('DIAMOND', 4), card('CLOVER', 4), card('HEART', 9), card('SPADE', 9)];
+    expect(getGoFishHint(state)?.reasonParams).toEqual({ rank: '4' });
+    expect(getGoFishHint(state)?.targetIndices).toEqual([0, 1]);
+  });
+
+  // A は 1 として持っているが、表示は "A"。数の小さい順のタイブレークでは
+  // 一番若いランクなので先に選ばれる。
+  it('treats the ace as the lowest rank', () => {
+    const state = makeState();
+    state.players[0].cards = [card('HEART', 7), card('SPADE', 7), card('DIAMOND', 1), card('CLOVER', 1)];
+    expect(getGoFishHint(state)?.reasonParams).toEqual({ rank: 'A' });
+    expect(getGoFishHint(state)?.targetIndices).toEqual([2, 3]);
+  });
+
   it('upgrades confidence when a cpu has recently taken a rank the human holds', () => {
     const state = makeState({
       cpuActions: [
@@ -81,6 +119,29 @@ describe('getGoFishHint', () => {
     const hint = getGoFishHint(state);
     expect(hint?.confidence).toBe('strong');
     expect(hint?.reason).toBe('hint.askKnownRank');
+    // 既知のランクも同じで、見つけた値を捨てずに返す。
+    expect(hint?.reasonParams).toEqual({ rank: '5' });
+    expect(hint?.targetIndices).toEqual([0, 1]);
+  });
+
+  // 既知のランクが複数あるときも、手札の並び順ではなく若い順に決める。
+  it('picks the lowest known rank when an opponent revealed several', () => {
+    const state = makeState({
+      cpuActions: [8, 3].map((askRank) => ({
+        askPlayerIdx: 1,
+        askTargetIdx: 2,
+        askRank,
+        success: true,
+        cardsReceived: 1,
+        drawnCard: null,
+        bookFormed: false,
+        bookRank: 0,
+      })),
+    });
+    const hint = getGoFishHint(state); // 手札は H5 S5 D8 C3
+    expect(hint?.reason).toBe('hint.askKnownRank');
+    expect(hint?.reasonParams).toEqual({ rank: '3' });
+    expect(hint?.targetIndices).toEqual([3]);
   });
 
   it('uses lastAsk when available', () => {

--- a/frontend/src/utils/hints/gofishHint.ts
+++ b/frontend/src/utils/hints/gofishHint.ts
@@ -1,6 +1,7 @@
-import type { GoFishCpuAction, GoFishLastAsk, GoFishResponse } from '../../types/card';
+import type { Card, GoFishCpuAction, GoFishLastAsk, GoFishResponse } from '../../types/card';
 import type { HintResult } from '../../types/hint';
 import { GoFishPhase } from '../../types/phases';
+import { valueName } from '../cardUtils';
 
 /** Returns a frontend HintResult for Go Fish, or null if no suggestion. */
 export function getGoFishHint(state: GoFishResponse): HintResult | null {
@@ -15,10 +16,55 @@ export function getGoFishHint(state: GoFishResponse): HintResult | null {
 
   const knownOpponentRank = findOpponentKnownRank(state, humanIdx);
   if (knownOpponentRank !== null) {
-    return { targetAction: 'ask', reason: 'hint.askKnownRank', confidence: 'strong' };
+    return {
+      targetAction: 'ask',
+      reason: 'hint.askKnownRank',
+      confidence: 'strong',
+      ...pointAtRank(human.cards, knownOpponentRank),
+    };
   }
 
-  return { targetAction: 'ask', reason: 'hint.askMostCopies', confidence: 'moderate' };
+  return {
+    targetAction: 'ask',
+    reason: 'hint.askMostCopies',
+    confidence: 'moderate',
+    ...pointAtRank(human.cards, mostCopiesRank(human.cards)),
+  };
+}
+
+/**
+ * Name a rank and point at every card of it in the hand.
+ *
+ * Both reasons promise a specific rank -- "the rank you hold most copies of",
+ * "the rank an opponent recently took" -- and the hint used to return neither
+ * the rank nor the cards, leaving the player to count the hand again (#5518).
+ */
+function pointAtRank(cards: Card[], rank: number): Pick<HintResult, 'reasonParams' | 'targetIndices'> {
+  const targetIndices = cards.map((c, i) => (c.value === rank ? i : -1)).filter((i) => i >= 0);
+  return { reasonParams: { rank: valueName(rank) }, targetIndices };
+}
+
+/**
+ * The rank held in the most copies, ties broken by the lowest rank.
+ *
+ * **The tie-break has to be on the rank, not on hand order.** Picking the first
+ * one encountered makes the same board recommend a different rank once the hand
+ * is re-sorted.
+ */
+function mostCopiesRank(cards: Card[]): number {
+  const counts = new Map<number, number>();
+  for (const c of cards) {
+    counts.set(c.value, (counts.get(c.value) ?? 0) + 1);
+  }
+  let best = cards[0].value;
+  let bestCount = 0;
+  for (const [rank, count] of [...counts].sort((a, b) => a[0] - b[0])) {
+    if (count > bestCount) {
+      best = rank;
+      bestCount = count;
+    }
+  }
+  return best;
 }
 
 /**
@@ -38,10 +84,10 @@ function findOpponentKnownRank(state: GoFishResponse, humanIdx: number): number 
     collectFromCpuAction(action, humanIdx, knownRanks);
   }
 
-  for (const rank of humanRanks) {
-    if (knownRanks.has(rank)) return rank;
-  }
-  return null;
+  // 若い順に見る。手札の並び順に任せると、同じ盤面でも並べ替えただけで
+  // 勧めるランクが変わる。
+  const matches = [...humanRanks].filter((rank) => knownRanks.has(rank));
+  return matches.length > 0 ? Math.min(...matches) : null;
 }
 
 function collectFromLastAsk(lastAsk: GoFishLastAsk | null, humanIdx: number, out: Set<number>): void {


### PR DESCRIPTION
Closes #5518

## 何が起きていたか

ヒントの文言はどちらも**特定のランクを教える体裁**なのに、返り値にランクが入っていなかった:

| キー | 文言 (ja) | 実際に返していたもの |
|---|---|---|
| `hint.askMostCopies` | 最も多く持っているランクを要求推奨 | `targetAction: 'ask'` だけ |
| `hint.askKnownRank` | 直前に相手が取ったランクを要求推奨 | `targetAction: 'ask'` だけ |

既知ランクのほうは分かりやすい形で落ちていて、`findOpponentKnownRank` が
**ランクを計算したうえで呼び出し側が捨てていた**。プレイヤーは助言を読んだあと
結局自分で手札を数え直すことになる。

## 直したこと

- ランクを `reasonParams.rank` で返し、文言に `{{rank}}` を入れた (ja/en 両方)
- そのランクの手札インデックスを `targetIndices` で返し、ページ側で
  Anaconda と同じ `ring-2 ring-ds-warning` + `data-hint-card` を付ける
- **どちらの選び方もランクで決めるようにした**。最多枚数は同数なら小さいランク、
  既知ランクが複数あるときも小さいランク。これまでは手札の並び順で決まっていたので、
  **並べ替えただけで勧めるランクが変わった**

## テスト計画

- [x] `gofishHint.test.ts` に 5 件追加 (最多ランクの特定、絵札は "K" 表記、
      同数のタイブレーク、A を最小として扱う、既知ランクが複数のとき)
- [x] `GoFishPage.test.tsx` に 2 件追加 (♠7 ♥7 だけに印が付き ♦3 には付かない /
      ヒント OFF では何も付かない)
- [x] `bun run check` / `bun run typecheck` / 既存 43 件緑

### 変異テスト (4件とも検出)

| 変異 | 落ちたテスト |
|---|---|
| ページが `data-hint-card` を付けない | 1 |
| 既知ランクのタイブレークが手札順に戻る | 1 |
| 最多ランクのタイブレークが手札順に戻る | 2 |
| ランクは名指しするが札を指さない | 7 |