### PR TITLE
feat(texasholdembonus): show the bonus paytable before the CUI takes the bet

### DIFF
--- a/internal/adapter/presenter/TexasHoldemBonusCuiPresenter.go
+++ b/internal/adapter/presenter/TexasHoldemBonusCuiPresenter.go
@@ -38,6 +38,13 @@ func (tp *TexasHoldemBonusCuiPresenter) Output(g interfaces.TexasHoldemBonusGame
 			"cost", strconv.Itoa(cost)))
 	}
 
+	// ボーナスは任意の追加ベット。Web は BET フェーズに配当表を出しているのに、
+	// CUI は "bet <ante> <bonus>" で実チップを賭けさせながら何が当たるのか
+	// 言っていなかった (#5529)。賭け終わった後は出さない。
+	if g.GetPhase() == domain.TexasHoldemBonusPhaseBet {
+		sb.WriteString(texasHoldemBonusPaytableStr())
+	}
+
 	if community := g.GetCommunity(); len(community) > 0 {
 		sb.WriteString("--- " + color.Bold(i18n.T("texasholdembonus.boardHeader")) + " ---\n")
 		parts := make([]string, len(community))
@@ -124,6 +131,30 @@ func (tp *TexasHoldemBonusCuiPresenter) Output(g interfaces.TexasHoldemBonusGame
 // ActionLogOutput 棋譜をテキスト出力
 func (tp *TexasHoldemBonusCuiPresenter) ActionLogOutput(g interfaces.TexasHoldemBonusGame) string {
 	return actionLogOutputText(g)
+}
+
+// texasHoldemBonusPaytableStr renders the bonus side-bet paytable.
+//
+// **倍率はドメインの定数から読む。**文言に書き写すと、配当を1つ直したときに
+// 表だけが古いまま残り、プレイヤーは違う倍率を見て賭けることになる (#5529)。
+func texasHoldemBonusPaytableStr() string {
+	rows := []struct {
+		key  string
+		mult int
+	}{
+		{"texasholdembonus.bonusPayAA", domain.TexasHoldemBonusBonusPayAA},
+		{"texasholdembonus.bonusPayAKSuited", domain.TexasHoldemBonusBonusPayAKSuited},
+		{"texasholdembonus.bonusPayAQAJSuited", domain.TexasHoldemBonusBonusPayAQAJSuited},
+		{"texasholdembonus.bonusPayAKOff", domain.TexasHoldemBonusBonusPayAKOff},
+		{"texasholdembonus.bonusPayKKQQJJ", domain.TexasHoldemBonusBonusPayKKQQJJ},
+		{"texasholdembonus.bonusPayAQAJOff", domain.TexasHoldemBonusBonusPayAQAJOff},
+		{"texasholdembonus.bonusPayMediumPair", domain.TexasHoldemBonusBonusPayMediumPair},
+	}
+	parts := make([]string, len(rows))
+	for i, r := range rows {
+		parts[i] = i18n.Tf(r.key, "mult", strconv.Itoa(r.mult))
+	}
+	return i18n.T("texasholdembonus.bonusPayHeader") + strings.Join(parts, " / ") + "\n"
 }
 
 // phaseStr フェーズ文字列

--- a/internal/adapter/presenter/TexasHoldemBonusCuiPresenter_test.go
+++ b/internal/adapter/presenter/TexasHoldemBonusCuiPresenter_test.go
@@ -1,12 +1,14 @@
 package presenter
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupTexasHoldemBonusCuiMockDefaults(m *interfaces.MockTexasHoldemBonusGame) {
@@ -363,4 +365,43 @@ func TestTexasHoldemBonusCuiPresenter_BetCostLine(t *testing.T) {
 		out := p.Output(game(domain.TexasHoldemBonusPhaseBet, 0, 0), nil)
 		assert.NotContains(t, out, "チップ / ")
 	})
+}
+
+// #5529: Web は BET フェーズにボーナスの配当表を出しているのに、CUI は
+// "bet <ante> <bonus>" で実チップを賭けさせながら何が当たるのか言っていなかった。
+func TestTexasHoldemBonusCuiPresenter_Output_BonusPaytable(t *testing.T) {
+	p := new(TexasHoldemBonusCuiPresenter)
+
+	outputInPhase := func(phase int) string {
+		m := new(interfaces.MockTexasHoldemBonusGame)
+		m.On("GetPhase").Return(phase)
+		setupTexasHoldemBonusCuiMockDefaults(m)
+		return p.Output(m, nil)
+	}
+
+	betOut := outputInPhase(domain.TexasHoldemBonusPhaseBet)
+	assert.Contains(t, betOut, i18n.T("texasholdembonus.bonusPayHeader"))
+
+	// **倍率はドメインの定数から出す。**画面に書き写すと、配当を1つ直したとき
+	// 表だけが古いまま残る。
+	for _, tc := range []struct {
+		key  string
+		mult int
+	}{
+		{"texasholdembonus.bonusPayAA", domain.TexasHoldemBonusBonusPayAA},
+		{"texasholdembonus.bonusPayAKSuited", domain.TexasHoldemBonusBonusPayAKSuited},
+		{"texasholdembonus.bonusPayAQAJSuited", domain.TexasHoldemBonusBonusPayAQAJSuited},
+		{"texasholdembonus.bonusPayAKOff", domain.TexasHoldemBonusBonusPayAKOff},
+		{"texasholdembonus.bonusPayKKQQJJ", domain.TexasHoldemBonusBonusPayKKQQJJ},
+		{"texasholdembonus.bonusPayAQAJOff", domain.TexasHoldemBonusBonusPayAQAJOff},
+		{"texasholdembonus.bonusPayMediumPair", domain.TexasHoldemBonusBonusPayMediumPair},
+	} {
+		assert.Contains(t, betOut, i18n.Tf(tc.key, "mult", strconv.Itoa(tc.mult)), tc.key)
+	}
+
+	// **賭け終わった後には出さない。**もう選べないものの説明は場所を取るだけ。
+	assert.NotContains(t, outputInPhase(domain.TexasHoldemBonusPhasePreFlop),
+		i18n.T("texasholdembonus.bonusPayHeader"))
+	assert.NotContains(t, outputInPhase(domain.TexasHoldemBonusPhaseEnd),
+		i18n.T("texasholdembonus.bonusPayHeader"))
 }

--- a/internal/i18n/locales/en/texasholdembonus.json
+++ b/internal/i18n/locales/en/texasholdembonus.json
@@ -28,5 +28,13 @@
   "betCostLine": "Ante: {{ante}} / {{action}}: {{cost}} chips",
   "costPlay": "Play",
   "costRaise": "Raise",
-  "helpExampleBet": "  b 100                bet 100 chips"
+  "helpExampleBet": "  b 100                bet 100 chips",
+  "bonusPayHeader": "Bonus payouts (hole cards): ",
+  "bonusPayAA": "AA {{mult}}:1",
+  "bonusPayAKSuited": "AK suited {{mult}}:1",
+  "bonusPayAQAJSuited": "AQ/AJ suited {{mult}}:1",
+  "bonusPayAKOff": "AK offsuit {{mult}}:1",
+  "bonusPayKKQQJJ": "KK/QQ/JJ {{mult}}:1",
+  "bonusPayAQAJOff": "AQ/AJ offsuit {{mult}}:1",
+  "bonusPayMediumPair": "22-TT {{mult}}:1"
 }

