### PR TITLE
feat(reddog): print the payout table before the CUI takes the ante

### DIFF
--- a/internal/adapter/presenter/RedDogCuiPresenter.go
+++ b/internal/adapter/presenter/RedDogCuiPresenter.go
@@ -78,6 +78,12 @@ func (rp *RedDogCuiPresenter) Output(rd interfaces.RedDogGame, lastErr error) st
 			"ranks", redDogWinningRanksStr(rd.GetInitialCards())) + "\n")
 	}
 
+	// 配当表。Web はベット前に常設しているのに、CUI はベット額を決める材料が
+	// スプレッドの広さだけだった (#5539)。賭け終わった後は出さない。
+	if rd.GetPhase() == domain.RedDogPhaseBet {
+		sb.WriteString(redDogPaytableStr())
+	}
+
 	initial := rd.GetInitialCards()
 	if len(initial) > 0 {
 		sb.WriteString("--- " + color.Bold(i18n.T("reddog.initialHeader")) + " ---\n")
@@ -144,6 +150,29 @@ func (rp *RedDogCuiPresenter) HintOutput(rd interfaces.RedDogGame) string {
 // ActionLogOutput 棋譜をテキスト出力
 func (rp *RedDogCuiPresenter) ActionLogOutput(rd interfaces.RedDogGame) string {
 	return actionLogOutputText(rd)
+}
+
+// redDogPaytableStr renders the payout table shown before the ante is placed.
+//
+// **倍率はドメインの定数から読む。**文言に書き写すと、配当を1つ直したときに
+// 表だけが古いまま残り、プレイヤーは違う倍率を見て賭ける (#5539)。
+func redDogPaytableStr() string {
+	rows := []struct {
+		key  string
+		mult int
+	}{
+		{"reddog.paySpread1", domain.RedDogPaySpread1},
+		{"reddog.paySpread2", domain.RedDogPaySpread2},
+		{"reddog.paySpread3", domain.RedDogPaySpread3},
+		{"reddog.paySpread4Plus", domain.RedDogPaySpread4},
+		{"reddog.payPair", domain.RedDogPayPair},
+	}
+	parts := make([]string, 0, len(rows)+1)
+	for _, r := range rows {
+		parts = append(parts, i18n.Tf(r.key, "mult", strconv.Itoa(r.mult)))
+	}
+	parts = append(parts, i18n.T("reddog.payPush"))
+	return i18n.T("reddog.paytableHeader") + strings.Join(parts, " / ") + "\n"
 }
 
 // phaseStr フェーズ文字列

--- a/internal/adapter/presenter/RedDogCuiPresenter_test.go
+++ b/internal/adapter/presenter/RedDogCuiPresenter_test.go
@@ -2,12 +2,14 @@ package presenter
 
 import (
 	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupRedDogCuiMockDefaults(m *interfaces.MockRedDogGame) {
@@ -236,4 +238,41 @@ func TestRedDogCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetGameEndFlag").Return(false)
 	result := p.ActionLogOutput(m)
 	assert.NotEmpty(t, result)
+}
+
+// #5539: Web はベット前に配当表を常設しているのに、CUI はベット額を決める材料が
+// スプレッドの広さだけだった。
+func TestRedDogCuiPresenter_Output_Paytable(t *testing.T) {
+	p := new(RedDogCuiPresenter)
+
+	outputInPhase := func(phase int) string {
+		m := new(interfaces.MockRedDogGame)
+		m.On("GetPhase").Return(phase)
+		setupRedDogCuiMockDefaults(m)
+		return p.Output(m, nil)
+	}
+
+	betOut := outputInPhase(domain.RedDogPhaseBet)
+	assert.Contains(t, betOut, i18n.T("reddog.paytableHeader"))
+	// **倍率はドメインの定数から出す。**表示用に書き写すと、配当を直したときに
+	// 表だけが古いまま残る。
+	for _, tc := range []struct {
+		key  string
+		mult int
+	}{
+		{"reddog.paySpread1", domain.RedDogPaySpread1},
+		{"reddog.paySpread2", domain.RedDogPaySpread2},
+		{"reddog.paySpread3", domain.RedDogPaySpread3},
+		{"reddog.paySpread4Plus", domain.RedDogPaySpread4},
+		{"reddog.payPair", domain.RedDogPayPair},
+	} {
+		assert.Contains(t, betOut, i18n.Tf(tc.key, "mult", strconv.Itoa(tc.mult)), tc.key)
+	}
+	// プッシュになる2ケースも Web と同じく書く。
+	assert.Contains(t, betOut, i18n.T("reddog.payPush"))
+
+	// **他フェーズでは出さない。**もう賭け終わっている。
+	header := i18n.T("reddog.paytableHeader")
+	assert.NotContains(t, outputInPhase(domain.RedDogPhaseSpreadDecision), header)
+	assert.NotContains(t, outputInPhase(domain.RedDogPhaseEnd), header)
 }

--- a/internal/i18n/locales/en/reddog.json
+++ b/internal/i18n/locales/en/reddog.json
@@ -26,5 +26,12 @@
   "hintSpread": "Spread {{spread}} (winning ranks: {{ranks}}) -> {{rec}}",
   "hintBetFirst": "Place a bet first.",
   "hintGameOver": "The game is over.",
-  "helpExampleBet": "  b 100                bet 100 chips"
+  "helpExampleBet": "  b 100                bet 100 chips",
+  "paytableHeader": "Payouts: ",
+  "paySpread1": "spread 1 {{mult}}:1",
+  "paySpread2": "spread 2 {{mult}}:1",
+  "paySpread3": "spread 3 {{mult}}:1",
+  "paySpread4Plus": "spread 4+ {{mult}}:1",
+  "payPair": "pair + matching third {{mult}}:1",
+  "payPush": "consecutive and pair-no-match push"
 }

--- a/internal/i18n/locales/ja/reddog.json
+++ b/internal/i18n/locales/ja/reddog.json
@@ -26,5 +26,12 @@
   "hintSpread": "スプレッド {{spread}}（勝てるランク: {{ranks}}）→ {{rec}}",
   "hintBetFirst": "まずベットしてください。",
   "hintGameOver": "ゲームは終了しています。",
-  "helpExampleBet": "  b 100              100 チップを賭ける"
+  "helpExampleBet": "  b 100              100 チップを賭ける",
+  "paytableHeader": "配当: ",
+  "paySpread1": "スプレッド1 {{mult}}:1",
+  "paySpread2": "スプレッド2 {{mult}}:1",
+  "paySpread3": "スプレッド3 {{mult}}:1",
+  "paySpread4Plus": "スプレッド4以上 {{mult}}:1",
+  "payPair": "同位ペア＋3枚目同位 {{mult}}:1",
+  "payPush": "連続・ペア＋不一致はプッシュ"
 }


### PR DESCRIPTION
Closes #5539

Web はベットフェーズで配当表 (`payoutRef`) を常設しているのに、CUI はチップ・
フェーズ・アンティしか出さず、**ベット額を決める材料がスプレッドの広さだけ**だった。
`HintOutput` もスプレッドから推奨を出すだけで倍率そのものは見せない。

## 直したこと

ベットフェーズに配当表を 1 ブロック追加 (ja/en)。

**倍率はドメインの定数から読む** (`RedDogPaySpread1` 等)。書き写すと配当を
直したときに表だけが古いまま残る。プッシュになる 2 ケース (連続 / ペア＋不一致) も
Web と同じく明記。

賭け終わった後 (SPREAD_DECISION / END) には出さない。

## テスト計画

- [x] ベットフェーズの出力に 5 行の倍率 + プッシュの説明が出る。
      **各倍率は `domain.*` の定数と突き合わせる** (テストに数字を書かない)
- [x] SPREAD_DECISION / END には出ない
- [x] 既存の RedDog CUI テスト緑 / `golangci-lint` 0 issues / `bun run check` 緑

### 変異テスト (3件とも検出)

| 変異 | 落ちたアサーション |
|---|---|
| 全フェーズで出す | 2 |
| スプレッド1の倍率をベタ書き (4) | 1 |
| プッシュの行を落とす | 1 |