### PR TITLE
feat(president): show who played what on the web page

### DIFF
--- a/frontend/src/i18n/locales/en/president.json
+++ b/frontend/src/i18n/locales/en/president.json
@@ -37,5 +37,10 @@
   "exchange": {
     "title": "[Card Exchange]",
     "entry": "{{from}} → {{to}}: {{cards}}"
+  },
+  "actionPlayed": "{{name}} played: {{cards}}",
+  "actionPassed": "{{name}} passed",
+  "label": {
+    "actionLog": "Action history"
   }
 }

--- a/frontend/src/i18n/locales/ja/president.json
+++ b/frontend/src/i18n/locales/ja/president.json
@@ -37,5 +37,10 @@
   "exchange": {
     "title": "[カード交換]",
     "entry": "{{from}} → {{to}}: {{cards}}"
+  },
+  "actionPlayed": "{{name}}が出しました: {{cards}}",
+  "actionPassed": "{{name}}がパスしました",
+  "label": {
+    "actionLog": "行動履歴"
   }
 }

--- a/frontend/src/pages/PresidentPage.test.tsx
+++ b/frontend/src/pages/PresidentPage.test.tsx
@@ -368,3 +368,46 @@ describe('PresidentPage', () => {
     expect(screen.queryByTestId('exchange-log')).not.toBeInTheDocument();
   });
 });
+
+// #5548: CUI は毎ターン「誰が何を出したか / パスしたか」を出しているのに、
+// Web は場札しか見えず、CPU3人のうち誰が場をこの形にしたのか追えなかった。
+describe('PresidentPage action history', () => {
+  const log = () => screen.getByTestId('pr-action-log');
+
+  it('lists each CPU play and pass', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        cpuActions: [
+          { playerIdx: 1, playedCards: [card('SPADE', 5)] },
+          { playerIdx: 2, playedCards: null },
+        ],
+      }),
+    );
+    renderWithProviders(<PresidentPage />);
+    // CPU の手は 1 手ずつリプレイされるので、全部出そろうまで待つ。
+    await waitFor(() => expect(log()).toHaveTextContent('CPU 2'));
+    expect(log()).toHaveTextContent('CPU 1');
+    // パスは「出した」と書き分ける。
+    expect(log()).toHaveTextContent('パス');
+  });
+
+  it('includes the human action in the same list', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        humanAction: { playerIdx: 0, playedCards: [card('SPADE', 3)] },
+        cpuActions: [{ playerIdx: 1, playedCards: null }],
+      }),
+    );
+    renderWithProviders(<PresidentPage />);
+    await waitFor(() => expect(log()).toHaveTextContent('CPU 1'));
+    expect(log()).toHaveTextContent('あなた');
+  });
+
+  // **何も起きていないうちは出さない。**空の枠は場所を取るだけ。
+  it('renders nothing before anyone has acted', async () => {
+    mockExec.mockResolvedValue(makeState({ cpuActions: [], humanAction: null }));
+    renderWithProviders(<PresidentPage />);
+    await waitFor(() => expect(screen.getByTestId('hand-card-0')).toBeInTheDocument());
+    expect(screen.queryByTestId('pr-action-log')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/PresidentPage.tsx
+++ b/frontend/src/pages/PresidentPage.tsx
@@ -21,9 +21,10 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePresidentGame } from '../hooks/usePresidentGame';
 import { gameTheme } from '../styles/gameTheme';
-import type { PresidentResponse } from '../types/card';
+import type { PresidentAction, PresidentResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
+import { cardLabel } from '../utils/cardUtils';
 import {
   formatPresidentState,
   PRESIDENT_HELP,
@@ -183,6 +184,16 @@ function PresidentPageContent() {
   const humanWon = isGameEnd && state.players[0]?.rank === 1;
   const isHumanTurn = state.currentTurn === 0 && !isGameEnd;
   const human = state.players[0];
+  // 自分の手と CPU の手を 1 本の時系列にする。CUI と同じ書き分け
+  // (出した / パスした) を使う。
+  const describeAction = (action: PresidentAction): string => {
+    const name = action.playerIdx === 0 ? tc('player.you') : tc('player.cpu', { id: action.playerIdx });
+    if (!action.playedCards || action.playedCards.length === 0) return t('actionPassed', { name });
+    return t('actionPlayed', { name, cards: action.playedCards.map(cardLabel).join(', ') });
+  };
+  const actionHistory = [...(state.humanAction ? [state.humanAction] : []), ...(state.cpuActions ?? [])].map(
+    describeAction,
+  );
   const canPlay = isHumanTurn && selectedIndices.length > 0;
   const phaseName = isGameEnd ? t('phase.end') : t('phase.play');
 
@@ -289,6 +300,21 @@ function PresidentPageContent() {
                 )}
               </div>
             </div>
+
+            {/* Action history: CUI は毎ターン「誰が何を出したか / パスしたか」を
+                出しているのに、Web は場札しか見えず、CPU 3 人のうち誰が場をこの形に
+                したのか追えなかった (#5548)。 */}
+            {actionHistory.length > 0 && (
+              <div
+                role="log"
+                aria-live="polite"
+                aria-label={t('label.actionLog')}
+                className="bg-black/40 rounded-lg text-ds-text-primary py-2 px-3.5 my-2 whitespace-pre-line text-xs"
+                data-testid="pr-action-log"
+              >
+                {actionHistory.join('\n')}
+              </div>
+            )}
 
             {/* Human hand */}
             <div className="text-center" data-tutorial="pr-player-hand">


### PR DESCRIPTION
Closes #5548

`PresidentResponse` は `cpuActions` と `humanAction` を持ち、プレゼンタも
きちんと埋めている。CUI はそれを毎ターン「誰が何を出したか / パスしたか」として
出しているのに、**ページはどちらも一度も参照していなかった**。CPU が 3 人いるので、
自分の番が回ってくるまでに場がどう変わったのかを Web からは追えない。

## 直したこと

場札の下に行動履歴を出す (`role="log"` / `aria-live="polite"`)。

- **自分の手も同じ 1 本の時系列に含める**
- 書き分けは CUI と同じ (`出しました` / `パスしました`)
- **誰も動いていないうちは出さない** — 空の枠は場所を取るだけ

## 実装で分かったこと

`usePresidentGame` は CPU の手を**1 手ずつリプレイ**するので、描画直後の
`state.cpuActions` は途中経過 (1件) になる。テストは全部出そろうまで
`waitFor` で待つ形にした。

## テスト計画

- [x] CPU のプレイとパスが両方並ぶ
- [x] human の手が同じ一覧に入る
- [x] 誰も動いていなければ表示自体が無い
- [x] 既存 26 件緑 / `bun run check` / `typecheck` 緑

### 変異テスト (2件とも検出)

| 変異 | 落ちたテスト |
|---|---|
| human の手を一覧から外す | 1 |
| パスを「出した」として描く | 2 |