### PR TITLE
feat(caribbeanstud): explain the jackpot bet before the CUI asks for it

### DIFF
--- a/internal/adapter/presenter/CaribbeanStudCuiPresenter.go
+++ b/internal/adapter/presenter/CaribbeanStudCuiPresenter.go
@@ -24,6 +24,13 @@ func (cp *CaribbeanStudCuiPresenter) Output(cs interfaces.CaribbeanStudGame, las
 	sb.WriteString(i18n.Tf("caribbeanstud.chipsLine", "chips", strconv.Itoa(cs.GetChips())) + "\n")
 	sb.WriteString(i18n.Tf("caribbeanstud.phaseLine", "phase", cp.phaseStr(cs.GetPhase())) + "\n")
 
+	// ジャックポットは任意の追加ベット。Web には常設の説明があるのに CUI には
+	// 一言も無く、"b <ante> <jackpot>" で実チップを賭けさせていた (#5528)。
+	// 賭け終わった後は出さない -- もう選べないものの説明は場所を取るだけ。
+	if cs.GetPhase() == domain.CaribbeanStudPhaseBet {
+		sb.WriteString(i18n.T("caribbeanstud.jackpotHelp") + "\n")
+	}
+
 	playerHand := cs.GetPlayerHand()
 	if len(playerHand) > 0 {
 		sb.WriteString("--- " + color.Bold(i18n.T("caribbeanstud.playerHeader")) + " ---\n")

--- a/internal/adapter/presenter/CaribbeanStudCuiPresenter_test.go
+++ b/internal/adapter/presenter/CaribbeanStudCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupCaribbeanStudCuiMockDefaults(m *interfaces.MockCaribbeanStudGame) {
@@ -267,4 +268,30 @@ func TestCaribbeanStudCuiPresenter_HintOutput(t *testing.T) {
 			p.HintOutput(game(domain.CaribbeanStudPhaseAction, domain.PokerHandHighCard, nil)),
 			"ヒントを出せません")
 	})
+}
+
+// #5528: Web には常設の説明があるのに、CUI は "b <ante> <jackpot>" で
+// 実チップを賭けさせながら、何が当たれば配当されるのか一言も言っていなかった。
+func TestCaribbeanStudCuiPresenter_Output_JackpotIsExplainedBeforeBetting(t *testing.T) {
+	p := new(CaribbeanStudCuiPresenter)
+
+	// GetPhase を先に登録する。testify は最初に一致した期待を返すので、
+	// defaults の .Maybe() より前に置けば差し替えになる。
+	outputInPhase := func(phase int) string {
+		m := new(interfaces.MockCaribbeanStudGame)
+		m.On("GetPhase").Return(phase)
+		setupCaribbeanStudCuiMockDefaults(m)
+		return p.Output(m, nil)
+	}
+
+	betOut := outputInPhase(domain.CaribbeanStudPhaseBet)
+	assert.Contains(t, betOut, i18n.T("caribbeanstud.jackpotHelp"))
+	// Web の説明と揃っていること: フラッシュ以上で、勝敗に関係なく配当。
+	assert.Contains(t, i18n.T("caribbeanstud.jackpotHelp"), "フラッシュ")
+
+	// **賭け終わった後には出さない。**もう選べないものの説明は場所を取るだけ。
+	assert.NotContains(t, outputInPhase(domain.CaribbeanStudPhaseAction),
+		i18n.T("caribbeanstud.jackpotHelp"))
+	assert.NotContains(t, outputInPhase(domain.CaribbeanStudPhaseEnd),
+		i18n.T("caribbeanstud.jackpotHelp"))
 }

--- a/internal/i18n/locales/en/caribbeanstud.json
+++ b/internal/i18n/locales/en/caribbeanstud.json
@@ -30,5 +30,6 @@
   "hintWeakHand": "no made hand and nothing as high as Ace-King",
   "helpExampleBet": "  b 10                 ante 10 and get a hand",
   "helpExamplePlay": "  p                    call, placing a play bet of 2x the ante",
-  "helpHint": "  h                    show a hint"
+  "helpHint": "  h                    show a hint",
+  "jackpotHelp": "Jackpot (optional): pays on a flush or better, whether or not you beat the dealer"
 }

--- a/internal/i18n/locales/ja/caribbeanstud.json
+++ b/internal/i18n/locales/ja/caribbeanstud.json
@@ -30,5 +30,6 @@
   "hintWeakHand": "役が無く A-K にも届かない",
   "helpExampleBet": "  b 10                 アンテ 10 で参加する",
   "helpExamplePlay": "  p                    勝負する (アンテの 2 倍を追加)",
-  "helpHint": "  h                    助言を表示"
+  "helpHint": "  h                    助言を表示",
+  "jackpotHelp": "ジャックポット(任意): フラッシュ以上の役が成立すれば、勝敗に関係なく配当が当たります"
 }


### PR DESCRIPTION
Closes #5528

CUI の `b <ante> <jackpot>` は**実チップを賭ける任意のサイドベット**なのに、
何が当たれば配当されるのか一言も説明していなかった。Web の BET フェーズには
`jackpotHelp` の常設説明があり、CUI 側だけが取り残されていた。

## 直したこと

BET フェーズの出力にジャックポットの成立条件を 1 行追加した (ja/en)。
文言は Web の `jackpotHelp` と揃えてある — **フラッシュ以上、勝敗に関係なく配当**。

賭け終わった後 (ACTION / END) には出さない。もう選べないものの説明は場所を取るだけ。

## テスト計画

- [x] BET フェーズの出力に説明が含まれる
- [x] **ACTION / END フェーズには出ない**
- [x] 文言が Web の説明と揃っている (「フラッシュ」を含むことを確認)
- [x] 既存の CaribbeanStud CUI テスト緑 / `golangci-lint` 0 issues

`docs/manual/cui/caribbeanstud.md` は既にジャックポットを説明済みなので変更なし
(欠けていたのは対局中の画面だけ)。

### 変異テスト (2件とも検出)

| 変異 | 落ちたアサーション |
|---|---|
| 全フェーズで出す | 2 |
| どのフェーズでも出さない | 1 |