### PR TITLE
feat(clocksolitaire): show how many piles are finished in both UIs

### DIFF
--- a/frontend/src/i18n/locales/en/clocksolitaire.json
+++ b/frontend/src/i18n/locales/en/clocksolitaire.json
@@ -34,5 +34,6 @@
     "controls": "Step advances one card, Auto Play runs to completion.",
     "resetButton": "Press Reset to start a new game."
   },
-  "undo": "Undo"
+  "undo": "Undo",
+  "completedPiles": "Completed: {{completed}}/{{total}}"
 }

--- a/frontend/src/i18n/locales/ja/clocksolitaire.json
+++ b/frontend/src/i18n/locales/ja/clocksolitaire.json
@@ -34,5 +34,6 @@
     "controls": "ステップで1枚ずつ、オートプレイで自動進行します。",
     "resetButton": "リセットボタンで新しいゲームを始められます。"
   },
-  "undo": "元に戻す"
+  "undo": "元に戻す",
+  "completedPiles": "完成: {{completed}}/{{total}}"
 }

--- a/frontend/src/pages/ClockSolitairePage.test.tsx
+++ b/frontend/src/pages/ClockSolitairePage.test.tsx
@@ -389,3 +389,28 @@ describe('ClockSolitairePage', () => {
     await waitFor(() => expect(screen.getByTestId('cs-live-region')).toHaveTextContent(/中央/));
   });
 });
+
+// #5523: 「あと何山で揃うか」は CLI ターミナルを開いたときだけ見える計算だった。
+describe('ClockSolitairePage progress', () => {
+  it('shows how many piles are finished in the header', async () => {
+    mockExec.mockResolvedValue(playingState); // 1枚だけ表なので完成 0
+    renderWithProviders(<ClockSolitairePage />);
+    await waitFor(() => expect(screen.getByTestId('clock-completed')).toHaveTextContent('完成: 0/13'));
+  });
+
+  it('counts a pile only once all four cards are up', async () => {
+    const fuc = Array(13).fill(0);
+    fuc[0] = 4;
+    fuc[1] = 4;
+    fuc[2] = 3; // あと1枚 -- 数に入れない
+    mockExec.mockResolvedValue({ ...playingState, faceUpCount: fuc });
+    renderWithProviders(<ClockSolitairePage />);
+    await waitFor(() => expect(screen.getByTestId('clock-completed')).toHaveTextContent('完成: 2/13'));
+  });
+
+  it('reads 13/13 on a clear', async () => {
+    mockExec.mockResolvedValue({ ...gameClearState, faceUpCount: Array(13).fill(4) });
+    renderWithProviders(<ClockSolitairePage />);
+    await waitFor(() => expect(screen.getByTestId('clock-completed')).toHaveTextContent('完成: 13/13'));
+  });
+});

