### PR TITLE
fix(twotenjack): announce the score that was actually added

### DIFF
--- a/frontend/src/pages/TwoTenJackPage.test.tsx
+++ b/frontend/src/pages/TwoTenJackPage.test.tsx
@@ -440,3 +440,50 @@ describe('TwoTenJackPage', () => {
     expect(document.querySelectorAll('[data-hint-suggested="true"]')).toHaveLength(0);
   });
 });
+
+// #5527: 読み上げの「+N」に獲得点札の生の合計を渡していた。契約を落とした
+// ラウンドでは実際の加点が 0 でも点札は取っているので、読み上げた数字と
+// 実際に累計へ足された数字が食い違う。
+describe('TwoTenJackPage round announcement', () => {
+  const announce = () => screen.getByRole('status').textContent ?? '';
+
+  const stateWith = (fields: { captured: number[]; round: number[]; cumulative: number[] }) =>
+    makeTwoTenJackState({
+      phase: 3,
+      players: makeTwoTenJackState().players.map((p, i) => ({
+        ...p,
+        capturedPoints: fields.captured[i],
+        roundScore: fields.round[i],
+        cumulativeScore: fields.cumulative[i],
+      })),
+    });
+
+  it('announces the score that was actually added, not the points captured', async () => {
+    // 宣言チーム(0)が 20 点しか取れず契約を落としたラウンド。
+    // 加点はチーム1に 6 点、チーム0 は 0 点。
+    mockExec.mockResolvedValue(
+      stateWith({ captured: [12, 30, 8, 20], round: [0, 6, 0, 6], cumulative: [10, 16, 10, 16] }),
+    );
+    renderWithProviders(<TwoTenJackPage />);
+    await waitFor(() => expect(announce()).toContain('ラウンド終了'));
+
+    // チーム0 は点札を 20 枚分取っているが加点は 0。
+    expect(announce()).toContain('+0');
+    // チーム1 は 2 人分の roundScore の合計 = 累計の増分。
+    expect(announce()).toContain('+12');
+    // 生の獲得点札 (20 / 50) は読み上げに出てこない。
+    expect(announce()).not.toContain('+20');
+    expect(announce()).not.toContain('+50');
+  });
+
+  it('still shows the captured points in the score table', async () => {
+    mockExec.mockResolvedValue(
+      stateWith({ captured: [12, 30, 8, 20], round: [0, 6, 0, 6], cumulative: [10, 16, 10, 16] }),
+    );
+    renderWithProviders(<TwoTenJackPage />);
+    await waitFor(() => expect(screen.getByRole('status').textContent).toContain('ラウンド終了'));
+    // 点札の合計 (12+8=20 / 30+20=50) は表に残す。
+    expect(screen.getAllByText('20').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('50').length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/pages/TwoTenJackPage.test.tsx
+++ b/frontend/src/pages/TwoTenJackPage.test.tsx
@@ -486,6 +486,15 @@ describe('TwoTenJackPage round announcement', () => {
     expect(screen.getByRole('status').textContent).toContain('+0');
   });
 
+  // 席が1つも無いレスポンス: 4本の `?.` がすべて短絡する側を通す。
+  it('renders with no players at all', async () => {
+    const short = makeTwoTenJackState({ phase: 3 });
+    mockExec.mockResolvedValue({ ...short, players: [] });
+    renderWithProviders(<TwoTenJackPage />);
+    await waitFor(() => expect(screen.getByRole('status').textContent).toContain('ラウンド終了'));
+    expect(screen.getByRole('status').textContent).toContain('+0');
+  });
+
   it('still shows the captured points in the score table', async () => {
     mockExec.mockResolvedValue(
       stateWith({ captured: [12, 30, 8, 20], round: [0, 6, 0, 6], cumulative: [10, 16, 10, 16] }),

--- a/frontend/src/pages/TwoTenJackPage.test.tsx
+++ b/frontend/src/pages/TwoTenJackPage.test.tsx
@@ -476,6 +476,16 @@ describe('TwoTenJackPage round announcement', () => {
     expect(announce()).not.toContain('+50');
   });
 
+  // **席が欠けたレスポンスでも落ちない。**合計は `?? 0` で埋めるので、
+  // その分岐も一度は通しておく (codecov は ?. と ?? を別の枝に数える)。
+  it('treats a missing seat as zero rather than crashing', async () => {
+    const short = makeTwoTenJackState({ phase: 3 });
+    mockExec.mockResolvedValue({ ...short, players: short.players.slice(0, 2) });
+    renderWithProviders(<TwoTenJackPage />);
+    await waitFor(() => expect(screen.getByRole('status').textContent).toContain('ラウンド終了'));
+    expect(screen.getByRole('status').textContent).toContain('+0');
+  });
+
   it('still shows the captured points in the score table', async () => {
     mockExec.mockResolvedValue(
       stateWith({ captured: [12, 30, 8, 20], round: [0, 6, 0, 6], cumulative: [10, 16, 10, 16] }),

--- a/frontend/src/pages/TwoTenJackPage.tsx
+++ b/frontend/src/pages/TwoTenJackPage.tsx
@@ -185,6 +185,12 @@ function TwoTenJackPageContent() {
   const team1Total = (state.players[1]?.cumulativeScore ?? 0) + (state.players[3]?.cumulativeScore ?? 0);
   const team0Captured = (state.players[0]?.capturedPoints ?? 0) + (state.players[2]?.capturedPoints ?? 0);
   const team1Captured = (state.players[1]?.capturedPoints ?? 0) + (state.players[3]?.capturedPoints ?? 0);
+  // **読み上げる「+N」は加点であって、取った点札ではない (#5527)。**契約を
+  // 落としたラウンドは点札を取っていても加点 0 になるので、capturedPoints を
+  // 読み上げると累計の増分と食い違う。cumulativeScore が両席の合計である以上
+  // (domain の checkGameEnd も同じ数え方)、増分も両席の roundScore の合計。
+  const team0RoundScore = (state.players[0]?.roundScore ?? 0) + (state.players[2]?.roundScore ?? 0);
+  const team1RoundScore = (state.players[1]?.roundScore ?? 0) + (state.players[3]?.roundScore ?? 0);
 
   return (
     <GamePageShell
@@ -364,8 +370,8 @@ function TwoTenJackPageContent() {
                 <RoundScoreAnnouncement
                   active={isRoundEnd || isGameEnd}
                   entries={[
-                    { name: t('team0'), roundScore: team0Captured, cumulativeScore: team0Total },
-                    { name: t('team1'), roundScore: team1Captured, cumulativeScore: team1Total },
+                    { name: t('team0'), roundScore: team0RoundScore, cumulativeScore: team0Total },
+                    { name: t('team1'), roundScore: team1RoundScore, cumulativeScore: team1Total },
                   ]}
                 />
               </div>


### PR DESCRIPTION
Closes #5527

ラウンド終了の読み上げ (`RoundScoreAnnouncement`) には `capturedPoints`
(**取った点札の生の合計**) を渡していたのに、隣に出る合計は `cumulativeScore` から
来ていた。契約を落としたラウンドは点札を取っていても加点が 0 なので、
**「+20 (合計 10)」のように、実際には 1 点も増えていないのに増えたと読み上げる**。

## 直したこと

`roundScore` の合計を渡す。`CommitRoundScore` が累計に足すのはこの値で、
**チームの両席が同じ値を持つ**。`cumulativeScore` を両席分合計するのは
domain の `checkGameEnd` もページの `team0Total` も同じ数え方なので、
増分も両席の合計にすると累計の増分とちょうど一致する。

スコア表の `capturedPoints` 列は**そのまま**。

## テスト計画

- [x] 契約失敗のラウンド (点札 20/50、加点 0/12) で、読み上げが `+0` と `+12` になり
      **生の点札 (`+20` / `+50`) が出ない**
- [x] 同じ局面でスコア表には点札の 20 / 50 が残る
- [x] 既存 34 件緑 / `bun run check` / `typecheck` 緑

### 変異テスト (2件とも検出)

| 変異 | 落ちたテスト |
|---|---|
| `capturedPoints` に戻す | 1 |
| 片方の席の `roundScore` だけを使う (増分の半分) | 1 |