### PR TITLE
feat(pinochle): show what each meld is worth while the bid is being decided

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -40241,6 +40241,18 @@ components:
           type: array
           items:
             type: integer
+        meldTable:
+          type: array
+          description: >-
+            Points for each of the 15 meld types, cheapest first. Sent by the
+            server so the UI never carries a second copy of the scoring values.
+          items:
+            type: object
+            properties:
+              type:
+                type: integer
+              points:
+                type: integer
         message:
           type: string
         messageCode:

--- a/frontend/src/i18n/locales/en/pinochle.json
+++ b/frontend/src/i18n/locales/en/pinochle.json
@@ -78,5 +78,6 @@
   "bidAmountLabel": "Bid amount (min {{min}})",
   "bidTooLow": "Bid must be at least {{min}}.",
   "hintRequested": "Hint available",
-  "noHint": "No hint available"
+  "noHint": "No hint available",
+  "meldTableTitle": "Meld reference"
 }

--- a/frontend/src/i18n/locales/ja/pinochle.json
+++ b/frontend/src/i18n/locales/ja/pinochle.json
@@ -78,5 +78,6 @@
   "bidAmountLabel": "ビッド額（最低 {{min}}）",
   "bidTooLow": "ビッド額は {{min}} 以上にしてください",
   "hintRequested": "ヒントがあります",
-  "noHint": "ヒントはありません"
+  "noHint": "ヒントはありません",
+  "meldTableTitle": "メルド早見表"
 }

--- a/frontend/src/pages/PinochlePage.test.tsx
+++ b/frontend/src/pages/PinochlePage.test.tsx
@@ -46,6 +46,12 @@ const bidPhaseState: PinochleResponse = {
   winnerTeam: -1,
   leadPlayerIdx: -1,
   playerMelds: [[], [], [], []],
+  meldTable: [
+    { type: 0, points: 10 },
+    { type: 1, points: 20 },
+    { type: 2, points: 40 },
+    { type: 14, points: 1500 },
+  ],
   message: '',
   config: { cpuDifficulty: 1, pointLimit: 1500 },
 };
