### PR TITLE
docs(spanish21): state the player-blackjack rule in the CUI payout table

### DIFF
--- a/internal/adapter/presenter/BlackJackCuiPresenter_test.go
+++ b/internal/adapter/presenter/BlackJackCuiPresenter_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // setupBJCuiTest creates a BlackJack game with the given chip values, calls Reset, and returns the game + dealer.
@@ -1040,6 +1042,25 @@ func TestBlackJackCuiPresenter_PayoutTable(t *testing.T) {
 		assert.Contains(t, out, "5枚で21 (3:2)")
 		assert.Contains(t, out, "7-7-7")
 		assert.Contains(t, out, "プレイヤー21は常に勝利")
+		// #5550: 両者ナチュラルBJでもプレイヤーが勝つ。Web の配当表は書いているのに
+		// CUI 側の文言にだけ抜けていた。
+		assert.Contains(t, out, i18n.T("spanish21.payoutRef.blackjack"))
+		assert.Contains(t, i18n.T("spanish21.payoutRef.blackjack"), "両者BJ")
+	})
+
+	// **文言と実装が一致していること。**配当表がルールを謳っていても、
+	// バリアントのフラグが false なら嘘の説明になる。
+	t.Run("the blackjack line matches the variant flag", func(t *testing.T) {
+		bj := domain.NewSpanish21BlackJack()
+		bj.Reset()
+		v := bj.GetVariant()
+		require.NotNil(t, v)
+		assert.True(t, v.PlayerBJBeatsDealerBJ, "spanish21 は両者BJでプレイヤー勝ち")
+
+		// 標準ブラックジャックは謳っていないこと (負のコントロール)。
+		std, _ := setupBJCuiTest(1000, 1000)
+		std.Reset()
+		assert.NotContains(t, bjp.Output(std, nil), "両者BJ")
 	})
 
 	t.Run("not listed once the hand is dealt", func(t *testing.T) {

--- a/internal/i18n/locales/en/spanish21.json
+++ b/internal/i18n/locales/en/spanish21.json
@@ -10,7 +10,7 @@
   "bonus.777.samesuit": "7-7-7 (same suit)",
   "bonus.777.spade": "7-7-7 (all spades)",
   "payoutRef.title": "Payouts",
-  "payoutRef.blackjack": "Blackjack (3:2)",
+  "payoutRef.blackjack": "Blackjack (3:2, player BJ beats dealer BJ)",
   "payoutRef.win": "Win (1:1); player 21 always wins",
   "payoutRef.insurance": "Insurance (2:1)",
   "payoutRef.push": "Push (tie: bet returned)",

--- a/internal/i18n/locales/ja/spanish21.json
+++ b/internal/i18n/locales/ja/spanish21.json
@@ -10,7 +10,7 @@
   "bonus.777.samesuit": "7-7-7 (同一スート)",
   "bonus.777.spade": "7-7-7 (全スペード)",
   "payoutRef.title": "配当表",
-  "payoutRef.blackjack": "ブラックジャック (3:2)",
+  "payoutRef.blackjack": "ブラックジャック (3:2、両者BJでもプレイヤー勝ち)",
   "payoutRef.win": "通常勝利 (1:1)、プレイヤー21は常に勝利",
   "payoutRef.insurance": "インシュランス (2:1)",
   "payoutRef.push": "プッシュ (引き分け: 返金)",


### PR DESCRIPTION
Closes #5550

`Spanish21Variant()` は `PlayerBJBeatsDealerBJ: true` を立てていて、Web の
配当表も「両者BJでもプレイヤー勝ち」と書いている。**バックエンド側のカタログだけ**
`ブラックジャック (3:2)` で止まっていて、CUI プレイヤーは
**ディーラーが BJ でも自分の BJ が勝つ**ことを配当表から知れなかった。

## 直したこと

`internal/i18n/locales/{ja,en}/spanish21.json` の `payoutRef.blackjack` を
Web と同じ内容に揃えた (numstat 1/1 ずつ)。

## テスト計画

- [x] Spanish 21 の CUI 配当表に「両者BJ」が出る
- [x] **文言とバリアントのフラグが一致していること** (`PlayerBJBeatsDealerBJ == true`)。
      謳っているのにフラグが false なら嘘の説明になる
- [x] **標準ブラックジャックでは謳わない** (負のコントロール)
- [x] 既存の BlackJack CUI テスト緑

### 変異テスト (2件とも検出)

| 変異 | 落ちたアサーション |
|---|---|
| 文言を元の簡潔版に戻す | 1 |
| バリアントが規則を与えなくなる (文言が嘘になる) | 1 |