### PR TITLE
fix(whist): update each player's round and cumulative score

### DIFF
--- a/internal/domain/Whist.go
+++ b/internal/domain/Whist.go
@@ -232,6 +232,15 @@ func (w *Whist) ScoreRound() {
 			points = teamTricks[ti] - WhistBookThreshold
 		}
 		w.teamScores[ti] += points
+		// **個人行の得点も更新する。**CUI の "round"/"cum" と Web の CPU 一覧は
+		// この値を読んでいて、teamScores しか動かしていなかったので常に 0 が
+		// 表示されていた (#5535)。同じチームの2人は同じ得点を持つ。
+		for _, p := range w.players {
+			if p.GetTeam() == ti {
+				p.SetRoundScore(points)
+				p.CommitRoundScore()
+			}
+		}
 		w.appendLog(-1, "round_score",
 			fmt.Sprintf("Team %d: %d points (tricks: %d, total: %d)", ti, points, teamTricks[ti], w.teamScores[ti]), nil)
 	}

--- a/internal/domain/Whist_test.go
+++ b/internal/domain/Whist_test.go
@@ -275,6 +275,48 @@ func TestWhist_ScoreRound(t *testing.T) {
 	assert.Equal(t, 2, w.GetTeamScore(0))
 	// Team 1: 5 - 6 = 0 points (below threshold)
 	assert.Equal(t, 0, w.GetTeamScore(1))
+
+	// #5535: 個人行の得点は死んだ 0 のままだった。CUI の "round"/"cum" も
+	// Web の CPU 一覧も、この値を読んでいる。
+	for _, i := range []int{0, 2} {
+		assert.Equal(t, 2, w.GetPlayer(i).GetRoundScore(), "player %d round", i)
+		assert.Equal(t, 2, w.GetPlayer(i).GetCumulativeScore(), "player %d cum", i)
+	}
+	for _, i := range []int{1, 3} {
+		assert.Equal(t, 0, w.GetPlayer(i).GetRoundScore(), "player %d round", i)
+		assert.Equal(t, 0, w.GetPlayer(i).GetCumulativeScore(), "player %d cum", i)
+	}
+}
+
+// **累積はチームスコアと一致し続ける。**1ラウンド分だけ合わせても、
+// 次のラウンドで足し忘れれば表示はまた嘘になる。
+func TestWhist_ScoreRound_CumulativeTracksTheTeamScoreAcrossRounds(t *testing.T) {
+	w := newTestWhist()
+	w.Reset()
+
+	giveTricks := func(playerIdx, n int) {
+		for i := 0; i < n; i++ {
+			w.GetPlayer(playerIdx).AddTrick([]*domain.Card{domain.NewCard(domain.CardDesignHeart, i+1, false)})
+		}
+	}
+
+	for round := 1; round <= 2; round++ {
+		w.SetPhase(domain.WhistPhaseRoundEnd)
+		for i := range 4 {
+			w.GetPlayer(i).ResetRound()
+		}
+		giveTricks(0, 8) // チーム0が8トリック = 2点
+		giveTricks(1, 5)
+		w.ScoreRound()
+
+		for _, i := range []int{0, 2} {
+			assert.Equal(t, w.GetTeamScore(0), w.GetPlayer(i).GetCumulativeScore(), "round %d player %d", round, i)
+		}
+		for _, i := range []int{1, 3} {
+			assert.Equal(t, w.GetTeamScore(1), w.GetPlayer(i).GetCumulativeScore(), "round %d player %d", round, i)
+		}
+	}
+	assert.Equal(t, 4, w.GetPlayer(0).GetCumulativeScore(), "2ラウンド分たまる")
 }
 
 func TestWhist_ScoreRound_GameEnd(t *testing.T) {


### PR DESCRIPTION
Closes #5535

`ScoreRound` はチームの得点をローカル変数で計算して `teamScores` に足すだけで、
`player.SetRoundScore` / `SetCumulativeScore` を**一度も呼んでいなかった**。
`Reset` が入れた 0 のまま動かないので:

- CUI の `whistPlayerStr` の `"round"` / `"cum"` は**常に 0**
- Web の CPU 一覧の `roundScore` / `cumulativeScore` も**常に 0**

正しかったのは画面下のチームスコア表だけで、**個人行の得点は死んだ値**だった。

## 直したこと

ラウンド確定時に、そのチームの各プレイヤーへ `SetRoundScore(points)` +
`CommitRoundScore()`。同じチームの 2 人は同じ得点を持ち、累積は
`GetTeamScore` と一致し続ける。

## テスト計画

- [x] `TestWhist_ScoreRound` — チーム0の2人が round=2 / cum=2、チーム1の2人が 0 / 0
- [x] `TestWhist_ScoreRound_CumulativeTracksTheTeamScoreAcrossRounds` —
      **2ラウンド回して累積がチームスコアと一致し続ける**。1ラウンドだけ合わせても
      次で足し忘れれば表示はまた嘘になる
- [x] `golangci-lint` 0 issues / 既存の Whist テスト緑

### 変異テスト (2件とも検出)

| 変異 | 落ちたアサーション |
|---|---|
| `CommitRoundScore()` を落とす (累積が動かない) | 7 |
| チーム判定を外して全員に加点 | 8 |