### PR TITLE
feat(letitride): print the total at risk instead of making the player multiply

### DIFF
--- a/internal/adapter/presenter/LetItRideCuiPresenter.go
+++ b/internal/adapter/presenter/LetItRideCuiPresenter.go
@@ -30,6 +30,14 @@ func (lp *LetItRideCuiPresenter) Output(lir interfaces.LetItRideGame, lastErr er
 			"amount", strconv.Itoa(lir.GetBetAmount()),
 			"active", strconv.Itoa(lp.activeBetCount(lir)),
 		))
+		// **いま場に出ている総額。**Web は常設で出しているのに、CUI は 1 口の額と
+		// 口数しか出さず、Pull するか決めるたびに暗算が要った (#5537)。
+		// ベット確定前 (BET フェーズ) は出さない。値は GetPullPreview の
+		// RiskBefore と同じ式なので、Pull 確認画面と食い違わない。
+		if lir.GetPhase() != domain.LetItRidePhaseBet {
+			fmt.Fprintf(&sb, "%s\n", i18n.Tf("letitride.totalRiskLine",
+				"risk", strconv.Itoa(lir.GetBetAmount()*lp.activeBetCount(lir))))
+		}
 	}
 
 	playerHand := lir.GetPlayerHand()

--- a/internal/adapter/presenter/LetItRideCuiPresenter_test.go
+++ b/internal/adapter/presenter/LetItRideCuiPresenter_test.go
@@ -2,6 +2,7 @@ package presenter
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -9,6 +10,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupLetItRideCuiMockDefaults(m *interfaces.MockLetItRideGame) {
@@ -212,4 +214,54 @@ func TestLetItRideCuiPresenter_PullConfirmOutput(t *testing.T) {
 	t.Run("reports when pulling is not possible", func(t *testing.T) {
 		assert.Contains(t, p.PullConfirmOutput(withPreview(nil)), "引き下げられません")
 	})
+}
+
+// #5537: Web は「いまリスクにさらされている総額」を常設で出しているのに、
+// CUI は 1 口の額と口数しか出さず、判断のたびに暗算が要った。
+func TestLetItRideCuiPresenter_Output_TotalRisk(t *testing.T) {
+	p := new(LetItRideCuiPresenter)
+
+	build := func(phase int, active [3]bool) *interfaces.MockLetItRideGame {
+		m := new(interfaces.MockLetItRideGame)
+		m.On("GetPhase").Return(phase)
+		m.On("GetBetAmount").Return(100)
+		m.On("GetBet1Active").Return(active[0])
+		m.On("GetBet2Active").Return(active[1])
+		m.On("GetBet3Active").Return(active[2])
+		setupLetItRideCuiMockDefaults(m)
+		return m
+	}
+	riskLine := func(total int) string {
+		return i18n.Tf("letitride.totalRiskLine", "risk", strconv.Itoa(total))
+	}
+
+	// 3口すべて有効 = 300。
+	assert.Contains(t, p.Output(build(domain.LetItRidePhaseFirstDecision, [3]bool{true, true, true}), nil), riskLine(300))
+	// 1口引いた後 = 200。
+	assert.Contains(t, p.Output(build(domain.LetItRidePhaseSecondDecision, [3]bool{false, true, true}), nil), riskLine(200))
+	assert.Contains(t, p.Output(build(domain.LetItRidePhaseEnd, [3]bool{false, false, true}), nil), riskLine(100))
+
+	// **BET フェーズでは出さない。**まだ賭けが確定していない。
+	// i18n.T() で比べると {{risk}} のままの文字列と比べることになり、
+	// 何を出していても通ってしまう。実際に出るはずの行で比べる。
+	betOut := p.Output(build(domain.LetItRidePhaseBet, [3]bool{true, true, true}), nil)
+	assert.NotContains(t, betOut, riskLine(300))
+	assert.NotContains(t, betOut, strings.SplitN(i18n.T("letitride.totalRiskLine"), "{{", 2)[0])
+}
+
+// **Pull 確認画面の RiskBefore と同じ値であること。**二重に計算していると、
+// 同じ局面で違う総額を見せることになる。
+func TestLetItRideCuiPresenter_TotalRiskMatchesThePullPreview(t *testing.T) {
+	p := new(LetItRideCuiPresenter)
+	m := new(interfaces.MockLetItRideGame)
+	m.On("GetPhase").Return(domain.LetItRidePhaseFirstDecision)
+	m.On("GetBetAmount").Return(50)
+	m.On("GetBet1Active").Return(true)
+	m.On("GetBet2Active").Return(true)
+	m.On("GetBet3Active").Return(false)
+	m.On("GetPullPreview").Return(&domain.LetItRidePullPreview{Returned: 50, RiskBefore: 100, RiskAfter: 50})
+	setupLetItRideCuiMockDefaults(m)
+
+	assert.Contains(t, p.Output(m, nil), i18n.Tf("letitride.totalRiskLine", "risk", "100"))
+	assert.Contains(t, p.PullConfirmOutput(m), "100")
 }

--- a/internal/i18n/locales/en/letitride.json
+++ b/internal/i18n/locales/en/letitride.json
@@ -23,5 +23,6 @@
   "pullConfirm": "Pull one bet back. {{amount}} returns to you and the amount at stake goes {{risk}} -> {{newRisk}}. This cannot be undone.",
   "pullConfirmPrompt": "Enter y to go ahead (any other command cancels).",
   "pullUnavailable": "You cannot pull right now.",
-  "helpExampleBet": "  b 100                bet 100 chips"
+  "helpExampleBet": "  b 100                bet 100 chips",
+  "totalRiskLine": "At risk right now: {{risk}}"
 }

