### PR TITLE
feat(pokersquares): say when there is nothing to undo

### DIFF
--- a/internal/adapter/presenter/PokerSquaresCuiPresenter.go
+++ b/internal/adapter/presenter/PokerSquaresCuiPresenter.go
@@ -56,6 +56,12 @@ func (pr *PokerSquaresCuiPresenter) Output(p interfaces.PokerSquaresGame, lastEr
 			"placed", strconv.Itoa(p.GetPlacedCount()),
 			"total", strconv.Itoa(domain.PokerSquaresTotalCells),
 			"score", strconv.Itoa(p.TotalScore())) + "\n")
+		// Web は Undo ボタンの disabled で押せないことが見えるが、CUI は `u` を
+		// 打ってエラーが返って初めて分かる状態だった (#5538)。戻せるときは
+		// 何も足さない -- 毎手「戻せます」と言われても情報にならない。
+		if !p.CanUndo() {
+			b.WriteString(i18n.T("pokersquares.undoUnavailable") + "\n")
+		}
 
 		if p.GetPhase() != domain.PokerSquaresPhaseComplete {
 			b.WriteString(i18n.T("pokersquares.cuiPlaceHint") + "\n")

--- a/internal/adapter/presenter/PokerSquaresCuiPresenter_test.go
+++ b/internal/adapter/presenter/PokerSquaresCuiPresenter_test.go
@@ -9,11 +9,13 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupPokerSquaresCuiMock() *interfaces.MockPokerSquaresGame {
 	pg := new(interfaces.MockPokerSquaresGame)
 	pg.On("GetPhase").Return(domain.PokerSquaresPhasePlaying).Maybe()
+	pg.On("CanUndo").Return(true).Maybe()
 	pg.On("GetPlacedCount").Return(0).Maybe()
 	pg.On("GetCurrentCard").Return(domain.NewCard(domain.CardDesignSpade, 5, false)).Maybe()
 	var board [domain.PokerSquaresGridSize][domain.PokerSquaresGridSize]*domain.Card
@@ -23,6 +25,7 @@ func setupPokerSquaresCuiMock() *interfaces.MockPokerSquaresGame {
 		pg.On("ColScore", i).Return(0).Maybe()
 	}
 	pg.On("TotalScore").Return(0).Maybe()
+	pg.On("CanUndo").Return(true).Maybe()
 	return pg
 }
 
@@ -39,6 +42,7 @@ func TestPokerSquaresCuiPresenter_Output_Playing(t *testing.T) {
 func TestPokerSquaresCuiPresenter_Output_Complete(t *testing.T) {
 	pg := new(interfaces.MockPokerSquaresGame)
 	pg.On("GetPhase").Return(domain.PokerSquaresPhaseComplete).Maybe()
+	pg.On("CanUndo").Return(true).Maybe()
 	pg.On("GetPlacedCount").Return(25).Maybe()
 	pg.On("GetCurrentCard").Return((*domain.Card)(nil)).Maybe()
 	var board [domain.PokerSquaresGridSize][domain.PokerSquaresGridSize]*domain.Card
@@ -102,6 +106,7 @@ func TestPokerSquaresCuiPresenter_Hint_NoCurrentCard(t *testing.T) {
 func TestPokerSquaresCuiPresenter_ActionLog_Playing(t *testing.T) {
 	pg := new(interfaces.MockPokerSquaresGame)
 	pg.On("GetPhase").Return(domain.PokerSquaresPhasePlaying)
+	pg.On("CanUndo").Return(true).Maybe()
 	p := &PokerSquaresCuiPresenter{}
 	assert.Contains(t, p.ActionLogOutput(pg), "棋譜はありません")
 }
@@ -109,10 +114,38 @@ func TestPokerSquaresCuiPresenter_ActionLog_Playing(t *testing.T) {
 func TestPokerSquaresCuiPresenter_ActionLog_Complete(t *testing.T) {
 	pg := new(interfaces.MockPokerSquaresGame)
 	pg.On("GetPhase").Return(domain.PokerSquaresPhaseComplete)
+	pg.On("CanUndo").Return(true).Maybe()
 	pg.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, ActionType: "place", Detail: "test"},
 	})
 	p := &PokerSquaresCuiPresenter{}
 	out := p.ActionLogOutput(pg)
 	assert.Contains(t, out, "place")
+}
+
+// #5538: Web は Undo ボタンの disabled で押せないことが見えるのに、CUI は
+// `u` を打ってエラーが返って初めて分かる状態だった。
+func TestPokerSquaresCuiPresenter_Output_UndoAvailability(t *testing.T) {
+	p := &PokerSquaresCuiPresenter{}
+
+	outWith := func(canUndo bool) string {
+		pg := new(interfaces.MockPokerSquaresGame)
+		pg.On("CanUndo").Return(canUndo)
+		pg.On("GetPhase").Return(domain.PokerSquaresPhasePlaying).Maybe()
+		pg.On("GetPlacedCount").Return(0).Maybe()
+		pg.On("GetCurrentCard").Return(domain.NewCard(domain.CardDesignSpade, 5, false)).Maybe()
+		var board [domain.PokerSquaresGridSize][domain.PokerSquaresGridSize]*domain.Card
+		pg.On("GetBoard").Return(board).Maybe()
+		for i := 0; i < domain.PokerSquaresGridSize; i++ {
+			pg.On("RowScore", i).Return(0).Maybe()
+			pg.On("ColScore", i).Return(0).Maybe()
+		}
+		pg.On("TotalScore").Return(0).Maybe()
+		return p.Output(pg, nil)
+	}
+
+	// 戻せないときだけ注記を出す。
+	assert.Contains(t, outWith(false), i18n.T("pokersquares.undoUnavailable"))
+	// **戻せるときは何も足さない。**毎手「戻せます」と言われても情報にならない。
+	assert.NotContains(t, outWith(true), i18n.T("pokersquares.undoUnavailable"))
 }

--- a/internal/i18n/locales/en/pokersquares.json
+++ b/internal/i18n/locales/en/pokersquares.json
@@ -11,5 +11,6 @@
   "hintLine": "Hint: place {{card}} at ({{r}},{{c}}) - {{reason}}",
   "hintSynergy": "it pairs, flushes, or extends a straight with cards already in that row/column",
   "hintAny": "no synergy yet; any empty cell keeps your options open",
-  "gameComplete": "Game complete! Total score: {{score}}"
+  "gameComplete": "Game complete! Total score: {{score}}",
+  "undoUnavailable": "(nothing to undo)"
 }

--- a/internal/i18n/locales/ja/pokersquares.json
+++ b/internal/i18n/locales/ja/pokersquares.json
@@ -11,5 +11,6 @@
   "hintLine": "ヒント: {{card}} を ({{r}},{{c}}) に置く - {{reason}}",
   "hintSynergy": "同じ行・列の既存カードとペア/フラッシュ/ストレートを狙えます",
   "hintAny": "まだ相乗効果はありません。空きセルならどこでも大丈夫です",
-  "gameComplete": "ゲーム終了 合計得点: {{score}}"
+  "gameComplete": "ゲーム終了 合計得点: {{score}}",
+  "undoUnavailable": "（戻せる手はありません）"
 }


### PR DESCRIPTION
Closes #5538

`PokerSquaresGame` には `CanUndo()` があり、Web はそれで Undo ボタンを
`disabled` にしているので**押せないことが見て分かる**。CUI は `CanUndo()` を
一度も呼んでおらず、`u` を打ってエラーが返って初めて分かる状態だった。

## 直したこと

配置済み行の直後に、**戻せないときだけ**注記を 1 行出す (ja/en)。
25 手すべてで「戻せます」と言っても行が増えるだけで情報にならない。

## テスト計画

- [x] `CanUndo()==false` で注記が出る
- [x] `CanUndo()==true` では出ない (既存出力から変化しない)
- [x] 既存の PokerSquares CUI テスト緑 / `golangci-lint` 0 issues

### 変異テスト (2件とも検出)

| 変異 | 落ちたアサーション |
|---|---|
| `CanUndo()` を見ずに常に出す | 1 |
| 条件を反転 (戻せるときだけ出す) | 2 |