### PR TITLE
feat(fortythieves): tell the player to draw instead of saying there is no hint

### DIFF
--- a/frontend/src/i18n/locales/en/fortythieves.json
+++ b/frontend/src/i18n/locales/en/fortythieves.json
@@ -36,6 +36,7 @@
     "waste": "Waste",
     "tableau": "Tableau column {{col}}",
     "foundation": "Foundation",
-    "fortythievesMove": "This card can move"
+    "fortythievesMove": "This card can move",
+    "fortythievesDraw": "Nothing else can move — draw from the stock"
   }
 }

--- a/frontend/src/i18n/locales/ja/fortythieves.json
+++ b/frontend/src/i18n/locales/ja/fortythieves.json
@@ -36,6 +36,7 @@
     "waste": "捨て札",
     "tableau": "タブロー列{{col}}",
     "foundation": "組札",
-    "fortythievesMove": "この札を動かせます"
+    "fortythievesMove": "この札を動かせます",
+    "fortythievesDraw": "他に動かせる札はありません。山札から引きましょう"
   }
 }

--- a/frontend/src/pages/FortyThievesPage.test.tsx
+++ b/frontend/src/pages/FortyThievesPage.test.tsx
@@ -89,6 +89,12 @@ const withHintState: FortyThievesResponse = {
   hint: { fromZone: 'waste', fromCol: -1, cardIndex: -1, toZone: 'tableau', toCol: 3 },
 };
 