--- a/internal/i18n/locales/ja/letitride.json
+++ b/internal/i18n/locales/ja/letitride.json
@@ -23,5 +23,6 @@
   "pullConfirm": "ベットを1口引き下げます。{{amount}} が戻り、場に残る額は {{risk}} → {{newRisk}} になります。この操作は取り消せません。",
   "pullConfirmPrompt": "実行するには y を入力してください (他のコマンドで取り消し)。",
   "pullUnavailable": "いまは引き下げられません。",
-  "helpExampleBet": "  b 100              100 チップを賭ける"
+  "helpExampleBet": "  b 100              100 チップを賭ける",
+  "totalRiskLine": "いまのリスク総額: {{risk}}"
 }


### PR DESCRIPTION
Closes #5537

Web は FIRST/SECOND/END の間ずっと `current-risk` (= `betAmount × activeBetCount`) を
`role="status"` で出しているのに、CUI は `letitride.betLine` の
「1口の額 と 有効な口数」しか出さない。**Pull するかを決めるその瞬間に、
プレイヤーが暗算する**ことになっていた。

## 直したこと

ベット行の直後に合計リスク額の行を追加 (ja/en)。

- **BET フェーズでは出さない** — まだ何もリスクにさらされていない
- 式は `GetPullPreview()` の `RiskBefore` と同じなので、**Pull 確認画面と
  食い違わない** (#4699 で既に同じ値を計算していた)

## テスト計画

- [x] 3口=300 / 2口=200 / 1口=100 が FIRST / SECOND / END で出る
- [x] BET フェーズでは出ない
- [x] **`PullConfirmOutput` の `RiskBefore` と同じ値**であることを同一局面で確認
- [x] `golangci-lint` 0 issues / 既存の LetItRide テスト緑

### 変異テスト (2件とも検出)

| 変異 | 落ちたアサーション |
|---|---|
| BET フェーズでも出す | 2 |
| 口数を掛けずに1口の額を出す | 3 |

**負のコントロールで自分のテストのバグも見つけた**: 最初 BET フェーズの否定を
`i18n.T("letitride.totalRiskLine")` (= `{{risk}}` のままの文字列) と比べていて、
何を出しても通る形だった。変異 M1 が検出されなかったので気付き、
実際に出る行と、`{{` の手前までの固定部分の両方で比べるよう直した。