### PR TITLE
feat(fiftyone): say who called stop and that the round is the last

### DIFF
--- a/frontend/src/i18n/locales/en/fiftyone.json
+++ b/frontend/src/i18n/locales/en/fiftyone.json
@@ -20,7 +20,8 @@
     "stopCalled": "Stop called",
     "yourTurn": "Your turn",
     "cpuTurn": "CPU {{id}}'s turn",
-    "suitScores": "Suit totals"
+    "suitScores": "Suit totals",
+    "stopCalledBy": "Stop is in effect ({{name}}) — this is the final round"
   },
   "settings": {
     "cpuDifficulty": "CPU Difficulty",

--- a/frontend/src/i18n/locales/ja/fiftyone.json
+++ b/frontend/src/i18n/locales/ja/fiftyone.json
@@ -20,7 +20,8 @@
     "stopCalled": "ストップ宣言済み",
     "yourTurn": "あなたのターン",
     "cpuTurn": "CPU{{id}}のターン",
-    "suitScores": "スート別合計"
+    "suitScores": "スート別合計",
+    "stopCalledBy": "ストップ宣言中（{{name}}）— 残り1巡が最終ラウンドです"
   },
   "settings": {
     "cpuDifficulty": "CPU難易度",

--- a/frontend/src/pages/FiftyOnePage.test.tsx
+++ b/frontend/src/pages/FiftyOnePage.test.tsx
@@ -239,3 +239,36 @@ describe('FiftyOnePage', () => {
     expect(heart.className).not.toContain('bg-ds-accent');
   });
 });
+
+// #5532: CUI は「誰が宣言したか」と「残り1巡で終わる」を出しているのに、
+// Web は「ストップ宣言済み」の一文だけで、どちらも分からなかった。
+describe('FiftyOnePage stop indicator', () => {
+  const stopBanner = () => screen.getByTestId('fo-stop-called');
+
+  it('names the CPU that called stop and says it is the last round', async () => {
+    mockExec.mockResolvedValue({ ...baseState, stopCallerIdx: 2 });
+    const { FiftyOnePage } = await import('./FiftyOnePage');
+    renderWithProviders(<FiftyOnePage />);
+    await waitFor(() => expect(stopBanner()).toBeInTheDocument());
+    expect(stopBanner()).toHaveTextContent('CPU 2');
+    expect(stopBanner()).toHaveTextContent('最終');
+  });
+
+  it('names the human when the human called it', async () => {
+    mockExec.mockResolvedValue({ ...baseState, stopCallerIdx: 0 });
+    const { FiftyOnePage } = await import('./FiftyOnePage');
+    renderWithProviders(<FiftyOnePage />);
+    await waitFor(() => expect(stopBanner()).toBeInTheDocument());
+    expect(stopBanner()).toHaveTextContent('あなた');
+    // **CPU 0 と読ませない。**席0は人間。
+    expect(stopBanner()).not.toHaveTextContent('CPU 0');
+  });
+
+  it('shows nothing before anyone calls stop', async () => {
+    mockExec.mockResolvedValue(baseState);
+    const { FiftyOnePage } = await import('./FiftyOnePage');
+    renderWithProviders(<FiftyOnePage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    expect(screen.queryByTestId('fo-stop-called')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/FiftyOnePage.tsx
+++ b/frontend/src/pages/FiftyOnePage.tsx
@@ -255,8 +255,17 @@ function FiftyOnePageContent() {
             </div>
 
             {/* Stop indicator */}
+            {/* CUI は宣言者と「残り1巡が最終ラウンド」まで出しているのに、Web は
+                「ストップ宣言済み」の一文だけで、誰が宣言したのかも、あと何巡で
+                終わるのかも分からなかった (#5532)。 */}
             {state.stopCallerIdx >= 0 && (
-              <div className="text-center text-ds-warning text-sm font-medium">{t('label.stopCalled')}</div>
+              <div className="text-center text-ds-warning text-sm font-medium" data-testid="fo-stop-called">
+                {t('label.stopCalledBy', {
+                  name: state.players[state.stopCallerIdx]?.isHuman
+                    ? tc('player.you')
+                    : tc('player.cpu', { id: state.stopCallerIdx }),
+                })}
+              </div>
             )}
 
             {/* Human hand */}


### PR DESCRIPTION
Closes #5532

CUI は `fiftyone.cuiStopCalled` で「⚠ ストップ宣言中（{{name}}）— 残り1巡が最終ラウンドです」と
**誰が宣言したか**と**あと何巡で終わるか**を出している。Web は同じ `stopCallerIdx` を
持ちながら「ストップ宣言済み」の一文だけで、**プレイヤーがその瞬間に知りたい 2 つとも
答えていなかった**。

## 直したこと

CUI と同じ文言に差し替え、宣言者名を出す (`label.stopCalledBy`、ja/en)。
席 0 は人間なので「あなた」と呼ぶ — 一律 `CPU {{id}}` にすると自分の宣言が
「CPU 0」になる。

## テスト計画

- [x] CPU が宣言 → 「CPU 2」と「最終」が出る
- [x] 人間が宣言 → 「あなた」が出て、**「CPU 0」とは出ない**
- [x] 宣言前は表示自体が無い
- [x] 既存 15 件緑 / `bun run check` / `typecheck` 緑

### 変異テスト (2件とも検出)

| 変異 | 落ちたテスト |
|---|---|
| 席によらず `CPU {{id}}` と呼ぶ | 1 |
| 元の「ストップ宣言済み」に戻す | 2 |