--- a/frontend/src/pages/ClockSolitairePage.tsx
+++ b/frontend/src/pages/ClockSolitairePage.tsx
@@ -29,6 +29,7 @@ import { ClockSolitairePhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
+import { CLOCK_PILE_COUNT, completedClockPiles } from '../utils/clockSolitaireProgress';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
 /** Clock Solitaire tutorial step definitions. */
@@ -187,8 +188,7 @@ function ClockSolitairePageContent() {
               ? 'OVER'
               : 'Playing';
         lines.push(`Phase: ${phase} | Steps: ${s.stepCount}`);
-        const completed = s.faceUpCount.filter((c) => c >= 4).length;
-        lines.push(`Completed: ${completed}/13`);
+        lines.push(`Completed: ${completedClockPiles(s.faceUpCount).toString()}/${CLOCK_PILE_COUNT.toString()}`);
         if (s.currentCard) {
           lines.push(`Current: ${s.currentCard.design[0]}${s.currentCard.value}`);
         }
@@ -264,6 +264,14 @@ function ClockSolitairePageContent() {
         <>
           <span className="text-sm text-ds-text-muted">
             {t('stepCount')}: {state.stepCount}
+          </span>
+          {/* 「あと何山で揃うか」は CLI ターミナルを開いた人にしか見えない
+              隠れた計算だった (#5523)。 */}
+          <span className="text-sm text-ds-text-muted" data-testid="clock-completed">
+            {t('completedPiles', {
+              completed: completedClockPiles(state.faceUpCount),
+              total: CLOCK_PILE_COUNT,
+            })}
           </span>
           <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
         </>

--- a/frontend/src/utils/clockSolitaireProgress.test.ts
+++ b/frontend/src/utils/clockSolitaireProgress.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { CLOCK_PILE_COUNT, completedClockPiles } from './clockSolitaireProgress';
+
+describe('completedClockPiles', () => {
+  it('counts only the piles with all four cards face up', () => {
+    expect(completedClockPiles([4, 3, 4, 0, 4])).toBe(3);
+  });
+
+  it('is 0 at the start', () => {
+    expect(completedClockPiles(Array(CLOCK_PILE_COUNT).fill(0))).toBe(0);
+  });
+
+  // **クリア時は 13/13。**中央のKの山も数に入る。
+  it('is 13 once every pile is done', () => {
+    expect(completedClockPiles(Array(CLOCK_PILE_COUNT).fill(4))).toBe(CLOCK_PILE_COUNT);
+  });
+
+  // 3枚では完成でない -- 境界を off-by-one で数えると進捗が先走る。
+  it('does not count a pile of three', () => {
+    expect(completedClockPiles([3, 3, 3])).toBe(0);
+  });
+});

--- a/frontend/src/utils/clockSolitaireProgress.ts
+++ b/frontend/src/utils/clockSolitaireProgress.ts
@@ -1,0 +1,18 @@
+/**
+ * Clock Solitaire progress: how many of the 13 piles are finished.
+ *
+ * The count lived inline in the page's CLI formatter, so "how many piles are
+ * still open" was visible only to players who opened the terminal (#5523).
+ * Extracted so the header and the terminal read the same number.
+ */
+
+/** Cards in a completed pile — mirrors domain.ClockSolitaireCardsPerPile. */
+export const CLOCK_CARDS_PER_PILE = 4;
+
+/** Piles on the clock, including the centre kings pile — domain.ClockSolitairePileCount. */
+export const CLOCK_PILE_COUNT = 13;
+
+/** Number of piles whose four cards are all face up. */
+export function completedClockPiles(faceUpCount: readonly number[]): number {
+  return faceUpCount.filter((c) => c >= CLOCK_CARDS_PER_PILE).length;
+}

--- a/internal/adapter/presenter/ClockSolitaireCuiPresenter.go
+++ b/internal/adapter/presenter/ClockSolitaireCuiPresenter.go
@@ -20,6 +20,18 @@ func (pr *ClockSolitaireCuiPresenter) Output(g interfaces.ClockSolitaireGame, la
 		piles := g.GetPiles()
 		fuc := g.GetFaceUpCount()
 
+		// 完成した山の数。「あと何山で揃うか」という進捗の要約は、これまで
+		// CLI ターミナルを開いたときだけ見える隠れた計算だった (#5523)。
+		completed := 0
+		for _, up := range fuc {
+			if up >= domain.ClockSolitaireCardsPerPile {
+				completed++
+			}
+		}
+		b.WriteString(i18n.Tf("clocksolitaire.completedPiles",
+			"completed", strconv.Itoa(completed),
+			"total", strconv.Itoa(domain.ClockSolitairePileCount)) + "\n")
+
 		// Clock positions: 12, 1, 2, ..., 11 in display order.
 		displayOrder := []int{11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 		labels := []string{"12", " 1", " 2", " 3", " 4", " 5", " 6", " 7", " 8", " 9", "10", "11"}

--- a/internal/adapter/presenter/ClockSolitaireCuiPresenter_test.go
+++ b/internal/adapter/presenter/ClockSolitaireCuiPresenter_test.go
@@ -4,12 +4,14 @@ package presenter
 
 import (
 	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func TestClockSolitaireCuiPresenterOutput_Playing(t *testing.T) {
@@ -132,4 +134,48 @@ func TestClockSolitaireCuiPresenterActionLog(t *testing.T) {
 
 	assert.Contains(t, result, "Action Log")
 	assert.Contains(t, result, "テスト")
+}
+
+// #5523: 「あと何山で揃うか」は CLI ターミナルを開いたときだけ見える隠れた
+// 計算式で、通常プレイでは CUI にも Web にも出ていなかった。
+func TestClockSolitaireCuiPresenterOutput_CompletedCount(t *testing.T) {
+	outputWithCompleted := func(completed int) string {
+		gg := new(interfaces.MockClockSolitaireGame)
+		setupClockSolitaireWebMockDefaults(gg)
+		gg.ExpectedCalls = nil
+		gg.On("GetPhase").Return(domain.ClockSolitairePhasePlaying)
+		gg.On("GetStepCount").Return(1)
+		gg.On("GetCurrentCard").Return((*domain.Card)(nil))
+
+		var piles [domain.ClockSolitairePileCount][]*domain.ClockSolitaireCard
+		var fuc [domain.ClockSolitairePileCount]int
+		for i := range domain.ClockSolitairePileCount {
+			piles[i] = make([]*domain.ClockSolitaireCard, domain.ClockSolitaireCardsPerPile)
+			for j := range domain.ClockSolitaireCardsPerPile {
+				piles[i][j] = &domain.ClockSolitaireCard{
+					Card:   domain.NewCard(domain.CardDesignSpade, i+1, false),
+					FaceUp: i < completed,
+				}
+			}
+			if i < completed {
+				fuc[i] = domain.ClockSolitaireCardsPerPile
+			}
+		}
+		gg.On("GetPiles").Return(piles)
+		gg.On("GetFaceUpCount").Return(fuc)
+		return (&ClockSolitaireCuiPresenter{}).Output(gg, nil)
+	}
+
+	line := func(completed int) string {
+		return i18n.Tf("clocksolitaire.completedPiles",
+			"completed", strconv.Itoa(completed),
+			"total", strconv.Itoa(domain.ClockSolitairePileCount))
+	}
+
+	assert.Contains(t, outputWithCompleted(0), line(0))
+	assert.Contains(t, outputWithCompleted(5), line(5))
+	// **クリア時は 13/13。**中央のKの山も数に入る。
+	assert.Contains(t, outputWithCompleted(domain.ClockSolitairePileCount), line(domain.ClockSolitairePileCount))
+	// 4枚に届いていない山は数えない。
+	assert.NotContains(t, outputWithCompleted(5), line(6))
 }

--- a/internal/i18n/locales/en/clocksolitaire.json
+++ b/internal/i18n/locales/en/clocksolitaire.json
@@ -14,5 +14,6 @@
   "gameOverLine": "Game over. Steps: {{count}}",
   "actionLogTitle": "Clock Solitaire Action Log",
   "actionLogEntry": "[{{turn}}] {{detail}}",
-  "helpExampleStep": "  s                        turn the next card"
+  "helpExampleStep": "  s                        turn the next card",
+  "completedPiles": "Completed: {{completed}}/{{total}}"
 }

--- a/internal/i18n/locales/ja/clocksolitaire.json
+++ b/internal/i18n/locales/ja/clocksolitaire.json
@@ -14,5 +14,6 @@
   "gameOverLine": "ゲームオーバー ステップ数: {{count}}",
   "actionLogTitle": "Clock Solitaire Action Log",
   "actionLogEntry": "[{{turn}}] {{detail}}",
-  "helpExampleStep": "  s                        次の 1 枚をめくる"
+  "helpExampleStep": "  s                        次の 1 枚をめくる",
+  "completedPiles": "完成: {{completed}}/{{total}}"
 }


### PR DESCRIPTION
Closes #5523

`Completed: N/13` の計算は**すでに存在していた** — ページの CLI フォーマッタの中に
インラインで。つまり「あと何山で揃うか」という要約は、**ターミナルを開いた人にだけ
見える隠れた式**だった。通常のページヘッダはステップ数だけ、CUI は各山の up/total を
出すが合計は一切出さない。

## 直したこと

- `completedClockPiles()` を `frontend/src/utils/clockSolitaireProgress.ts` に切り出し、
  **ヘッダと CLI フォーマッタが同じ数字を読む**ようにした
- CUI の `Output` 冒頭にも同じ行を追加
- どちらも**13山すべて (中央のKの山を含む)** を数える。クリアで 13/13 になる

## テスト計画

- [x] `clockSolitaireProgress.test.ts` 4件 — 数える/開始時0/クリアで13/**3枚では数えない**
- [x] `ClockSolitairePage.test.tsx` 3件 — ヘッダに「完成: 0/13」、3枚の山は数に入らない、クリアで 13/13
- [x] `TestClockSolitaireCuiPresenterOutput_CompletedCount` — 0 / 5 / 13 と、**5のとき6を含まない**
- [x] `bun run check` / `typecheck` / `golangci-lint` 緑

### 変異テスト (2件とも検出)

| 変異 | 落ちたテスト |
|---|---|
| 境界を off-by-one (3枚で完成扱い) | 3 |
| CUI が中央のKの山を数えない | 1 |