### PR TITLE
feat(sevencardstud): show the CPU HUD stats on the web page too

### DIFF
--- a/frontend/src/i18n/locales/en/sevencardstud.json
+++ b/frontend/src/i18n/locales/en/sevencardstud.json
@@ -76,5 +76,17 @@
     "sevencardstudCallHigh": "You hold a high card — call and see the next street",
     "sevencardstudFoldWeak": "No pair and no high card — fold",
     "sevencardstudCheckLow": "Five cards of eight or lower and nothing to call — take the next card for free"
+  },
+  "style": {
+    "tag": "TAG",
+    "tagTooltip": "Tight Aggressive: plays few hands but bets strongly when in",
+    "lag": "LAG",
+    "lagTooltip": "Loose Aggressive: plays many hands and bets strongly",
+    "tp": "TP",
+    "tpTooltip": "Tight Passive: plays few hands, mostly calls",
+    "lp": "LP",
+    "lpTooltip": "Loose Passive: plays many hands but rarely raises",
+    "balanced": "BAL",
+    "balancedTooltip": "Balanced style"
   }
 }

--- a/frontend/src/i18n/locales/en/sevencardstudhilo.json
+++ b/frontend/src/i18n/locales/en/sevencardstudhilo.json
@@ -87,5 +87,17 @@
     "sevencardstudCallHigh": "You hold a high card — call and see the next street",
     "sevencardstudFoldWeak": "No pair and no high card — fold",
     "sevencardstudCheckLow": "Five cards of eight or lower and nothing to call — take the next card for free"
+  },
+  "style": {
+    "tag": "TAG",
+    "tagTooltip": "Tight Aggressive: plays few hands but bets strongly when in",
+    "lag": "LAG",
+    "lagTooltip": "Loose Aggressive: plays many hands and bets strongly",
+    "tp": "TP",
+    "tpTooltip": "Tight Passive: plays few hands, mostly calls",
+    "lp": "LP",
+    "lpTooltip": "Loose Passive: plays many hands but rarely raises",
+    "balanced": "BAL",
+    "balancedTooltip": "Balanced style"
   }
 }

--- a/frontend/src/i18n/locales/ja/sevencardstud.json
+++ b/frontend/src/i18n/locales/ja/sevencardstud.json
@@ -76,5 +76,17 @@
     "sevencardstudCallHigh": "高い札がある。コールして様子を見よう",
     "sevencardstudFoldWeak": "高い札もペアも無い。降りよう",
     "sevencardstudCheckLow": "8以下が5枚。払う額は無いので、ただで次の札を見よう"
+  },
+  "style": {
+    "tag": "TAG",
+    "tagTooltip": "Tight Aggressive：参加少なめだが入ったら強気",
+    "lag": "LAG",
+    "lagTooltip": "Loose Aggressive：参加多くかつ攻め志向",
+    "tp": "TP",
+    "tpTooltip": "Tight Passive：参加少なめでコール中心",
+    "lp": "LP",
+    "lpTooltip": "Loose Passive：参加多めだがコール中心",
+    "balanced": "BAL",
+    "balancedTooltip": "バランス型のスタイル"
   }
 }

--- a/frontend/src/i18n/locales/ja/sevencardstudhilo.json
+++ b/frontend/src/i18n/locales/ja/sevencardstudhilo.json
@@ -87,5 +87,17 @@
     "sevencardstudCallHigh": "高い札がある。コールして様子を見よう",
     "sevencardstudFoldWeak": "高い札もペアも無い。降りよう",
     "sevencardstudCheckLow": "8以下が5枚。払う額は無いので、ただで次の札を見よう"
+  },
+  "style": {
+    "tag": "TAG",
+    "tagTooltip": "Tight Aggressive：参加少なめだが入ったら強気",
+    "lag": "LAG",
+    "lagTooltip": "Loose Aggressive：参加多くかつ攻め志向",
+    "tp": "TP",
+    "tpTooltip": "Tight Passive：参加少なめでコール中心",
+    "lp": "LP",
+    "lpTooltip": "Loose Passive：参加多めだがコール中心",
+    "balanced": "BAL",
+    "balancedTooltip": "バランス型のスタイル"
   }
 }

--- a/frontend/src/pages/SevenCardStudHiLoPage.test.tsx
+++ b/frontend/src/pages/SevenCardStudHiLoPage.test.tsx
@@ -146,3 +146,25 @@ describe('SevenCardStudHiLoPage', () => {
     expect(screen.queryByTestId('studhilo-split')).not.toBeInTheDocument();
   });
 });
+
+// #5522: Hi-Lo はページを共有するが i18n の名前空間は別。style.* を
+// sevencardstudhilo.json にも入れないと、生キーが画面に出る。
+describe('SevenCardStudHiLoPage HUD stats', () => {
+  it('shows the CPU HUD with translated style names', async () => {
+    const cpu = {
+      ...seat(1, false),
+      totalHands: 20,
+      vpip: 42,
+      pfr: 8,
+      threeBet: 3,
+      af: '2.5',
+    } as unknown as SevenCardStudPlayerData;
+    mockExec.mockResolvedValue(makeState({ players: [seat(0, true), cpu] }));
+    renderWithProviders(<SevenCardStudHiLoPage />);
+    const hud = await screen.findByTestId('hud-stats');
+    expect(hud).toHaveTextContent('42%');
+    const style = screen.getByTestId('hud-overall-style');
+    expect(style).toHaveTextContent('LP');
+    expect(style.textContent).not.toContain('style.');
+  });
+});

