### PR TITLE
feat(russiansolitaire): announce how many cards move together

### DIFF
--- a/frontend/src/i18n/locales/en/russiansolitaire.json
+++ b/frontend/src/i18n/locales/en/russiansolitaire.json
@@ -41,5 +41,6 @@
   "tableauRule": "Tableau moves must be same suit, one rank down — unlike Yukon, alternating colours will not connect. Face-down cards can't be moved.",
   "faceDownRule": "Face-down cards can't be moved — only face-up cards are playable",
   "dismissRule": "Dismiss rule note",
-  "faceDownCardLabel": "Column {{col}}, card {{pos}} from top, face down"
+  "faceDownCardLabel": "Column {{col}}, card {{pos}} from top, face down",
+  "blockMoveLabel": "moves as a block of {{n}} cards"
 }

--- a/frontend/src/i18n/locales/ja/russiansolitaire.json
+++ b/frontend/src/i18n/locales/ja/russiansolitaire.json
@@ -41,5 +41,6 @@
   "tableauRule": "タブロー間の移動は「同じスートで1つ下」のみ。Yukonと違い交互色では繋げません。裏向きのカードは動かせません。",
   "faceDownRule": "裏向きのカードは移動できません（表向きのカードのみ操作可能）",
   "dismissRule": "ルール説明を閉じる",
-  "faceDownCardLabel": "列{{col}}、上から{{pos}}枚目、裏向き"
+  "faceDownCardLabel": "列{{col}}、上から{{pos}}枚目、裏向き",
+  "blockMoveLabel": "{{n}}枚まとめて移動"
 }

--- a/frontend/src/pages/RussianSolitairePage.test.tsx
+++ b/frontend/src/pages/RussianSolitairePage.test.tsx
@@ -404,6 +404,31 @@ describe('RussianSolitairePage block move announcement', () => {
     expect(screen.getByRole('button', { name: /♥ 8/ }).getAttribute('aria-label')).toContain('2枚');
   });
 
+  // faceUp なのに card が無いレスポンス (壊れた state) でも落ちず、
+  // 枚数だけは読める。`tc.card ? ... : ''` の空側を通す。
+  it('still announces the block when a face-up entry has no card', async () => {
+    const broken = {
+      ...blockState,
+      tableau: [
+        [
+          { card: null, faceUp: true },
+          { card: card('HEART', 8), faceUp: true },
+        ],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+    };
+    mockExec.mockResolvedValue(broken);
+    renderWithProviders(<RussianSolitairePage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: /♥ 8/ })).toBeInTheDocument());
+    // 先頭の空カードのボタンは名前が枚数だけになる。
+    expect(screen.getByRole('button', { name: '2枚まとめて移動' })).toBeInTheDocument();
+  });
+
   // **列の末尾は 1 枚。**「あと0枚と一緒に」は読み上げても意味がない。
   it('does not announce a block for the bottom card', async () => {
     mockExec.mockResolvedValue(blockState);

--- a/frontend/src/pages/RussianSolitairePage.test.tsx
+++ b/frontend/src/pages/RussianSolitairePage.test.tsx
@@ -373,3 +373,44 @@ describe('RussianSolitairePage deselect routing (#4439)', () => {
     expect(mockExec).not.toHaveBeenCalled();
   });
 });
+
+// #5534: 選んだ札の上に乗る札は全部まとめて動く (Yukon 系共通)。画面には
+// ハイライトのリングで示していたが、**読み上げには枚数が一切乗っていなかった**。
+describe('RussianSolitairePage block move announcement', () => {
+  const blockState = {
+    ...playingState,
+    tableau: [
+      [
+        { card: card('SPADE', 13), faceUp: true },
+        { card: card('HEART', 8), faceUp: true },
+        { card: card('CLOVER', 5), faceUp: true },
+      ],
+      [{ card: card('DIAMOND', 10), faceUp: true }],
+      [],
+      [],
+      [],
+      [],
+      [],
+    ],
+  };
+
+  it('says how many cards come along with the one being read', async () => {
+    mockExec.mockResolvedValue(blockState);
+    renderWithProviders(<RussianSolitairePage />);
+    // ♠K の上に ♥8 と ♣5 が乗っている → 3枚まとめて動く。
+    await waitFor(() => expect(screen.getByRole('button', { name: /♠ K/ })).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /♠ K/ }).getAttribute('aria-label')).toContain('3枚');
+    // 中間の ♥8 からは 2 枚。
+    expect(screen.getByRole('button', { name: /♥ 8/ }).getAttribute('aria-label')).toContain('2枚');
+  });
+
+  // **列の末尾は 1 枚。**「あと0枚と一緒に」は読み上げても意味がない。
+  it('does not announce a block for the bottom card', async () => {
+    mockExec.mockResolvedValue(blockState);
+    renderWithProviders(<RussianSolitairePage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: /♣ 5/ })).toBeInTheDocument());
+    const label = screen.getByRole('button', { name: /♣ 5/ }).getAttribute('aria-label') ?? '';
+    expect(label).toContain('♣ 5');
+    expect(label).not.toContain('枚まとめて');
+  });
+});

--- a/frontend/src/pages/RussianSolitairePage.tsx
+++ b/frontend/src/pages/RussianSolitairePage.tsx
@@ -492,7 +492,15 @@ function RussianSolitairePageContent() {
                                         }
                                       }}
                                       disabled={!isPlaying}
-                                      aria-label={`${tc.card ? cardAlt(tc.card) : ''}${hintAria}`}
+                                      // 上に乗る札は全部まとめて動く。画面はリングで
+                                      // 示していたが、読み上げには枚数が乗っていな
+                                      // かった (#5534)。末尾の1枚だけのときは言わない
+                                      // -- 「1枚まとめて」は情報にならない。
+                                      aria-label={`${tc.card ? cardAlt(tc.card) : ''}${
+                                        col.length - cardIdx > 1
+                                          ? ` ${t('blockMoveLabel', { n: col.length - cardIdx })}`
+                                          : ''
+                                      }${hintAria}`}
                                     >
                                       {tc.card && <AnimatedCard card={tc.card} width={rs.cw} />}
                                     </button>


### PR DESCRIPTION
Closes #5534

表向きの札を選ぶと**その上に乗る札が全部まとめて動く** (Yukon 系共通のルール)。
ページはそれを `hoveredBlock` のリングで示しているが、**リングは見える人にしか
届かない**。`aria-label` にはカード名とヒントしか入っておらず、
「この札を選ぶと何枚が一緒に動くのか」がスクリーンリーダー利用者には分からなかった。

## 直したこと

`aria-label` に「{{n}}枚まとめて移動」を付ける (ja/en)。

**1 枚のときは付けない。** 「1枚まとめて移動」は情報を足していない。
視覚側の `hoveredBlock` ハイライトは変更なし。

## テスト計画

- [x] ♠K (上に2枚) → 「3枚」、中間の ♥8 → 「2枚」
- [x] **列の末尾 (♣5) には付かない**
- [x] 既存 27 件緑 / `bun run check` / `typecheck` 緑

### 変異テスト (2件とも検出)

| 変異 | 落ちたテスト |
|---|---|
| 末尾の1枚にも付ける | 1 |
| 枚数を1つずらす (自分を数えない) | 1 |