### PR TITLE
fix(wasp): require an empty stock before offering auto-complete

### DIFF
--- a/frontend/src/pages/WaspPage.test.tsx
+++ b/frontend/src/pages/WaspPage.test.tsx
@@ -249,6 +249,7 @@ describe('WaspPage', () => {
     // AutoComplete が同じ条件で弾くため)。
     mockExec.mockResolvedValue({
       ...playingState,
+      stockCount: 0,
       tableau: playingState.tableau.map((col) => col.map((c) => ({ ...c, faceUp: true }))),
     });
     renderWithProviders(<WaspPage />);
@@ -741,9 +742,25 @@ describe('WaspPage autocomplete readiness', () => {
     expect(button().className).not.toContain('animate-pulse');
   });
 
+  // レビュー指摘 (#5545): ドメインの AllFaceUp は**ストックが空であること**も
+  // 要求する。表向きだけ見ると、山札が残った状態でボタンが押せてしまい、
+  // 押すと "not all cards are face up" で弾かれる — 直したはずのバグに戻る。
+  it('stays disabled while the stock still has cards, even with a fully face-up tableau', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      stockCount: 3,
+      tableau: playingState.tableau.map((col) => col.map((c) => ({ ...c, faceUp: true }))),
+    });
+    renderWithProviders(<WaspPage />);
+    await waitFor(() => expect(button()).toBeInTheDocument());
+    expect(button()).toBeDisabled();
+    expect(button().className).not.toContain('animate-pulse');
+  });
+
   it('pulses once every card is face up', async () => {
     const allUp = {
       ...playingState,
+      stockCount: 0,
       tableau: playingState.tableau.map((col) => col.map((c) => ({ ...c, faceUp: true }))),
     };
     mockExec.mockResolvedValue(allUp);

--- a/frontend/src/pages/WaspPage.tsx
+++ b/frontend/src/pages/WaspPage.tsx
@@ -291,8 +291,10 @@ function WaspPageContent() {
     [preview.source, state],
   );
   const dealBlockedByEmpty = hasEmptyColumn && (state?.stockCount ?? 0) > 0;
-  // ドメインの AutoComplete は「全カードが表向き」でしか通らない (Scorpion と共有の規則)。
-  const autoCompleteReady = isTableauAllFaceUp(state?.tableau ?? []);
+  // ドメインの AllFaceUp は**ストックが空であること**も要求する (Wasp.go)。
+  // 表向きだけで判定すると、山札が残った盤面でボタンが押せてしまい、押すと
+  // "not all cards are face up" で弾かれる — #5545 が直したはずの形に戻る。
+  const autoCompleteReady = (state?.stockCount ?? 0) === 0 && isTableauAllFaceUp(state?.tableau ?? []);
   const handleDealGuarded = useCallback(() => {
     if (dealBlockedByEmpty) {
       setEmptyDealAttemptKey((k) => k + 1);


### PR DESCRIPTION
#5905 のレビュー指摘への追従。**指摘を読む前にマージしてしまった**ので別PRで直す。

`Wasp.AllFaceUp()` は**ストックが空であること**も要求する:

```go
func (s *Wasp) AllFaceUp() bool {
	if len(s.stock) > 0 {
		return false
	}
	...
}
```

`autoCompleteReady` を表向き判定だけにしていたので、**山札が 3 枚残ったまま
タブローが全部表向き**になる盤面 (初期配置の裏カードを上から捌けば到達する) で
ボタンがパルスして押せてしまい、押すと `not all cards are face up` で弾かれる。
**#5545 が消したはずの「押すと拒否される」形が別の局面で復活していた。**

## 直したこと

`(state?.stockCount ?? 0) === 0 && isTableauAllFaceUp(...)` — Spiderette と同じ形。

## テスト計画

- [x] **全部表向きでも山札が残っていれば disabled、パルスしない** (指摘の局面)
- [x] 既存の「表向きでパルス」テストは `stockCount: 0` を明示するよう更新
- [x] 既存 57 件緑 / `bun run check` / `typecheck` 緑

### 変異テスト

| 変異 | 落ちたテスト |
|---|---|
| ストック条件を落とす (元の実装に戻す) | 1 |