--- a/frontend/src/pages/SevenCardStudPage.test.tsx
+++ b/frontend/src/pages/SevenCardStudPage.test.tsx
@@ -826,3 +826,34 @@ describe('SevenCardStudPage keyboard shortcuts', () => {
     expect(mockExec).not.toHaveBeenCalled();
   });
 });
+
+// #5522: バックエンドは VPIP/PFR/3Bet/AF を毎回返し、CUI は毎ターン出しているのに、
+// Web だけが playStyleName しか出していなかった。
+describe('SevenCardStudPage HUD stats', () => {
+  const withStats = (n: number) => cpuPlayer(n, { totalHands: 12, vpip: 42, pfr: 8, threeBet: 3, af: '2.5' });
+
+  it('shows the CPU HUD once hands have been played', async () => {
+    mockExec.mockResolvedValue({ ...thirdStreetState, players: [humanPlayer(), withStats(1)] });
+    renderWithProviders(<SevenCardStudPage />);
+    const hud = await screen.findByTestId('hud-stats');
+    expect(hud).toHaveTextContent('42%');
+    expect(hud).toHaveTextContent('2.5');
+    // 傾向バッジも他のポーカーページと同じ判定で色分けされる。
+    expect(screen.getByTestId('hud-vpip-tendency')).toHaveAttribute('data-tendency', 'loose');
+    expect(screen.getByTestId('hud-pfr-tendency')).toHaveAttribute('data-tendency', 'passive');
+    // **スタイル名は翻訳済みであること。**名前空間に style.* が無いと
+    // 生キー ("style.lp") がそのまま画面に出る。
+    const style = screen.getByTestId('hud-overall-style');
+    expect(style).toHaveAttribute('data-style', 'lp');
+    expect(style).toHaveTextContent('LP');
+    expect(style.textContent).not.toContain('style.');
+  });
+
+  // **1ハンドも打っていないうちは出さない。**全部 0% の HUD は情報ではなく雑音。
+  it('stays hidden before the first hand is over', async () => {
+    mockExec.mockResolvedValue({ ...thirdStreetState, players: [humanPlayer(), cpuPlayer(1)] });
+    renderWithProviders(<SevenCardStudPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    expect(screen.queryByTestId('hud-stats')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/SevenCardStudPage.tsx
+++ b/frontend/src/pages/SevenCardStudPage.tsx
@@ -14,6 +14,7 @@ import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
+import { HudStats } from '../components/HudStats';
 import { HintTooltip } from '../components/hint/HintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
@@ -329,6 +330,12 @@ export function SevenCardStudPageContent({ gameKey }: { gameKey: StudPageGameKey
                   <div className="text-ds-text-primary text-sm mb-1">
                     CPU {p.id}
                     <span className="ml-2 text-xs text-ds-text-muted">{p.playStyleName}</span>
+                    {/* サーバは VPIP/PFR/3Bet/AF を毎回返し CUI も毎ターン出しているのに、
+                        Web だけ出していなかった (#5522)。0 ハンドのうちは全部 0% で
+                        情報にならないので他のポーカーページと同じ条件で出す。 */}
+                    {p.totalHands > 0 && (
+                      <HudStats vpip={p.vpip} pfr={p.pfr} threeBet={p.threeBet} af={p.af} namespace={gameKey} />
+                    )}
                     <span className="ml-2 text-xs">
                       {tc('betting.chips')} {p.chips}
                     </span>


### PR DESCRIPTION
Closes #5522

`SevenCardStudWebPresenter` は `vpip`/`pfr`/`threeBet`/`af` を毎回レスポンスに載せ、
CUI は毎ターン `playerStats` 行で出している。**Web だけが `playStyleName` しか出さず**、
`HudStats` を import すらしていない唯一のポーカーページだった。

## 直したこと

- CPU 表示に他ページと同じ条件 (`p.totalHands > 0`) で `<HudStats … namespace={gameKey} />`
- **`style.*` を sevencardstud / sevencardstudhilo の ja/en に追加**。
  `stats.*` はあったが `style.*` が無く、そのままでは総合スタイルのバッジが
  生キー (`style.lp`) を表示していた。import を足すだけでは足りなかった箇所

## テスト計画

- [x] `SevenCardStudPage.test.tsx` — 42%/2.5 が出る、傾向バッジが loose/passive、
      **スタイル名が翻訳済み (`style.` を含まない)**
- [x] 0 ハンドのうちは HUD を出さない (全部 0% は情報ではなく雑音)
- [x] `SevenCardStudHiLoPage.test.tsx` — 共有ページだが**名前空間は別**なので Hi-Lo 側も検証
- [x] 既存 65 + 5 件緑 / `bun run check` / `typecheck` 緑

### 変異テスト

| 変異 | 結果 |
|---|---|
| 0 ハンドでも HUD を出す | 検出 (1) |
| Hi-Lo の名前空間から `style.*` を落とす | 検出 (1) |
| `namespace={gameKey}` を外す | **検出できず** — 既定の `holdem` 名前空間が同じキーを同じ文言で持っているため、描画結果が変わらない。文言をわざとずらしてまで検出可能にはしていない |