@@ -578,5 +584,37 @@ describe('PinochlePage', () => {
     mockExec.mockResolvedValue({ ...bidPhaseState, bidPlayerIdx: 2 });
     renderWithProviders(<PinochlePage />);
     await waitFor(() => expect(document.querySelectorAll('[data-on-turn]')).toHaveLength(1));
+  });
+});
+
+// #5519: 15種類のメルドが何点なのかを対局中に見る場所がどちらのUIにも無く、
+// ビッド額を決める材料が実質的に無かった。
+describe('PinochlePage meld reference', () => {
+  it('lists the melds and the points the server sent, while bidding', async () => {
+    mockExec.mockResolvedValue(bidPhaseState);
+    renderWithProviders(<PinochlePage />);
+    const panel = await screen.findByTestId('pn-meld-table');
+    // **点数はサーバが送った値をそのまま出す。**画面側に書き写すと、
+    // 加点を直したときに表だけが古いまま残る。
+    expect(panel).toHaveTextContent('ディクス');
+    expect(panel).toHaveTextContent('10');
+    expect(panel).toHaveTextContent('ダブルラン');
+    expect(panel).toHaveTextContent('1500');
+  });
+
+  // **プレイ中は出さない。**盤面を見る場面で15行の参照表は邪魔になる。
+  it('is gone once the cards are being played', async () => {
+    mockExec.mockResolvedValue(playPhaseState);
+    renderWithProviders(<PinochlePage />);
+    await waitFor(() => expect(screen.getByText(/ラウンド/)).toBeInTheDocument());
+    expect(screen.queryByTestId('pn-meld-table')).not.toBeInTheDocument();
+  });
+
+  // 古いサーバや未対応のレスポンスでも落ちないこと。
+  it('renders nothing when the server sent no table', async () => {
+    mockExec.mockResolvedValue({ ...bidPhaseState, meldTable: undefined });
+    renderWithProviders(<PinochlePage />);
+    await waitFor(() => expect(screen.getByText(/ラウンド/)).toBeInTheDocument());
+    expect(screen.queryByTestId('pn-meld-table')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/PinochlePage.tsx
+++ b/frontend/src/pages/PinochlePage.tsx
@@ -222,6 +222,11 @@ function PinochlePageContent() {
   const humanIdx = humanPlayer ? state.players.indexOf(humanPlayer) : -1;
   const isBidTurn = phase === PinochlePhase.BID && state.players?.[state.bidPlayerIdx]?.isHuman;
   const isTrumpTurn = phase === PinochlePhase.TRUMP && state.players?.[state.currentPlayerIdx]?.isHuman;
+  // 早見表はビッド〜メルド確認の間だけ。プレイ中は盤面を見る場面なので畳む。
+  const meldTable =
+    phase === PinochlePhase.BID || phase === PinochlePhase.TRUMP || phase === PinochlePhase.MELD
+      ? state.meldTable
+      : undefined;
   const isPlayTurn = phase === PinochlePhase.PLAY && state.players?.[state.currentPlayerIdx]?.isHuman;
   // Bids must strictly beat the current highest (or start at 20). Validate on the
   // client so an empty (NaN) or too-low value can't be submitted for a server error.
@@ -343,6 +348,24 @@ function PinochlePageContent() {
                   })}
                 </div>
               </div>
+            )}
+
+            {/* Meld reference: ビッド額を決める段階で「自分の手にいくら分の目が
+                あるか」を見る先がどこにも無かった (#5519)。点数はサーバが送る
+                domain の値そのもので、ここには書き写さない。 */}
+            {meldTable && (
+              <details data-testid="pn-meld-table" className="mb-3 rounded bg-black/30">
+                <summary className="cursor-pointer select-none px-3 py-2 text-ds-text-primary font-bold text-sm">
+                  {t('meldTableTitle')}
+                </summary>
+                <ul className="px-3 pb-2 text-ds-text-muted text-sm grid grid-cols-2 sm:grid-cols-3 gap-x-3">
+                  {meldTable.map((e) => (
+                    <li key={e.type}>
+                      {t(`meldTypes.${e.type}`)} {e.points}
+                    </li>
+                  ))}
+                </ul>
+              </details>
             )}
 
             {/* Melds */}

--- a/frontend/src/types/games/pinochle.ts
+++ b/frontend/src/types/games/pinochle.ts
@@ -16,6 +16,17 @@ export interface PinochleMeldData {
   cards: Card[];
 }
 
+/**
+ * One row of the meld reference table: a meld type and what it scores.
+ *
+ * The server sends it with every state so the UI never carries a second copy
+ * of the scoring values (#5519).
+ */
+export interface PinochleMeldTableEntry {
+  type: number;
+  points: number;
+}
+
 /** Pinochle trick card data. */
 export interface PinochleTrickCard {
   playerIdx: number;
@@ -55,6 +66,7 @@ export interface PinochleResponse extends BaseGameResponse {
   leadPlayerIdx: number;
   playerMelds: PinochleMeldData[][];
   validPlayIndices?: number[];
+  meldTable?: PinochleMeldTableEntry[];
   hint?: {
     cardIndex?: number;
     bidAmount?: number;

--- a/internal/adapter/controller/PinochleWebController.go
+++ b/internal/adapter/controller/PinochleWebController.go
@@ -73,8 +73,18 @@ type PinochleWebOutput struct {
 	PlayerMelds      [4][]*PinochleWebOutputMeld `json:"playerMelds"`
 	ValidPlayIndices []int                       `json:"validPlayIndices,omitempty"`
 	Hint             *PinochleWebOutputHint      `json:"hint,omitempty"`
+	// MeldTable はメルド15種類の点数一覧 (安い順)。ビッド額を決めるときの
+	// 早見表として使う。**サーバが domain の値を送る。**フロントに書き写すと、
+	// 加点を直したときに表だけが古いまま残る (#5519)。
+	MeldTable []*PinochleWebOutputMeldTableEntry `json:"meldTable"`
 	WebOutputBase
 	Config PinochleWebOutputConfig `json:"config"`
+}
+
+// PinochleWebOutputMeldTableEntry メルド早見表の1行
+type PinochleWebOutputMeldTableEntry struct {
+	Type   int `json:"type"`
+	Points int `json:"points"`
 }
 
 // PinochleWebOutputConfig ピノクル設定アウトプット

--- a/internal/adapter/presenter/PinochleCuiPresenter.go
+++ b/internal/adapter/presenter/PinochleCuiPresenter.go
@@ -41,6 +41,33 @@ func pinochleMeldName(t domain.PinochleMeldType) string {
 	return fmt.Sprintf("meld#%d", int(t))
 }
 
+// pinochleMeldTablePerLine は早見表の1行に並べるメルドの数。
+const pinochleMeldTablePerLine = 5
+
+// pinochleMeldTableStr renders the 15 meld types and their points, cheapest
+// first, wrapped a few per line.
+//
+// **点数は domain.PinochleMeldTable() から引く。**ここに書き写すと、加点の値を
+// 直したときに表だけが古いまま残る (#5519)。
+func pinochleMeldTableStr() string {
+	var b strings.Builder
+	b.WriteString(i18n.T("pinochle.meldTableHeader"))
+	for i, e := range domain.PinochleMeldTable() {
+		switch {
+		case i == 0:
+		case i%pinochleMeldTablePerLine == 0:
+			b.WriteString("\n  ")
+		default:
+			b.WriteString(" / ")
+		}
+		b.WriteString(i18n.Tf("pinochle.meldTableEntry",
+			"type", pinochleMeldName(e.Type),
+			"points", strconv.Itoa(e.Points)))
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
 // pinochlePlayerStr returns the display string for a single Pinochle player.
 // legalIndices, when non-nil, lists the hand positions the human may legally
 // play this turn and is rendered as a follow-rule legend below their hand.
@@ -134,6 +161,13 @@ func (p *PinochleCuiPresenter) Output(g interfaces.PinochleGame, lastErr error) 
 					}
 				}
 			}
+		}
+
+		// メルド早見表: ビッド〜メルド確認の間だけ。ビッド額を決めるときに
+		// 「自分の手にいくら分の目があるか」を見る先がどこにも無かった (#5519)。
+		// プレイ中は毎トリック流れて盤面が読めなくなるので出さない。
+		if phase == domain.PinochlePhaseBid || phase == domain.PinochlePhaseTrump || phase == domain.PinochlePhaseMeld {
+			b.WriteString(pinochleMeldTableStr())
 		}
 
 		// Current trick

--- a/internal/adapter/presenter/PinochleCuiPresenter_test.go
+++ b/internal/adapter/presenter/PinochleCuiPresenter_test.go
@@ -4,9 +4,12 @@ package presenter_test
 
 import (
 	"errors"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -366,5 +369,74 @@ func TestPinochleCuiPresenter_English(t *testing.T) {
 		assert.Contains(t, result, "Dealer: You")
 		assert.Contains(t, result, "Team 0: 0pt")
 		assert.Contains(t, result, "to play")
+	})
+}
+
+// #5519: ビッドを決める段階で、15種類のメルドが何点なのかを見る場所が
+// どちらのUIにも無かった。
+func TestPinochleCuiPresenter_MeldTable(t *testing.T) {
+	p := new(presenter.PinochleCuiPresenter)
+
+	outputInPhase := func(phase domain.PinochlePhase) string {
+		m, _ := setupPinochleCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(phase)
+		return p.Output(m, nil)
+	}
+
+	// 出力から早見表の部分だけを取り出し、"名前 点数" の並びに割る。
+	entriesOf := func(out string) []string {
+		header := i18n.T("pinochle.meldTableHeader")
+		idx := strings.Index(out, header)
+		if idx < 0 {
+			return nil
+		}
+		// ヘッダの後ろから、"名前 点数" の形で読める行だけを拾う。
+		var entries []string
+		for _, line := range strings.Split(out[idx+len(header):], "\n") {
+			lineEntries := strings.Split(strings.TrimSpace(line), " / ")
+			for _, e := range lineEntries {
+				e = strings.TrimSpace(e)
+				fields := strings.Fields(e)
+				if len(fields) < 2 {
+					return entries
+				}
+				if _, err := strconv.Atoi(fields[len(fields)-1]); err != nil {
+					return entries
+				}
+				entries = append(entries, e)
+			}
+		}
+		return entries
+	}
+
+	t.Run("lists every meld with the points the domain scores it at", func(t *testing.T) {
+		entries := entriesOf(outputInPhase(domain.PinochlePhaseBid))
+		table := domain.PinochleMeldTable()
+		require.Len(t, entries, len(table))
+
+		for i, e := range table {
+			// **点数は domain の表から読む。**ここで数字を書くと、
+			// 表示と加点が食い違ってもテストは通ってしまう。
+			assert.True(t, strings.HasSuffix(entries[i], " "+strconv.Itoa(e.Points)),
+				"entry %d = %q, want it to end with %d points", i, entries[i], e.Points)
+			name := strings.TrimSuffix(entries[i], " "+strconv.Itoa(e.Points))
+			// 名前が訳されていること。未訳だとキーか "meld#3" がそのまま出る。
+			assert.NotContains(t, name, "meld#")
+			assert.NotContains(t, name, "pinochle.")
+			assert.NotEmpty(t, name)
+		}
+		// 並びは安い順。1行目がディックス、最後がダブルラン。
+		assert.Equal(t, "ディクス 10", entries[0])
+		assert.Equal(t, "ダブルラン 1500", entries[len(entries)-1])
+	})
+
+	t.Run("is available while choosing melds too", func(t *testing.T) {
+		assert.Contains(t, outputInPhase(domain.PinochlePhaseMeld), i18n.T("pinochle.meldTableHeader"))
+	})
+
+	// **プレイ中は出さない。**毎トリック15行流れると盤面が読めなくなる。
+	t.Run("is not printed once the cards are being played", func(t *testing.T) {
+		assert.NotContains(t, outputInPhase(domain.PinochlePhasePlay), i18n.T("pinochle.meldTableHeader"))
 	})
 }

--- a/internal/adapter/presenter/PinochleWebPresenter.go
+++ b/internal/adapter/presenter/PinochleWebPresenter.go
@@ -54,6 +54,17 @@ func (p *PinochleWebPresenter) buildBase(g interfaces.PinochleGame, lastErr erro
 	resObj.WinnerTeam = g.GetWinnerTeam()
 	resObj.LeadPlayerIdx = g.GetLeadPlayerIdx()
 
+	// メルド早見表。盤面ではなく固定の参照表なので毎回同じ内容だが、
+	// フロントに数値を持たせないためにサーバから送る (#5519)。
+	table := domain.PinochleMeldTable()
+	resObj.MeldTable = make([]*controller.PinochleWebOutputMeldTableEntry, 0, len(table))
+	for _, e := range table {
+		resObj.MeldTable = append(resObj.MeldTable, &controller.PinochleWebOutputMeldTableEntry{
+			Type:   int(e.Type),
+			Points: e.Points,
+		})
+	}
+
 	// 設定
 	cfg := g.GetConfig()
 	resObj.Config = controller.PinochleWebOutputConfig{

--- a/internal/adapter/presenter/PinochleWebPresenter_test.go
+++ b/internal/adapter/presenter/PinochleWebPresenter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
@@ -207,4 +208,21 @@ func TestPinochleWebPresenterHintOutputMarksTheRequest(t *testing.T) {
 	none.ExpectedCalls = removeMockCall(none.ExpectedCalls, "GetHint")
 	none.On("GetHint").Return((*domain.PinochleHint)(nil))
 	assert.Contains(t, new(presenter.PinochleWebPresenter).HintOutput(none), "pinochle.noHint")
+}
+
+// #5519: 早見表の点数は domain の値をそのまま送る。フロントに書き写すと
+// 加点を直したときに表だけが古いまま残る。
+func TestPinochleWebPresenterOutputCarriesTheMeldTable(t *testing.T) {
+	p := new(presenter.PinochleWebPresenter)
+	m, _ := setupPinochleWebMockWithPlayers()
+
+	var resObj controller.PinochleWebOutput
+	require.NoError(t, json.Unmarshal([]byte(p.Output(m, nil)), &resObj))
+
+	table := domain.PinochleMeldTable()
+	require.Len(t, resObj.MeldTable, len(table))
+	for i, e := range table {
+		assert.Equal(t, int(e.Type), resObj.MeldTable[i].Type, "entry %d type", i)
+		assert.Equal(t, e.Points, resObj.MeldTable[i].Points, "entry %d points", i)
+	}
 }

--- a/internal/domain/Pinochle.go
+++ b/internal/domain/Pinochle.go
@@ -95,6 +95,32 @@ var pinochleMeldPoints = map[PinochleMeldType]int{
 	PinochleMeldDoubleRun:          1500,
 }
 
+// PinochleMeldTableEntry は早見表の1行。メルドの種類とその点数。
+type PinochleMeldTableEntry struct {
+	Type   PinochleMeldType
+	Points int
+}
+
+// PinochleMeldTable はメルド15種類の点数一覧を安い順で返す。同点のときは
+// 種類の定義順。
+//
+// **表示側が点数を書き写さないためにある。**書き写した表は pinochleMeldPoints
+// を1つ直した瞬間に黙って食い違い、プレイヤーはビッドの見積もりを誤った表で
+// 立てることになる (#5519)。
+func PinochleMeldTable() []PinochleMeldTableEntry {
+	table := make([]PinochleMeldTableEntry, 0, len(pinochleMeldPoints))
+	for t, p := range pinochleMeldPoints {
+		table = append(table, PinochleMeldTableEntry{Type: t, Points: p})
+	}
+	sort.Slice(table, func(i, j int) bool {
+		if table[i].Points != table[j].Points {
+			return table[i].Points < table[j].Points
+		}
+		return table[i].Type < table[j].Type
+	})
+	return table
+}
+
 // PinochleHint ヒント情報
 type PinochleHint struct {
 	CardIndex *int   // 推奨カードインデックス (プレイ時)

--- a/internal/domain/Pinochle_test.go
+++ b/internal/domain/Pinochle_test.go
@@ -1303,3 +1303,55 @@ func (p *Pinochle) findHumanIdxForTest() int {
 	}
 	return -1
 }
+
+// #5519: 早見表はメルド定義そのものから引くこと。別に書き写した表は、
+// 点数を1つ直したときに黙って食い違う。
+func TestPinochleMeldTable(t *testing.T) {
+	table := PinochleMeldTable()
+
+	if len(table) != len(pinochleMeldPoints) {
+		t.Fatalf("expected %d entries, got %d", len(pinochleMeldPoints), len(table))
+	}
+	seen := map[PinochleMeldType]bool{}
+	for _, e := range table {
+		if seen[e.Type] {
+			t.Errorf("duplicate entry for meld %d", int(e.Type))
+		}
+		seen[e.Type] = true
+		// **点数は表示用に書き写した値ではなく、加点に使う値そのもの。**
+		if want := pinochleMeldPoints[e.Type]; e.Points != want {
+			t.Errorf("meld %d: table says %d, scoring says %d", int(e.Type), e.Points, want)
+		}
+	}
+
+	// 安い順に並ぶこと。並びが不定だと表示のたびに行が入れ替わる。
+	for i := 1; i < len(table); i++ {
+		if table[i-1].Points > table[i].Points {
+			t.Errorf("entry %d (%d pts) must not come after %d pts", i, table[i].Points, table[i-1].Points)
+		}
+	}
+	if table[0].Type != PinochleMeldDix || table[0].Points != 10 {
+		t.Errorf("first entry should be the 10-point dix, got type=%d points=%d", int(table[0].Type), table[0].Points)
+	}
+	last := table[len(table)-1]
+	if last.Type != PinochleMeldDoubleRun || last.Points != 1500 {
+		t.Errorf("last entry should be the 1500-point double run, got type=%d points=%d", int(last.Type), last.Points)
+	}
+
+	// 同点のメルドは種類の順で並ぶ (40点が3種類ある)。
+	var at40 []PinochleMeldType
+	for _, e := range table {
+		if e.Points == 40 {
+			at40 = append(at40, e.Type)
+		}
+	}
+	want40 := []PinochleMeldType{PinochleMeldRoyalMarriage, PinochleMeldPinochle, PinochleMeldJacksAround}
+	if len(at40) != len(want40) {
+		t.Fatalf("expected %d melds worth 40, got %d", len(want40), len(at40))
+	}
+	for i := range want40 {
+		if at40[i] != want40[i] {
+			t.Errorf("40-point order[%d]: got %d, want %d", i, int(at40[i]), int(want40[i]))
+		}
+	}
+}

--- a/internal/i18n/locales/en/pinochle.json
+++ b/internal/i18n/locales/en/pinochle.json
@@ -53,5 +53,7 @@
   "promptTrickEnd": "Trick ended. (use 'next' to advance)",
   "promptRoundEnd": "Round ended. (use 'nextround' to advance)",
   "helpExamplePlay": "  p 0                  play hand card 0",
-  "helpHint": "  h                    show a hint"
+  "helpHint": "  h                    show a hint",
+  "meldTableHeader": "Meld reference:\n  ",
+  "meldTableEntry": "{{type}} {{points}}"
 }

--- a/internal/i18n/locales/ja/pinochle.json
+++ b/internal/i18n/locales/ja/pinochle.json
@@ -53,5 +53,7 @@
   "promptTrickEnd": "トリック終了。(next で次のトリックへ)",
   "promptRoundEnd": "ラウンド終了。(nextround で次のラウンドへ)",
   "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す",
-  "helpHint": "  h                    助言を表示"
+  "helpHint": "  h                    助言を表示",
+  "meldTableHeader": "メルド早見表:\n  ",
+  "meldTableEntry": "{{type}} {{points}}"
 }


### PR DESCRIPTION
Closes #5519

## 何が無かったか

CUI も Web も「**確定した後の**メルド名と合計点」しか出していなかった。
15種類のメルドがそれぞれ何点なのか (ダブルピノクル 300、ラン 150、…) を
対局中に見る場所がどちらにも無く、**ビッド額を決めるのに必要な数字が画面のどこにも無い**。

## 直したこと

- `domain.PinochleMeldTable()` — 15種類を安い順 (同点なら種類順) で返す。
  値は `pinochleMeldPoints` そのもの
- **CUI**: ビッド / トランプ宣言 / メルド確認の3フェーズで早見表を印字。
  プレイ中は出さない (毎トリック15行流れると盤面が読めない)
- **Web**: レスポンスに `meldTable` を載せ、ページは折り畳みパネル
  (`<details data-testid="pn-meld-table">`) をサーバの値から描く。
  Mississippi Stud のペイテーブルと同じ形

**どちらのUIも点数を持たない。** 書き写した表は加点を1つ直した瞬間に黙って
食い違い、プレイヤーは古い表でビッドを見積もることになる。

## テスト計画

- [x] `TestPinochleMeldTable` — 15件・重複なし・**点数は `pinochleMeldPoints` と一致**・
      安い順・同点は種類順 (40点が3種類)
- [x] `TestPinochleCuiPresenter_MeldTable` — 出力から表を切り出して
      **domain の表と1行ずつ突き合わせる** (数字をテストに書かない)。
      メルドフェーズでも出る / プレイ中は出ない
- [x] `TestPinochleWebPresenterOutputCarriesTheMeldTable` — JSON の `meldTable` が
      domain の表と型・点数とも一致
- [x] `PinochlePage.test.tsx` 3件 — サーバの値が並ぶ / プレイ中は消える /
      `meldTable` が無いレスポンスでも落ちない
- [x] `golangci-lint` 0 issues、`bun run check` / `typecheck` 緑
- [x] `api/openapi.yaml` に `meldTable` を追加 (CRLF 維持: numstat 12/0)

### 変異テスト (3件とも検出)

| 変異 | 落ちたアサーション |
|---|---|
| 表の並びが map の走査順になる | 101 |
| CUI がプレイ中も表を出す | 2 |
| Web が空の表を送る | 2 |