### PR TITLE
fix(catchten): announce the honours won this round, not the running total

### DIFF
--- a/frontend/src/pages/CatchTenPage.test.tsx
+++ b/frontend/src/pages/CatchTenPage.test.tsx
@@ -216,3 +216,40 @@ describe('CatchTenPage', () => {
     }
   });
 });
+
+// #5536: 読み上げの「+N」に累積チームスコアをそのまま渡していたので、
+// 「+41 (合計 41)」のように増分と合計が同じ数字になっていた。CPU 一覧は
+// 正しい player.roundScore を出しているので、同じ画面で矛盾していた。
+describe('CatchTenPage round announcement', () => {
+  const announce = () => screen.getByRole('status').textContent ?? '';
+
+  const roundEnd = (round: number[], teamTotals: [number, number]) =>
+    makeState({
+      phase: 2,
+      teamScores: teamTotals,
+      players: makeState().players.map((p, i) => ({ ...p, roundScore: round[i] })),
+    });
+
+  it('announces the honours won this round, not the running total', async () => {
+    // チーム0 が 4+3=7 点、チーム1 が 2+0=2 点。累積は 30 / 11。
+    mockExec.mockResolvedValue(roundEnd([4, 2, 3, 0], [30, 11]));
+    renderWithProviders(<CatchTenPage />);
+    await waitFor(() => expect(announce()).toContain('ラウンド終了'));
+
+    expect(announce()).toContain('+7');
+    expect(announce()).toContain('+2');
+    // 合計は累積のまま。
+    expect(announce()).toContain('30');
+    expect(announce()).toContain('11');
+    // **増分に累積を出さない。**"+30" は今回入った点ではない。
+    expect(announce()).not.toContain('+30');
+  });
+
+  it('reads zero for a team that took no honours', async () => {
+    mockExec.mockResolvedValue(roundEnd([0, 5, 0, 6], [12, 25]));
+    renderWithProviders(<CatchTenPage />);
+    await waitFor(() => expect(announce()).toContain('ラウンド終了'));
+    expect(announce()).toContain('+0');
+    expect(announce()).toContain('+11');
+  });
+});

--- a/frontend/src/pages/CatchTenPage.tsx
+++ b/frontend/src/pages/CatchTenPage.tsx
@@ -194,6 +194,11 @@ function CatchTenPageContent() {
   const isRoundEnd = state.phase === CatchTenPhase.ROUND_END;
   const isGameEnd = state.phase === CatchTenPhase.GAME_END || state.gameEndFlag;
   const isHumanTurn = isPlayPhase && state.players[state.currentPlayerIdx]?.isHuman === true;
+  // **読み上げる「+N」はこのラウンドで入った点。**teamScores は累積で、渡すと
+  // 「+41 (合計 41)」のように増分と合計が同じ数字になる (#5536)。ドメインは
+  // ちょうどこの合計を teamScores に足しているので、両者は必ず整合する。
+  const teamRoundScore = (team: number) =>
+    state.players.reduce((sum, p) => (p.team === team ? sum + p.roundScore : sum), 0);
 
   // The human sits at seat 0, so team 0 is the human team. A draw
   // (CatchTenDrawTeam → winnerTeam < 0) never satisfies this, so the
@@ -427,12 +432,12 @@ function CatchTenPageContent() {
                   entries={[
                     {
                       name: t('team', { n: 0 }),
-                      roundScore: state.teamScores[0],
+                      roundScore: teamRoundScore(0),
                       cumulativeScore: state.teamScores[0],
                     },
                     {
                       name: t('team', { n: 1 }),
-                      roundScore: state.teamScores[1],
+                      roundScore: teamRoundScore(1),
                       cumulativeScore: state.teamScores[1],
                     },
                   ]}


### PR DESCRIPTION
Closes #5536

`RoundScoreAnnouncement` に `roundScore` と `cumulativeScore` の**両方へ
`state.teamScores` を渡していた**。読み上げは「+41（合計 41）」のように
同じ数字を 2 回言い、しかも「+41」はこのラウンドの得点ではなく開幕からの累積。

同じ画面の CPU 一覧 (`renderCpuStats`) は正しい `p.roundScore` を出しているので、
**1 つの画面に 2 つの答えが載っていた**。

## 直したこと

チームに属するプレイヤーの `roundScore` を合計して増分に渡す。
`cumulativeScore` は `teamScores` のまま。

ドメインの `ScoreRound` が `teamScores` に足しているのは**ちょうどこの合計**
(`teamHonor[ti] += p.GetRoundScore()`) なので、読み上げた増分と合計が食い違うことはない。

## テスト計画

- [x] チーム0=4+3、チーム1=2+0、累積 30/11 のラウンド終了で `+7` `+2` が読まれ、
      合計に 30 / 11 が出て、**`+30` は出ない**
- [x] 名誉点 0 のチームは `+0`、相手は `+11`
- [x] 既存 16 件緑 / `bun run check` / `typecheck` 緑

### 変異テスト (2件とも検出)

| 変異 | 落ちたテスト |
|---|---|
| 累積 (`teamScores`) に戻す | 2 |
| チームの絞り込みを外して4人分を合計 | 2 |