--- a/internal/i18n/locales/ja/texasholdembonus.json
+++ b/internal/i18n/locales/ja/texasholdembonus.json
@@ -28,5 +28,13 @@
   "betCostLine": "アンテ: {{ante}} / {{action}}: {{cost}} チップ",
   "costPlay": "プレイ",
   "costRaise": "レイズ",
-  "helpExampleBet": "  b 100                100 チップを賭ける"
+  "helpExampleBet": "  b 100                100 チップを賭ける",
+  "bonusPayHeader": "ボーナス配当(ホールカード): ",
+  "bonusPayAA": "AA {{mult}}:1",
+  "bonusPayAKSuited": "AK スーテッド {{mult}}:1",
+  "bonusPayAQAJSuited": "AQ/AJ スーテッド {{mult}}:1",
+  "bonusPayAKOff": "AK オフ {{mult}}:1",
+  "bonusPayKKQQJJ": "KK/QQ/JJ {{mult}}:1",
+  "bonusPayAQAJOff": "AQ/AJ オフ {{mult}}:1",
+  "bonusPayMediumPair": "22〜TT {{mult}}:1"
 }


### PR DESCRIPTION
Closes #5529

CUI の `bet <ante> <bonus>` は**実チップを賭ける任意のサイドベット**なのに、
AA やスーテッド AK など何が当たれば払い戻されるのか一言も出していなかった。
Web は BET フェーズに 7 行の配当表を出している。#4698 でアンテのコスト表示は
入ったが、ボーナス側は手つかずだった。

## 直したこと

BET フェーズに 7 行の配当をまとめた 1 ブロックを追加 (ja/en)。

**倍率はロケール文字列ではなくドメインの定数から読む** (`TexasHoldemBonusBonusPayAA` 等)。
文言に書き写すと、配当を 1 つ直したときに表だけが古いまま残り、
プレイヤーは**もう適用されない倍率を見て賭ける**ことになる。

賭け終わった後 (PREFLOP 以降) には出さない。

## テスト計画

- [x] BET フェーズの出力に 7 行すべてが出る。**各行の倍率は `domain.*` の定数と突き合わせる**
      (テストに数字を書かない)
- [x] PREFLOP / END には出ない
- [x] 既存の TexasHoldemBonus CUI テスト緑 / `golangci-lint` 0 issues

### 変異テスト (3件とも検出、いずれもコンパイル確認済み)

| 変異 | 落ちたアサーション |
|---|---|
| 全フェーズで出す | 2 |
| AA の行だけ定数でなく 25 をベタ書き | 1 |
| 1 行 (22〜TT) を落とす | 1 |