### PR TITLE
feat(durak): mark the CPUs that have gone out on the web page

### DIFF
--- a/frontend/src/i18n/locales/en/durak.json
+++ b/frontend/src/i18n/locales/en/durak.json
@@ -67,5 +67,6 @@
     "defend_beat": "this card beats it",
     "take_cannot_beat": "nothing in hand beats it",
     "pass_no_addition": "nothing left to pile on"
-  }
+  },
+  "finished": "Finished"
 }

--- a/frontend/src/i18n/locales/ja/durak.json
+++ b/frontend/src/i18n/locales/ja/durak.json
@@ -67,5 +67,6 @@
     "defend_beat": "この札で返せる",
     "take_cannot_beat": "返せる札が無い",
     "pass_no_addition": "追撃できる札が無い"
-  }
+  },
+  "finished": "上がり"
 }

--- a/frontend/src/pages/DurakPage.test.tsx
+++ b/frontend/src/pages/DurakPage.test.tsx
@@ -405,3 +405,30 @@ describe('DurakPage', () => {
     expect(screen.queryByTestId('durak-server-hint')).not.toBeInTheDocument();
   });
 });
+
+// #5524: CUI は上がった相手の手札欄を「上がり」に差し替えるのに、Web は
+// カード枚数を出すだけで、勝ち抜けた CPU と対局中の CPU の区別が付かなかった。
+describe('DurakPage finished players', () => {
+  it('badges the CPU that has gone out, and only that one', async () => {
+    const players = baseState.players.map((p) => ({ ...p }));
+    players[1] = { ...players[1], isFinished: true, cardCount: 0 };
+    mockExec.mockResolvedValue({ ...baseState, players });
+    renderWithProviders(<DurakPage />);
+
+    const finished = await screen.findByTestId('cpu-finished-1');
+    expect(finished).toHaveTextContent('上がり');
+    expect(screen.queryByTestId('cpu-finished-2')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('cpu-finished-3')).not.toBeInTheDocument();
+  });
+
+  // **枚数の 0 では代用できない。**配り直しの直前など、まだ抜けていないのに
+  // 0 枚の瞬間がある。
+  it('does not badge a player who merely has no cards yet', async () => {
+    const players = baseState.players.map((p) => ({ ...p }));
+    players[2] = { ...players[2], cardCount: 0 };
+    mockExec.mockResolvedValue({ ...baseState, players });
+    renderWithProviders(<DurakPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    expect(screen.queryByTestId('cpu-finished-2')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/DurakPage.tsx
+++ b/frontend/src/pages/DurakPage.tsx
@@ -375,7 +375,17 @@ function DurakPageContent() {
                           <span className="text-ds-info text-xs ml-1">({t('defender')})</span>
                         )}
                       </div>
-                      <div className="text-game-text-muted text-xs">{player.cardCount}</div>
+                      {/* 上がった相手は CUI では手札欄が「上がり」に差し替わるのに、
+                          Web は枚数を出すだけで対局中の CPU と見分けが付かなかった
+                          (#5524)。**枚数 0 では代用できない** -- 配り直しの直前など、
+                          まだ抜けていないのに 0 枚の瞬間がある。 */}
+                      {player.isFinished ? (
+                        <div className="text-ds-success text-xs font-bold" data-testid={`cpu-finished-${player.id}`}>
+                          {t('finished')}
+                        </div>
+                      ) : (
+                        <div className="text-game-text-muted text-xs">{player.cardCount}</div>
+                      )}
                     </div>
                   ))}
                 </div>


### PR DESCRIPTION
Closes #5524

`DurakCuiPresenter` は上がったプレイヤーの手札欄を丸ごと `durak.playerFinished`
(「上がり」) に差し替えるのに、Web のサイドバーは `isFinished` を一度も見ておらず
枚数を出すだけだった。**勝ち抜けた CPU とまだ対局中の CPU が見分けられない。**
ドゥラークは最後の1人が決まるまで続くゲームなので、抜けていく様子そのものが終盤の形。

## 直したこと

- `isFinished` の CPU に「上がり」バッジ (`data-testid="cpu-finished-<id>"`)
- `durak.json` の ja/en に `finished` を追加

**判定は `isFinished` で、`cardCount === 0` では代用しない。** 場の決着処理の途中など、
まだ抜けていないのに 0 枚になる瞬間がある。

## テスト計画

- [x] 上がった CPU だけにバッジが出る (他の 2 人には出ない)
- [x] **枚数 0 なだけの CPU にはバッジを出さない** (負のコントロール)
- [x] 既存 33 件緑 / `bun run check` / `typecheck` 緑

### 変異テスト

| 変異 | 落ちたテスト |
|---|---|
| 判定を `cardCount === 0` に差し替える | 1 |