### PR TITLE
feat(sevencardstud): name the bring-in on third street in the CUI

### DIFF
--- a/internal/adapter/presenter/SevenCardStudCuiPresenter.go
+++ b/internal/adapter/presenter/SevenCardStudCuiPresenter.go
@@ -47,6 +47,14 @@ func (p *SevenCardStudCuiPresenter) Output(s interfaces.SevenCardStudGame, lastE
 		b.WriteString(i18n.Tf("sevencardstud.tableMax", "n", strconv.Itoa(s.GetPlayerCnt())) + "\n")
 		b.WriteString(i18n.Tf("sevencardstud.dealerLine", "idx", strconv.Itoa(s.GetDealerIdx())) + "\n")
 
+		// ブリングイン (強制ベットを払い、3rd street で最初に動く席)。Web は
+		// バッジで示しているのに CUI には手掛かりが無かった (#5542)。Razz は
+		// 「一番強いドアカード」という逆転ルールなので、なおさら知りたい情報。
+		if bi := s.GetBringInPlayerIdx(); bi >= 0 && s.GetPhase() == domain.SevenCardStudPhaseThirdStreet {
+			b.WriteString(i18n.Tf("sevencardstud.bringInLine",
+				"name", cuiPlayerName(s.GetPlayer(bi), bi)) + "\n")
+		}
+
 		b.WriteString(i18n.Tf("sevencardstud.anteLine",
 			"ante", strconv.Itoa(cfg.Ante),
 			"bringIn", strconv.Itoa(cfg.BringIn),

--- a/internal/adapter/presenter/SevenCardStudCuiPresenter_test.go
+++ b/internal/adapter/presenter/SevenCardStudCuiPresenter_test.go
@@ -2,6 +2,8 @@ package presenter_test
 
 import (
 	"errors"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -739,4 +741,35 @@ func TestSevenCardStudCuiPresenter_HintOutput(t *testing.T) {
 		s.SetPhase(domain.SevenCardStudPhaseShowdown)
 		assert.Contains(t, p.HintOutput(s), i18n.T("sevencardstud.hintNone"))
 	})
+}
+
+// #5542: Web は 3rd street でブリングイン (強制ベットを払い最初に動く席) に
+// バッジを出すのに、CUI は誰なのかを知る手段が無かった。Razz は「一番強い
+// ドアカード」という逆転ルールなので、なおさら判断材料になる。
+func TestSevenCardStudCuiPresenter_Output_BringIn(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+	p := new(presenter.SevenCardStudCuiPresenter)
+
+	outputWith := func(phase, bringIn int) string {
+		s, players := makeSevenCardStudForPresenter()
+		s.SetPhase(phase)
+		s.SetBringInPlayerIdx(bringIn)
+		players[0].AddDoorCard(domain.NewCard(domain.CardDesignClover, 5, false))
+		return p.Output(s, nil)
+	}
+
+	line := func(idx int) string {
+		return i18n.Tf("sevencardstud.bringInLine", "name", i18n.Tf("cuiPlayerCpu", "idx", strconv.Itoa(idx)))
+	}
+
+	out := outputWith(domain.SevenCardStudPhaseThirdStreet, 2)
+	assert.Contains(t, out, line(2))
+
+	// **他ストリートでは出さない。**強制ベットは 3rd street だけの話。
+	header := strings.SplitN(i18n.T("sevencardstud.bringInLine"), "{{", 2)[0]
+	assert.NotContains(t, outputWith(domain.SevenCardStudPhaseFourthStreet, 2), header)
+	// 未確定 (-1) のときも出さない。
+	assert.NotContains(t, outputWith(domain.SevenCardStudPhaseThirdStreet, -1), header)
 }

--- a/internal/i18n/locales/en/sevencardstud.json
+++ b/internal/i18n/locales/en/sevencardstud.json
@@ -78,5 +78,6 @@
   "hintReasonHiLoLow": "a qualifying low is live (five cards of eight or lower)",
   "helpExampleFold": "  f                    fold this hand",
   "helpHint": "  h                    show a hint",
-  "helpLog": "  l                    show the action log"
+  "helpLog": "  l                    show the action log",
+  "bringInLine": "Bring-in: {{name}} (forced bet, acts first)"
 }

--- a/internal/i18n/locales/ja/sevencardstud.json
+++ b/internal/i18n/locales/ja/sevencardstud.json
@@ -79,7 +79,7 @@
   "helpExampleFold": "  f                    この手を降りる",
   "helpHint": "  h                    助言を表示",
   "helpLog": "  l                    行動ログを表示",
-  "bringInLine": "ブリングイン: {{name}} (強制ベット、最初に action)",
+  "bringInLine": "ブリングイン: {{name}} (強制ベット、最初に行動)",
   "wonSplit": " (ハイ: {{high}} / ロー: {{low}})",
   "wonScoop": " ★スクープ"
 }

--- a/internal/i18n/locales/ja/sevencardstud.json
+++ b/internal/i18n/locales/ja/sevencardstud.json
@@ -78,5 +78,6 @@
   "hintReasonHiLoLow": "ロー役が狙える (8以下が5枚)",
   "helpExampleFold": "  f                    この手を降りる",
   "helpHint": "  h                    助言を表示",
-  "helpLog": "  l                    行動ログを表示"
+  "helpLog": "  l                    行動ログを表示",
+  "bringInLine": "ブリングイン: {{name}} (強制ベット、最初に action)"
 }


### PR DESCRIPTION
Closes #5542

`GetBringInPlayerIdx()` は Web に渡っていて `RazzPage.tsx` は 3rd street で
バッジを出すのに、**CUI は一度も呼んでいなかった**。誰が強制ベットを払い、
誰が最初に動くのかを知る手段が無い。Razz ではブリングインが
**「一番強いドアカード」**という逆転ルールなので、なおさら判断材料になる。

## 直したこと

3rd street・ブリングイン確定済み (`>= 0`) のときだけ 1 行出す (ja/en)。

`SevenCardStudCuiPresenter` は **Razz / Seven Card Stud / Hi-Lo の 3 ゲームで
共有**していて (`GameManager.go` の 3 箇所が同じプレゼンタを渡す)、
文言も `sevencardstud.*` を共有しているので 3 ゲームとも同時に効く。

## テスト計画

- [x] 3rd street でブリングイン席の名前が出る
- [x] 4th street では出ない
- [x] 未確定 (-1) のときは出ない
- [x] 既存の SevenCardStud CUI テスト緑 / `golangci-lint` 0 issues

### 変異テスト (2件とも検出)

| 変異 | 落ちたアサーション |
|---|---|
| 全ストリートで出す | 1 |
| `-1` を弾かない (未確定でも出す) | 1 |