+// #5525: 引くヒントは列を持たない。移動の体裁に落とすと「タブロー列-1」が出る。
+const withDrawHintState: FortyThievesResponse = {
+  ...playingState,
+  hint: { fromZone: 'stock', fromCol: -1, cardIndex: -1, toZone: 'waste', toCol: -1 },
+};
+
 beforeEach(() => {
   mockExec.mockResolvedValue(playingState);
   vi.mocked(useGameHint).mockReturnValue({ hint: null, hintEnabled: false, setHintEnabled: vi.fn() });
@@ -489,6 +495,20 @@ describe('FortyThievesPage', () => {
     expect(region).toHaveAttribute('role', 'status');
     expect(region).toHaveAttribute('aria-live', 'polite');
     expect(region).toHaveTextContent('ヒント: ♣ 3をタブロー列3へ移動');
+  });
+
+  it('shows the draw hint as a sentence, not as a move with column -1', async () => {
+    renderWithProviders(<FortyThievesPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+
+    mockExec.mockResolvedValue(withDrawHintState);
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    const region = await screen.findByTestId('ft-hint-announcement');
+    await waitFor(() => expect(region).toHaveTextContent('山札から引きましょう'));
+    // **-1 が画面のどこにも出ないこと。**バナー側も同じ判定を通す。
+    expect(screen.getByTestId('ft-hint-display')).toHaveTextContent('山札から引きましょう');
+    expect(screen.getByTestId('ft-hint-display').textContent).not.toContain('-1');
   });
 
   it('renders an empty hint announcement region when there is no hint', async () => {

--- a/frontend/src/pages/FortyThievesPage.tsx
+++ b/frontend/src/pages/FortyThievesPage.tsx
@@ -479,11 +479,21 @@ function FortyThievesPageContent() {
             </div>
 
             {/* Hint display */}
-            <div data-tutorial="ft-hint-display">
+            <div data-tutorial="ft-hint-display" data-testid="ft-hint-display">
               {hint && (
                 <div className="text-ds-warning text-sm mb-2">
-                  {t('hintAvailable')}: {formatHintZone(t, hint.fromZone, hint.fromCol)} →{' '}
-                  {formatHintZone(t, hint.toZone, hint.toCol)}
+                  {/* 引くヒントは列を持たない (#5525)。移動の体裁に落とすと
+                      「タブロー列-1」が出る。 */}
+                  {hint.fromZone === 'stock' ? (
+                    <>
+                      {t('hintAvailable')}: {t('frontendHint.fortythievesDraw')}
+                    </>
+                  ) : (
+                    <>
+                      {t('hintAvailable')}: {formatHintZone(t, hint.fromZone, hint.fromCol)} →{' '}
+                      {formatHintZone(t, hint.toZone, hint.toCol)}
+                    </>
+                  )}
                 </div>
               )}
               {/* Visually hidden so the announcement adds no layout, but the hinted
@@ -492,7 +502,11 @@ function FortyThievesPageContent() {
                   reliably announces the first hint — some readers miss a live region
                   that is inserted already-populated. */}
               <div className="sr-only" role="status" aria-live="polite" data-testid="ft-hint-announcement">
-                {hint ? t('hintAnnouncement', { card: hintCardName, dest: hintDest }) : ''}
+                {hint
+                  ? hint.fromZone === 'stock'
+                    ? t('frontendHint.fortythievesDraw')
+                    : t('hintAnnouncement', { card: hintCardName, dest: hintDest })
+                  : ''}
               </div>
             </div>
             <div className="flex justify-center">

--- a/frontend/src/utils/cli/formatters/fortythievesFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/fortythievesFormatter.test.ts
@@ -47,6 +47,18 @@ describe('formatFortythievesState', () => {
     expect(out).toContain('HINT: t0[1] → foundation2');
   });
 
+  // #5525: 引くヒントは列を持たない。移動の体裁に落とすと t-1[-1] が出る。
+  it('renders the draw hint without leaking the -1 columns', () => {
+    const out = formatFortythievesState(
+      baseState({
+        hint: { fromZone: 'stock', fromCol: -1, cardIndex: -1, toZone: 'waste', toCol: -1 },
+        messageCode: 'fortythieves.hintAvailable',
+      }),
+    );
+    expect(out).toContain('HINT: draw from stock');
+    expect(out).not.toContain('-1');
+  });
+
   it('renders a waste hint source', () => {
     const out = formatFortythievesState(
       baseState({

--- a/frontend/src/utils/cli/formatters/fortythievesFormatter.ts
+++ b/frontend/src/utils/cli/formatters/fortythievesFormatter.ts
@@ -32,9 +32,14 @@ export function formatFortythievesState(state: FortyThievesResponse): string {
   lines.push(`moves: ${state.moveCount}  undo:${state.canUndo ? 'yes' : 'no'}`);
 
   if (state.hint && isRequestedHint(state)) {
-    const from = state.hint.fromZone === 'waste' ? 'waste' : `t${state.hint.fromCol}[${state.hint.cardIndex}]`;
-    const target = state.hint.toCol >= 0 ? `${state.hint.toZone}${state.hint.toCol}` : state.hint.toZone;
-    lines.push(`HINT: ${from} → ${target}`);
+    // 引くヒントは列を持たない (#5525)。移動の体裁に落とすと t-1[-1] が出る。
+    if (state.hint.fromZone === 'stock') {
+      lines.push('HINT: draw from stock');
+    } else {
+      const from = state.hint.fromZone === 'waste' ? 'waste' : `t${state.hint.fromCol}[${state.hint.cardIndex}]`;
+      const target = state.hint.toCol >= 0 ? `${state.hint.toZone}${state.hint.toCol}` : state.hint.toZone;
+      lines.push(`HINT: ${from} → ${target}`);
+    }
   }
   if (state.isStalemate) lines.push('Stalemate - no more moves possible');
   if (state.message) lines.push(state.message);

--- a/frontend/src/utils/hints/fortythievesHint.test.ts
+++ b/frontend/src/utils/hints/fortythievesHint.test.ts
@@ -29,4 +29,15 @@ describe('getFortyThievesHint', () => {
     const s = state({ fromZone: 'tableau', fromCol: 2, cardIndex: 0, toZone: 'foundation', toCol: -1 });
     expect(getFortyThievesHint(s)?.targetAction).toBe('foundation');
   });
+
+  // #5525: 盤上に手が無くストックだけ残っている局面。行き詰まりではないので
+  // 「引け」と言う。移動の体裁に落とすと waste--1 が出る。
+  it('tells the player to draw when the server says stock', () => {
+    const s = state({ fromZone: 'stock', fromCol: -1, cardIndex: -1, toZone: 'waste', toCol: -1 });
+    expect(getFortyThievesHint(s)).toEqual({
+      targetAction: 'draw',
+      reason: 'frontendHint.fortythievesDraw',
+      confidence: 'moderate',
+    });
+  });
 });

--- a/frontend/src/utils/hints/fortythievesHint.ts
+++ b/frontend/src/utils/hints/fortythievesHint.ts
@@ -14,6 +14,12 @@ export function getFortyThievesHint(state: FortyThievesResponse): HintResult | n
   const hint = state.hint;
   if (!hint) return null;
 
+  // 盤上に手が無くストックだけ残っている局面 (#5525)。行き詰まりではないので
+  // 「引け」と言う。移動の体裁に落とすと列を持たない waste--1 が出てしまう。
+  if (hint.fromZone === 'stock') {
+    return { targetAction: 'draw', reason: 'frontendHint.fortythievesDraw', confidence: 'moderate' };
+  }
+
   // **列 0 は正当な列。**真偽値で見ると先頭の山だけ落ちる。ファウンデーション
   // など列を持たないゾーンは -1 で届くので、そこはゾーン名だけにする。
   const target = hint.toCol >= 0 ? `${hint.toZone}-${hint.toCol}` : hint.toZone;

--- a/internal/adapter/presenter/FortyThievesCuiPresenter.go
+++ b/internal/adapter/presenter/FortyThievesCuiPresenter.go
@@ -104,6 +104,11 @@ func (p *FortyThievesCuiPresenter) HintOutput(ft interfaces.FortyThievesGame) st
 	if hint == nil {
 		return i18n.T("cuiHintNone") + "\n"
 	}
+	// 盤上に手が無くストックだけ残っている局面。移動の体裁 (「A → B」) に
+	// 落とすと列 -1 が漏れるので、専用の文言で言う (#5525)。
+	if hint.FromZone == "stock" {
+		return i18n.T("fortythieves.hintDraw") + "\n"
+	}
 	var from string
 	if hint.FromZone == "tableau" {
 		from = i18n.Tf("fortythieves.hintFromTableau",

--- a/internal/adapter/presenter/FortyThievesCuiPresenter_test.go
+++ b/internal/adapter/presenter/FortyThievesCuiPresenter_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupFortyThievesCuiMockDefaults(fg *interfaces.MockFortyThievesGame) {
@@ -156,6 +157,25 @@ func TestFortyThievesCuiPresenter_HintOutput(t *testing.T) {
 		assert.Contains(t, result, "ヒント")
 		assert.Contains(t, result, "タブロー列0")
 		assert.Contains(t, result, "ファンデーション")
+	})
+
+	// #5525: ストックだけ残っている局面は行き詰まりではないので、
+	// 「ヒントはありません」ではなく「引け」と言う。
+	t.Run("stock hint tells the player to draw", func(t *testing.T) {
+		fg := new(interfaces.MockFortyThievesGame)
+		fg.On("GetHint").Return(&domain.FortyThievesHint{
+			FromZone:  "stock",
+			FromCol:   -1,
+			CardIndex: -1,
+			ToZone:    "waste",
+			ToCol:     -1,
+		})
+
+		result := new(FortyThievesCuiPresenter).HintOutput(fg)
+		assert.Contains(t, result, i18n.T("fortythieves.hintDraw"))
+		assert.NotContains(t, result, i18n.T("cuiHintNone"))
+		// 移動ヒントの体裁 (「A → B」) には落とさない。列 -1 が漏れる。
+		assert.NotContains(t, result, "-1")
 	})
 
 	t.Run("waste hint", func(t *testing.T) {

--- a/internal/domain/FortyThieves.go
+++ b/internal/domain/FortyThieves.go
@@ -35,11 +35,14 @@ type FortyThievesTableauCard struct {
 
 // FortyThievesHint ヒント
 type FortyThievesHint struct {
-	FromZone  string // "waste" or "tableau"
+	// FromZone は "waste" / "tableau"、どこにも手が無くストックが残っている
+	// ときは "stock" (= 引くことを勧める、#5525)。
+	FromZone  string
 	FromCol   int
 	CardIndex int
-	ToZone    string // "tableau" or "foundation"
-	ToCol     int
+	// ToZone は "tableau" / "foundation"、FromZone が "stock" のときは "waste"。
+	ToZone string
+	ToCol  int
 }
 
 // FortyThievesConfig フォーティシーブスゲーム設定
@@ -330,6 +333,21 @@ func (ft *FortyThieves) GetHint() *FortyThievesHint {
 					ToCol:     toCol,
 				}
 			}
+		}
+	}
+	// 優先度5: 盤上に手が無く、ストックが残っているなら「引く」。
+	//
+	// **ここで nil を返すと「ヒントはありません」になる。**行き詰まり判定
+	// (checkFortyThievesStalemate) はストックが残っていれば手詰まりではないと
+	// 正しく扱うのに、ヒントだけが同じ局面で黙っていた。プレイヤーからは
+	// 「詰んだ」のか「引けば良いだけ」なのか区別が付かない (#5525)。
+	if len(ft.stock) > 0 {
+		return &FortyThievesHint{
+			FromZone:  "stock",
+			FromCol:   -1,
+			CardIndex: -1,
+			ToZone:    "waste",
+			ToCol:     -1,
 		}
 	}
 	return nil

--- a/internal/domain/FortyThieves_test.go
+++ b/internal/domain/FortyThieves_test.go
@@ -491,6 +491,43 @@ func TestFortyThieves_GetHint(t *testing.T) {
 		assert.Nil(t, hint)
 	})
 
+	// #5525: 他に手が無くストックだけ残っている局面で「ヒントはありません」を
+	// 返していた。行き詰まりではないのに、プレイヤーには詰んだのか引けば良いのか
+	// 区別が付かない。
+	t.Run("suggests drawing when nothing else moves but stock remains", func(t *testing.T) {
+		ft := newTestFortyThieves()
+		ft.Reset()
+		clearFTTableau(ft)
+		var tableau [domain.FortyThievesTableauCnt][]*domain.FortyThievesTableauCard
+		tableau[0] = []*domain.FortyThievesTableauCard{makeFTTableauCard(domain.CardDesignSpade, 13)}
+		tableau[1] = []*domain.FortyThievesTableauCard{makeFTTableauCard(domain.CardDesignHeart, 13)}
+		ft.SetTableau(tableau)
+		ft.SetStock([]*domain.Card{makeFTCard(domain.CardDesignClover, 7)})
+
+		hint := ft.GetHint()
+		require.NotNil(t, hint)
+		assert.Equal(t, "stock", hint.FromZone)
+		assert.Equal(t, "waste", hint.ToZone)
+		assert.Equal(t, -1, hint.FromCol)
+		assert.Equal(t, -1, hint.ToCol)
+		assert.Equal(t, -1, hint.CardIndex)
+	})
+
+	// **盤上に手があるならそちらが先。**引くのは最後の手段。
+	t.Run("prefers a real move over drawing", func(t *testing.T) {
+		ft := newTestFortyThieves()
+		ft.Reset()
+		clearFTTableau(ft)
+		var tableau [domain.FortyThievesTableauCnt][]*domain.FortyThievesTableauCard
+		tableau[0] = []*domain.FortyThievesTableauCard{makeFTTableauCard(domain.CardDesignSpade, 1)}
+		ft.SetTableau(tableau)
+		ft.SetStock([]*domain.Card{makeFTCard(domain.CardDesignClover, 7)})
+
+		hint := ft.GetHint()
+		require.NotNil(t, hint)
+		assert.Equal(t, "foundation", hint.ToZone)
+	})
+
 	t.Run("no hint when not playing", func(t *testing.T) {
 		ft := newTestFortyThieves()
 		ft.SetPhase(domain.FortyThievesPhaseGameOver)

--- a/internal/i18n/locales/en/fortythieves.json
+++ b/internal/i18n/locales/en/fortythieves.json
@@ -21,5 +21,6 @@
   "hintLine": "Hint: {{from}} → {{to}}",
   "helpExampleHint": "  h                    ask for a move",
   "helpExampleAuto": "  ac                   send everything that can go to a foundation",
-  "helpUndo": "  u                    undo one move"
+  "helpUndo": "  u                    undo one move",
+  "hintDraw": "Hint: nothing else can move -- draw a card from the stock"
 }

--- a/internal/i18n/locales/ja/fortythieves.json
+++ b/internal/i18n/locales/ja/fortythieves.json
@@ -21,5 +21,6 @@
   "hintLine": "ヒント: {{from}} → {{to}}",
   "helpExampleHint": "  h                    次の一手を教えてもらう",
   "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る",
-  "helpUndo": "  u                    1手戻す"
+  "helpUndo": "  u                    1手戻す",
+  "hintDraw": "ヒント: 他に動かせる札はありません。山札から1枚引きましょう"
 }


### PR DESCRIPTION
Closes #5525

`GetHint` は組札・タブローへの移動しか候補にしていなかったので、**盤上に手が無く
ストックだけ残っている局面で nil を返し**、「ヒントはありません」と表示されていた。
`checkFortyThievesStalemate` は同じ局面を（正しく）手詰まりではないと扱うので、
2つの判定が食い違う。プレイヤーからは**「詰んだ」のか「引けば良いだけ」なのか
区別が付かない**。

## 直したこと

- `GetHint` の最終フォールバックに `FromZone: "stock"` (→ `"waste"`) を追加。
  **盤上に手があるならそちらが先** — 引くのは最後の手段
- CUI / Web とも専用の文言で表示する。移動の体裁 (`A → B`) に落とすと、
  引くのに意味の無い列 `-1` が漏れる
- ストックも空なら**従来どおり nil** (本当の手詰まり)

## テスト計画

- [x] `TestFortyThieves_GetHint` に 2 件 — ストックが残る局面で nil を返さない /
      **盤上に手があるならそちらを優先する**
- [x] 既存の「no hint available」(ストックも空) はそのまま緑 = 本当の手詰まりは nil のまま
- [x] `TestFortyThievesCuiPresenter_HintOutput` — 「引く」文言が出る、`cuiHintNone` を含まない、
      **`-1` が漏れていない**
- [x] `fortythievesHint.test.ts` — `targetAction: 'draw'` を返す
- [x] `golangci-lint` 0 issues / `bun run check` / `typecheck` / 各パッケージ緑

### 変異テスト (3件とも検出)

| 変異 | 落ちたアサーション |
|---|---|
| 引くヒントを盤上の手より先に返す | 1 |
| CUI が移動の体裁に落とす | 2 |
| フロントが移動の体裁に落とす | 1 |
