### PR TITLE
feat(deucetoseven): warn about a made low without being asked

### DIFF
--- a/internal/adapter/presenter/DeuceToSevenCuiPresenter.go
+++ b/internal/adapter/presenter/DeuceToSevenCuiPresenter.go
@@ -56,6 +56,13 @@ func (dcp *DeuceToSevenCuiPresenter) Output(g interfaces.DeuceToSevenGame, lastE
 			b.WriteString("\n")
 
 			if pl.GetIsHuman() && !pl.GetFolded() {
+				// 完成ローは自動で警告する。Web は交換フェーズでバナーを出すのに、
+				// CUI は `hint` を打った人にしか伝わらず、既にできているローを
+				// 崩す事故が「訊かなかった人」だけに起きていた (#5541)。
+				if g.GetPhase() == domain.DeuceToSevenPhaseDraw &&
+					g.GetCurrentTurn() == i && len(g.SuggestExchange(i)) == 0 {
+					b.WriteString(color.BoldYellow(i18n.T("deucetoseven.madeLowWarning")) + "\n")
+				}
 				handStr := cuiIndexedCardListStrEmoji(pl)
 				if isEnd {
 					b.WriteString(i18n.Tf("deucetoseven.humanHandWithName",

--- a/internal/adapter/presenter/DeuceToSevenCuiPresenter_test.go
+++ b/internal/adapter/presenter/DeuceToSevenCuiPresenter_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func TestDeuceToSevenCuiPresenter_Output_ContainsGameTitle(t *testing.T) {
@@ -168,4 +169,45 @@ func TestDeuceToSevenCuiPresenter_ActionLogOutput(t *testing.T) {
 	dt, _ := makeDeuceToSevenForPresenter()
 	out := pres.ActionLogOutput(dt)
 	assert.NotEmpty(t, out)
+}
+
+// #5541: Web は交換フェーズで完成ローを自動バナー表示するのに、CUI は
+// `hint` を打った人にしか伝わらなかった。既にできているローを崩す事故は
+// 「訊いた人」だけの問題ではない。
+func TestDeuceToSevenCuiPresenter_Output_MadeLowWarning(t *testing.T) {
+	pres := new(presenter.DeuceToSevenCuiPresenter)
+
+	// 2-4-5-6-8 のレインボー = 完成ロー (ストレートでもフラッシュでもない)。
+	madeLow := []*domain.Card{
+		domain.NewCard(domain.CardDesignSpade, 2, false),
+		domain.NewCard(domain.CardDesignHeart, 4, false),
+		domain.NewCard(domain.CardDesignDiamond, 5, false),
+		domain.NewCard(domain.CardDesignClover, 6, false),
+		domain.NewCard(domain.CardDesignSpade, 8, false),
+	}
+	// K を含むので未完成。
+	notMade := []*domain.Card{
+		domain.NewCard(domain.CardDesignSpade, 2, false),
+		domain.NewCard(domain.CardDesignHeart, 4, false),
+		domain.NewCard(domain.CardDesignDiamond, 5, false),
+		domain.NewCard(domain.CardDesignClover, 6, false),
+		domain.NewCard(domain.CardDesignSpade, 13, false),
+	}
+
+	outputWith := func(hand []*domain.Card, phase int) string {
+		dt, players := makeDeuceToSevenForPresenter()
+		dt.SetPhase(phase)
+		dt.SetCurrentTurn(0)
+		for _, c := range hand {
+			players[0].AddCard(c)
+		}
+		return pres.Output(dt, nil)
+	}
+
+	warn := i18n.T("deucetoseven.madeLowWarning")
+	assert.Contains(t, outputWith(madeLow, domain.DeuceToSevenPhaseDraw), warn)
+	// **未完成なら出さない。**毎ターン出ると警告が意味を失う。
+	assert.NotContains(t, outputWith(notMade, domain.DeuceToSevenPhaseDraw), warn)
+	// 交換できないフェーズでも出さない。
+	assert.NotContains(t, outputWith(madeLow, domain.DeuceToSevenPhaseBet), warn)
 }

--- a/internal/i18n/locales/en/deucetoseven.json
+++ b/internal/i18n/locales/en/deucetoseven.json
@@ -38,5 +38,6 @@
   "hintStandPat": "Suggestion: made low — stand pat (s).",
   "hintNotYourTurn": "It is not your draw phase right now.",
   "helpExampleFold": "  f                    fold this hand",
-  "helpLog": "  l                    show the action log"
+  "helpLog": "  l                    show the action log",
+  "madeLowWarning": "✨ You already have a made 8-or-better low — stand pat (s) rather than break it"
 }

--- a/internal/i18n/locales/ja/deucetoseven.json
+++ b/internal/i18n/locales/ja/deucetoseven.json
@@ -38,5 +38,6 @@
   "hintStandPat": "推奨: 完成ロー。スタンドパット (s) しましょう。",
   "hintNotYourTurn": "今はあなたのドローフェーズではありません。",
   "helpExampleFold": "  f                    この手を降りる",
-  "helpLog": "  l                    行動ログを表示"
+  "helpLog": "  l                    行動ログを表示",
+  "madeLowWarning": "✨ 8以下のローが完成しています。スタンドパット (s) 推奨 — 崩さないこと"
 }


### PR DESCRIPTION
Closes #5541

Web は交換フェーズで `d7-made-low-banner` を自動表示し、**既にできている
8以下のローを崩す**という事故を防いでいる。CUI は同じ判定を `hint` の中に
持っていて、**訊いた人にしか警告が出なかった**。

## 直したこと

交換フェーズ・人間の手番・`SuggestExchange` が空 (= 完成ロー) のとき、
手札行の直前に警告を自動出力する (ja/en)。

条件は `hintStandPat` と**同じ `SuggestExchange` の結果**なので、
自動警告とヒントが食い違うことはない。

## テスト計画

- [x] 2-4-5-6-8 レインボー (完成ロー) で警告が出る
- [x] K を含む未完成の手では出ない
- [x] ベットフェーズでは出ない
- [x] 既存の DeuceToSeven CUI テスト緑 / `golangci-lint` 0 issues

### 変異テスト (2件とも検出)

| 変異 | 落ちたアサーション |
|---|---|
| フェーズ判定を落とす (ベット中も警告) | 1 |
| 完成ロー判定を落とす (毎ターン警告) | 1 |