### PR TITLE
feat(canfield): say why an empty column will not take a card

### DIFF
--- a/frontend/src/i18n/locales/en/canfield.json
+++ b/frontend/src/i18n/locales/en/canfield.json
@@ -47,5 +47,7 @@
     "resetButton": "Start a new game."
   },
   "columnActionsFor": "Column {{n}} actions",
-  "collapseColumnActions": "Collapse column action buttons"
+  "collapseColumnActions": "Collapse column action buttons",
+  "reserveEmptyColumnRule": "While the reserve still has cards you cannot place a card on an empty column yourself — it is refilled from the reserve",
+  "dismissRule": "Dismiss this note"
 }

--- a/frontend/src/i18n/locales/ja/canfield.json
+++ b/frontend/src/i18n/locales/ja/canfield.json
@@ -47,5 +47,7 @@
     "resetButton": "新しいゲームを始めるボタンです。"
   },
   "columnActionsFor": "列 {{n}} の操作",
-  "collapseColumnActions": "列の操作ボタンを折りたたむ"
+  "collapseColumnActions": "列の操作ボタンを折りたたむ",
+  "reserveEmptyColumnRule": "リザーブが残っている間は、空いた列に自分でカードを置けません（リザーブから自動補充されます）",
+  "dismissRule": "説明を閉じる"
 }

--- a/frontend/src/pages/CanfieldPage.test.tsx
+++ b/frontend/src/pages/CanfieldPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { canfieldApi } from '../api/gameApi';
 import { flushPendingDispatch } from '../test/flushPendingDispatch';
@@ -442,5 +442,38 @@ describe('CanfieldPage', () => {
         ),
       );
     });
+  });
+});
+
+// #5531: 「リザーブが残っている間は空列に自分で置けない (自動補充される)」は
+// クロンダイクの直感と食い違う固有ルールなのに、画面のどこにも書いていなかった。
+describe('CanfieldPage reserve rule note', () => {
+  it('explains the empty-column restriction while the reserve has cards', async () => {
+    mockExec.mockResolvedValue(playingState); // reserve に1枚ある
+    renderWithProviders(<CanfieldPage />);
+    const note = await screen.findByTestId('cf-reserve-rule');
+    expect(note).toHaveAttribute('role', 'note');
+    expect(note).toHaveTextContent('自動補充');
+  });
+
+  // **リザーブが尽きたら制限も消える。**残しておくと嘘の説明になる。
+  it('is gone once the reserve is empty', async () => {
+    mockExec.mockResolvedValue({ ...playingState, reserve: [] });
+    renderWithProviders(<CanfieldPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    expect(screen.queryByTestId('cf-reserve-rule')).not.toBeInTheDocument();
+  });
+
+  it('can be dismissed and stays dismissed', async () => {
+    mockExec.mockResolvedValue(playingState);
+    const { unmount } = renderWithProviders(<CanfieldPage />);
+    const note = await screen.findByTestId('cf-reserve-rule');
+    fireEvent.click(within(note).getByRole('button'));
+    await waitFor(() => expect(screen.queryByTestId('cf-reserve-rule')).not.toBeInTheDocument());
+
+    unmount();
+    renderWithProviders(<CanfieldPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    expect(screen.queryByTestId('cf-reserve-rule')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/CanfieldPage.tsx
+++ b/frontend/src/pages/CanfieldPage.tsx
@@ -119,6 +119,10 @@ function CanfieldPageContent() {
   // behind a <details> disclosure, matching the mobile treatment. Persisted so
   // the preference survives reloads. Drag-and-drop is unaffected either way.
   const [collapseColActions, setCollapseColActions] = useLocalStorageToggle('canfield-collapse-col-actions', false);
+  const [reserveRuleDismissed, setReserveRuleDismissed] = useLocalStorageToggle(
+    'canfield-reserve-rule-dismissed',
+    false,
+  );
   const cliConfig: CliGameConfig<CanfieldResponse, Parameters<typeof canfieldApi.exec>> = useMemo(
     () => ({
       gameName: 'canfield',
@@ -378,6 +382,24 @@ function CanfieldPageContent() {
             </div>
 
             {/* Tableau */}
+            {/* 「リザーブが残っている間は空列に自分で置けない (自動補充される)」は
+                canPlaceOnTableau の非自明な規則で、クロンダイクの「空列にはK」という
+                直感と食い違う。書いていないと、プレイヤーは理由の分からない拒否を
+                受け取ることになる (#5531)。RussianSolitaire の rs-facedown-rule と
+                同じ、閉じられる注記。 */}
+            {state.reserve.length > 0 && !reserveRuleDismissed && (
+              <div className="flex items-center justify-center gap-1 mb-1" data-testid="cf-reserve-rule" role="note">
+                <p className="text-ds-text-muted text-xs text-center">{t('reserveEmptyColumnRule')}</p>
+                <button
+                  type="button"
+                  onClick={() => setReserveRuleDismissed(true)}
+                  aria-label={t('dismissRule')}
+                  className={`shrink-0 px-2 py-1 text-ds-text-muted hover:text-ds-text-primary text-sm leading-none ${focusRingWhite} rounded`}
+                >
+                  ×
+                </button>
+              </div>
+            )}
             <div className="mb-3 flex gap-2" data-tutorial="cf-tableau">
               {state.tableau.map((col, i) => {
                 const tZone: CanfieldMoveZone = { zone: 'tableau', col: i };


### PR DESCRIPTION
Closes #5531

`Canfield.canPlaceOnTableau` は**リザーブが残っている間、空列への配置を拒否する**
(`len(colCards) == 0` なら `return len(c.reserve) == 0`)。空列はリザーブから
自動補充されるためだが、これはクロンダイク系の「空列にはKを置ける」という直感と
食い違う固有ルールで、**ページにもロケールにも一言も書かれていなかった**。
プレイヤーは理由の分からない拒否メッセージを受け取るだけになる。

## 直したこと

RussianSolitaire の `rs-facedown-rule` (#4789) と同じ形の、閉じられる注記を
タブローの上に出す。

- `state.reserve.length > 0` の間だけ表示。**リザーブが尽きたら消える** —
  そこから先は制限が存在しないので、残すと嘘の説明になる
- 閉じるボタン + `useLocalStorageToggle('canfield-reserve-rule-dismissed')` で永続化
- ja/en 両方に文言を追加

## テスト計画

- [x] リザーブに札がある間、`role="note"` の注記が出て「自動補充」と説明する
- [x] **リザーブが空なら出ない**
- [x] 閉じると消え、**再マウントしても消えたまま**

### 変異テスト (2件とも検出)

| 変異 | 落ちたテスト |
|---|---|
| リザーブが空でも出す | 1 |
| 永続化キーをマウントごとに変える (= 閉じても次回また出る) | 1 |