### PR TITLE
feat(sevencardstudhilo): break the showdown win into high and low

### DIFF
--- a/internal/adapter/presenter/SevenCardStudCuiPresenter.go
+++ b/internal/adapter/presenter/SevenCardStudCuiPresenter.go
@@ -176,6 +176,18 @@ func (p *SevenCardStudCuiPresenter) Output(s interfaces.SevenCardStudGame, lastE
 				}
 				if r.WonAmount > 0 {
 					b.WriteString(i18n.Tf("sevencardstud.wonAmount", "total", strconv.Itoa(r.WonAmount)))
+					// Hi-Lo は合計額だけでは、ハイを取ったのかローを取ったのか、
+					// 両取り (スクープ) なのかが読めない (#5543)。Web の
+					// StudHiLoSplit は 3 通りを別バッジで出している。
+					if s.GetIsHiLo() {
+						high := r.WonAmount - r.WonLow
+						b.WriteString(i18n.Tf("sevencardstud.wonSplit",
+							"high", strconv.Itoa(high),
+							"low", strconv.Itoa(r.WonLow)))
+						if high > 0 && r.WonLow > 0 {
+							b.WriteString(i18n.T("sevencardstud.wonScoop"))
+						}
+					}
 				}
 				b.WriteString("\n")
 			}

--- a/internal/adapter/presenter/SevenCardStudCuiPresenter_test.go
+++ b/internal/adapter/presenter/SevenCardStudCuiPresenter_test.go
@@ -2,6 +2,8 @@ package presenter_test
 
 import (
 	"errors"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -738,5 +740,64 @@ func TestSevenCardStudCuiPresenter_HintOutput(t *testing.T) {
 			card(domain.CardDesignClover, 5))
 		s.SetPhase(domain.SevenCardStudPhaseShowdown)
 		assert.Contains(t, p.HintOutput(s), i18n.T("sevencardstud.hintNone"))
+	})
+}
+
+// #5543: Hi-Lo の結果は合計額しか出ておらず、ハイを取ったのかローを取ったのか、
+// スクープしたのかが CUI からは読み取れなかった。Web は StudHiLoSplit が
+// 3 通りを別バッジで出している。
+func TestSevenCardStudCuiPresenter_Output_HiLoSplit(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+	p := new(presenter.SevenCardStudCuiPresenter)
+
+	outputWith := func(hiLo bool, r domain.SevenCardStudResult) string {
+		var s *domain.SevenCardStud
+		if hiLo {
+			cfg := domain.DefaultSevenCardStudConfig()
+			s = domain.NewSevenCardStudHiLo(domain.NewTrumpCards(0),
+				domain.NewSevenCardStudPlayersForTable(cfg.TableSize), cfg)
+		} else {
+			s, _ = makeSevenCardStudForPresenter()
+		}
+		s.SetPhase(domain.SevenCardStudPhaseEnd)
+		s.SetRoundResults([]domain.SevenCardStudResult{r})
+		return p.Output(s, nil)
+	}
+
+	base := domain.SevenCardStudResult{PlayerIdx: 0, HandRank: domain.PokerHandFlush, HandName: "Flush"}
+
+	t.Run("splits the pot into the high and low shares", func(t *testing.T) {
+		r := base
+		r.WonAmount, r.WonLow = 100, 40
+		out := outputWith(true, r)
+		assert.Contains(t, out, i18n.Tf("sevencardstud.wonSplit",
+			"high", strconv.Itoa(60), "low", strconv.Itoa(40)))
+	})
+
+	t.Run("says scoop when the same player took both", func(t *testing.T) {
+		r := base
+		r.WonAmount, r.WonLow = 100, 40
+		assert.Contains(t, outputWith(true, r), i18n.T("sevencardstud.wonScoop"))
+	})
+
+	// ローだけ取ったときはスクープではない。
+	t.Run("is not a scoop when only the low was won", func(t *testing.T) {
+		r := base
+		r.WonAmount, r.WonLow = 40, 40
+		out := outputWith(true, r)
+		assert.NotContains(t, out, i18n.T("sevencardstud.wonScoop"))
+		assert.Contains(t, out, i18n.Tf("sevencardstud.wonSplit",
+			"high", strconv.Itoa(0), "low", strconv.Itoa(40)))
+	})
+
+	// **Hi-Lo でないゲームでは何も変わらない。**
+	t.Run("leaves plain seven card stud alone", func(t *testing.T) {
+		r := base
+		r.WonAmount = 100
+		out := outputWith(false, r)
+		assert.Contains(t, out, i18n.Tf("sevencardstud.wonAmount", "total", "100"))
+		assert.NotContains(t, out, strings.SplitN(i18n.T("sevencardstud.wonSplit"), "{{", 2)[0])
 	})
 }

--- a/internal/i18n/locales/en/sevencardstud.json
+++ b/internal/i18n/locales/en/sevencardstud.json
@@ -78,5 +78,7 @@
   "hintReasonHiLoLow": "a qualifying low is live (five cards of eight or lower)",
   "helpExampleFold": "  f                    fold this hand",
   "helpHint": "  h                    show a hint",
-  "helpLog": "  l                    show the action log"
+  "helpLog": "  l                    show the action log",
+  "wonSplit": " (high: {{high}} / low: {{low}})",
+  "wonScoop": " *scoop*"
 }

--- a/internal/i18n/locales/ja/sevencardstud.json
+++ b/internal/i18n/locales/ja/sevencardstud.json
@@ -78,5 +78,7 @@
   "hintReasonHiLoLow": "ロー役が狙える (8以下が5枚)",
   "helpExampleFold": "  f                    この手を降りる",
   "helpHint": "  h                    助言を表示",
-  "helpLog": "  l                    行動ログを表示"
+  "helpLog": "  l                    行動ログを表示",
+  "wonSplit": " (ハイ: {{high}} / ロー: {{low}})",
+  "wonScoop": " ★スクープ"
 }


### PR DESCRIPTION
Closes #5543

`SevenCardStudResult` は `WonLow` を持ち (`WonAmount` はハイ+ローの合計)、
Web の `StudHiLoSplit` は「ハイ勝者 / ロー勝者 / スクープ」を別バッジで出している。
CUI の結果ループは **`WonAmount` しか読んでおらず**、Hi-Lo プレイヤーは
自分がどちらを取ったのか、両取りしたのかが分からなかった。

## 直したこと

`GetIsHiLo()` が true のときだけ、獲得額の後ろに内訳を出す (ja/en):

- `(ハイ: N / ロー: M)`
- 両方が 0 より大きいときだけ `★スクープ`

**ローだけ取ったときはスクープではない** (`high > 0 && low > 0` を要求)。
通常の Seven Card Stud では出力は一切変わらない。

## テスト計画

- [x] ハイ 60 / ロー 40 の内訳が出る
- [x] 両取りで「スクープ」が出る
- [x] **ロー単独 (ハイ 0) ではスクープと言わない**
- [x] **Hi-Lo でないゲームでは内訳が出ない**
- [x] 既存の SevenCardStud CUI テスト緑 / `golangci-lint` 0 issues

### 変異テスト (3件とも検出)

| 変異 | 落ちたアサーション |
|---|---|
| 通常のスタッドでも内訳を出す | 1 |
| ロー獲得だけでスクープと言う | 1 |
| ハイの取り分からローを引かない | 3 |