### PR TITLE
feat(accordion): let the CLI mode run the merges too

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -12698,7 +12698,7 @@ paths:
               properties:
                 command:
                   type: string
-                  enum: [reset, r, move, m, giveup, g, hint, h, undo, u, undo_n, log, l]
+                  enum: [reset, r, move, m, giveup, g, hint, h, undo, u, undo_n, autocomplete, ac, log, l]
                 sessionId:
                   type: string
                 from:

--- a/frontend/src/api/games/accordion.ts
+++ b/frontend/src/api/games/accordion.ts
@@ -14,5 +14,5 @@ export interface AccordionMoveZone {
 export const accordionApi = createSolitaireMoveApi<
   AccordionResponse,
   AccordionMoveZone,
-  'reset' | 'move' | 'giveup' | 'hint' | 'log' | 'undo' | 'undo_n'
+  'reset' | 'move' | 'giveup' | 'hint' | 'log' | 'undo' | 'undo_n' | 'autocomplete'
 >('accordion');

--- a/frontend/src/pages/AccordionPage.test.tsx
+++ b/frontend/src/pages/AccordionPage.test.tsx
@@ -477,6 +477,19 @@ describe('AccordionPage', () => {
     );
   });
 
+  // #5546: 独立 CUI には ac があり、グラフィカル側にはボタンがあるのに、
+  // 同じページの CLI モードからだけ一括マージを呼べなかった。
+  it.each(['ac', 'autocomplete'])('CLI mode dispatches %s as autocomplete', async (cmd) => {
+    renderWithProviders(<AccordionPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    fireEvent.click(screen.getByRole('button', { name: /CLI|GUI/i }));
+    const input = await screen.findByLabelText(/コマンドを入力/);
+    mockExec.mockClear();
+    fireEvent.change(input, { target: { value: cmd } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('autocomplete'));
+  });
+
   it('CLI mode rejects malformed move command', async () => {
     renderWithProviders(<AccordionPage />);
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));

--- a/frontend/src/pages/AccordionPage.tsx
+++ b/frontend/src/pages/AccordionPage.tsx
@@ -84,6 +84,11 @@ function parseAccordionCommand(input: string): CliParseResult<ApiArgs> {
     case 'l':
     case 'log':
       return { args: ['log'] };
+    // 独立 CUI と同じ一括マージ。グラフィカル側にはボタンがあるのに、同じページの
+    // CLI モードからだけ呼べなかった (#5546)。
+    case 'ac':
+    case 'autocomplete':
+      return { args: ['autocomplete'] };
     case 'm':
     case 'move': {
       if (parts.length !== 3) return { error: 'Usage: m <fromIdx> <toIdx>' };
@@ -174,6 +179,7 @@ function AccordionPageContent() {
         'g              Give up',
         'h              Hint',
         'u              Undo',
+        'ac             Merge automatically until no legal merge is left',
         'l              Action log',
         'r              Reset',
       ],

--- a/internal/adapter/controller/AccordionWebController.go
+++ b/internal/adapter/controller/AccordionWebController.go
@@ -68,6 +68,10 @@ func accordionDispatch(bc *baseController, w http.ResponseWriter, ai usecase.Acc
 		bc.writePresenterResponse(w, ai.GiveUp())
 	case "u", "undo":
 		bc.writePresenterResponse(w, ai.Undo())
+	case "ac", "autocomplete":
+		// 独立 CUI には最初からある一括マージ。Web 側はページが自前でループを
+		// 回していて、同じページの CLI モードからは呼べなかった (#5546)。
+		bc.writePresenterResponse(w, ai.AutoComplete())
 	case "undo_n":
 		if !requireParam(bc, w, newDefault, param.N == nil, "param error: n is required.") {
 			return true

--- a/internal/adapter/controller/AccordionWebController_test.go
+++ b/internal/adapter/controller/AccordionWebController_test.go
@@ -37,6 +37,7 @@ func TestAccordionWebController_Method(t *testing.T) {
 	aiMock.On("Move", 3, 0).Return(mockOutput)
 	aiMock.On("Undo").Return(mockOutput)
 	aiMock.On("UndoN", 3).Return(mockOutput)
+	aiMock.On("AutoComplete").Return(mockOutput)
 
 	factory := func() uc.AccordionInteractorIF { return aiMock }
 	ctrl := controller.NewAccordionWebController(factory)
@@ -133,4 +134,26 @@ func TestAccordionWebController_Method(t *testing.T) {
 		recorded := execRequest(t, ctrl.Exec, &input)
 		recorded.CodeIs(http.StatusBadRequest)
 	})
+}
+
+// #5546: 独立 CUI には ac があり、Web GUI にもボタンがあるのに、Web の
+// コマンド体系にだけ autocomplete が無く、CLI モードから呼べなかった。
+func TestAccordionWebController_AutoComplete(t *testing.T) {
+	mockOutput := `{"piles":[],"pileCount":0,"phase":0,"moveCount":0,"canUndo":false,"isStalemate":false,"undoToEscape":0,"message":""}`
+
+	for _, cmd := range []string{"ac", "autocomplete"} {
+		t.Run(cmd, func(t *testing.T) {
+			aiMock := new(usecase.MockAccordionInteractor)
+			aiMock.On("AutoComplete").Return(mockOutput)
+			ctrl := controller.NewAccordionWebController(func() uc.AccordionInteractorIF { return aiMock })
+			defer ctrl.Stop()
+
+			var input controller.AccordionWebInput
+			_ = json.Unmarshal([]byte(`{"command":"`+cmd+`","sessionId":"s-ac-`+cmd+`"}`), &input)
+			recorded := execRequest(t, ctrl.Exec, &input)
+			recorded.CodeIs(http.StatusOK)
+			recorded.BodyIs(mockOutput)
+			aiMock.AssertCalled(t, "AutoComplete")
+		})
+	}
 }


### PR DESCRIPTION
Closes #5546

独立 CUI には `ac` / `autocomplete` があり、Web GUI には自動完成ボタンがあるのに、
**同じページに埋め込まれた CLI モードにだけ無かった**。`m <from> <to>` を
1 手ずつ打つしかない、いちばん打鍵が要る場所で欠けていた。

## 直したこと

`parseAccordionCommand` に `ac` / `autocomplete` を追加し、ヘルプにも 1 行足した。

**ここで気付いた点**: issue の提案どおり `accordionApi.exec('autocomplete')` を
呼ぼうとしたが、**Web エンドポイントには autocomplete コマンドが無かった**
(ページが自前でクライアント側ループを回している)。そこで
`AccordionWebController` に `ac` / `autocomplete` を追加し、独立 CUI と同じ
`AccordionInteractorIF.AutoComplete()` を通すようにした。既存のボタンの
クライアント側ループは変更していない。

`api/openapi.yaml` のコマンド enum にも追加 (CRLF 維持: numstat 1/1)。

## テスト計画

- [x] Web コントローラが `ac` / `autocomplete` の両方で `AutoComplete()` を呼ぶ
- [x] CLI モードで `ac` / `autocomplete` を打つと `exec('autocomplete')` が飛ぶ
- [x] 既存の `m` / 不正な `m` / その他のコマンドは変化なし (47件緑)
- [x] `golangci-lint` 0 issues / `bun run check` / `typecheck` 緑

### 変異テスト (2件とも検出)

| 変異 | 落ちたアサーション |
|---|---|
| コントローラの分岐を落とす | 2 |
| CLI が `ac` を reset として解釈 | 2 |