### PR TITLE
feat(calculation): print the next six ranks per foundation in the CUI

### DIFF
--- a/internal/adapter/presenter/CalculationCuiPresenter.go
+++ b/internal/adapter/presenter/CalculationCuiPresenter.go
@@ -43,6 +43,16 @@ func (p *CalculationCuiPresenter) Output(g interfaces.CalculationGame, lastErr e
 				b.WriteString(i18n.Tf("calculation.nextRank",
 					"rank", strconv.Itoa(next)))
 			}
+			// 1手先だけでは +3 の列で「次の次のまた次」を辿れない。Web は6手先まで
+			// バッジで出している (#5551)。空の組札には出さない。
+			if upcoming := g.GetUpcomingFoundationRanks(i, domain.CalculationMaxLookAhead); len(upcoming) > 0 {
+				parts := make([]string, len(upcoming))
+				for j, r := range upcoming {
+					parts[j] = strconv.Itoa(r)
+				}
+				b.WriteString(i18n.Tf("calculation.upcomingRanks",
+					"ranks", strings.Join(parts, " → ")))
+			}
 			b.WriteString("\n")
 		}
 		b.WriteString("----------\n")

--- a/internal/adapter/presenter/CalculationCuiPresenter_test.go
+++ b/internal/adapter/presenter/CalculationCuiPresenter_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupCalculationCuiMockDefaults(g *interfaces.MockCalculationGame) {
@@ -27,6 +28,8 @@ func setupCalculationCuiMockDefaults(g *interfaces.MockCalculationGame) {
 	}
 	g.On("GetFoundations").Return(foundations).Maybe()
 	g.On("GetNextFoundationRank", mock.Anything).Return(0).Maybe()
+	g.On("GetUpcomingFoundationRanks", mock.Anything, mock.Anything).Return([]int(nil)).Maybe()
+	g.On("GetUpcomingFoundationRanks", mock.Anything, mock.Anything).Return([]int(nil)).Maybe()
 
 	var wastes [domain.CalculationWasteCnt][]*domain.Card
 	wastes[0] = []*domain.Card{domain.NewCard(domain.CardDesignHeart, 11, false)}
@@ -65,6 +68,7 @@ func TestCalculationCuiPresenter_Output(t *testing.T) {
 		var foundations [domain.CalculationFoundationCnt][]*domain.Card
 		g.On("GetFoundations").Return(foundations).Maybe()
 		g.On("GetNextFoundationRank", mock.Anything).Return(0).Maybe()
+		g.On("GetUpcomingFoundationRanks", mock.Anything, mock.Anything).Return([]int(nil)).Maybe()
 		var wastes [domain.CalculationWasteCnt][]*domain.Card
 		g.On("GetWastes").Return(wastes).Maybe()
 
@@ -82,6 +86,7 @@ func TestCalculationCuiPresenter_Output(t *testing.T) {
 		var foundations [domain.CalculationFoundationCnt][]*domain.Card
 		g.On("GetFoundations").Return(foundations).Maybe()
 		g.On("GetNextFoundationRank", mock.Anything).Return(0).Maybe()
+		g.On("GetUpcomingFoundationRanks", mock.Anything, mock.Anything).Return([]int(nil)).Maybe()
 		var wastes [domain.CalculationWasteCnt][]*domain.Card
 		g.On("GetWastes").Return(wastes).Maybe()
 
@@ -99,6 +104,7 @@ func TestCalculationCuiPresenter_Output(t *testing.T) {
 		var foundations [domain.CalculationFoundationCnt][]*domain.Card
 		g.On("GetFoundations").Return(foundations).Maybe()
 		g.On("GetNextFoundationRank", mock.Anything).Return(0).Maybe()
+		g.On("GetUpcomingFoundationRanks", mock.Anything, mock.Anything).Return([]int(nil)).Maybe()
 		var wastes [domain.CalculationWasteCnt][]*domain.Card
 		g.On("GetWastes").Return(wastes).Maybe()
 
@@ -170,6 +176,7 @@ func TestCalculationCuiPresenter_NextRank(t *testing.T) {
 			g.On("GetNextFoundationRank", i).Return(r).Maybe()
 		}
 		g.On("GetNextFoundationRank", mock.Anything).Return(0).Maybe()
+		g.On("GetUpcomingFoundationRanks", mock.Anything, mock.Anything).Return([]int(nil)).Maybe()
 		g.On("GetWastes").Return([domain.CalculationWasteCnt][]*domain.Card{}).Maybe()
 		g.On("GetStockCount").Return(0).Maybe()
 		g.On("GetStockTop").Return((*domain.Card)(nil)).Maybe()
@@ -192,4 +199,21 @@ func TestCalculationCuiPresenter_NextRank(t *testing.T) {
 		out := p.Output(withRanks(2, 0, 6, 0), nil)
 		assert.Equal(t, 2, strings.Count(out, "→ 次:"))
 	})
+}
+
+// #5551: +3 の組札で「次の次のまた次」を辿るのは暗算負荷が高い。Web は6手先まで
+// バッジで出しているのに、CUI は1手先しか出していなかった。
+func TestCalculationCuiPresenter_Output_UpcomingRanks(t *testing.T) {
+	p := new(CalculationCuiPresenter)
+
+	g := new(interfaces.MockCalculationGame)
+	// 先に登録した期待が優先されるので、既定より前に置く。
+	g.On("GetUpcomingFoundationRanks", 2, domain.CalculationMaxLookAhead).Return([]int{6, 9, 12, 2, 5, 8})
+	g.On("GetUpcomingFoundationRanks", mock.Anything, mock.Anything).Return([]int{})
+	setupCalculationCuiMockDefaults(g)
+
+	out := p.Output(g, nil)
+	assert.Contains(t, out, i18n.Tf("calculation.upcomingRanks", "ranks", "6 → 9 → 12 → 2 → 5 → 8"))
+	// **先読みが空の組札には行を出さない。**完成した山に「次: 」だけ出しても意味がない。
+	assert.Equal(t, 1, strings.Count(out, i18n.T("calculation.upcomingRanksLabel")))
 }

--- a/internal/domain/Calculation.go
+++ b/internal/domain/Calculation.go
@@ -352,6 +352,33 @@ func (c *Calculation) GetNextFoundationRank(fIdx int) int {
 	return calculationNextValue(pile[len(pile)-1].GetValue(), fIdx+1)
 }
 
+// CalculationMaxLookAhead は先読みで返すランクの最大件数。Web の
+// calculationUpcomingRanks の既定値と同じ 6 手先。
+const CalculationMaxLookAhead = 6
+
+// GetUpcomingFoundationRanks は fIdx の組札にこれから必要になるランクを、
+// 次の1枚から最大 max 件まで順に返す。
+//
+// **+1/+2/+3/+4 を 13 で折り返す歩幅を何手も辿るのは暗算負荷が高い。**Web は
+// 6手先までバッジで出しているのに、CUI は1手先しか出していなかった (#5551)。
+// 13枚に達した時点で打ち切るので、完成した組札では空を返す。
+func (c *Calculation) GetUpcomingFoundationRanks(fIdx, max int) []int {
+	if fIdx < 0 || fIdx >= len(c.foundations) || max <= 0 {
+		return nil
+	}
+	pile := c.foundations[fIdx]
+	if len(pile) == 0 {
+		return nil
+	}
+	v := pile[len(pile)-1].GetValue()
+	out := make([]int, 0, max)
+	for n := len(pile); n < CardValueMax && len(out) < max; n++ {
+		v = calculationNextValue(v, fIdx+1)
+		out = append(out, v)
+	}
+	return out
+}
+
 // calculationNextValue ファンデーションの次に置くべき値を返す（step は 1..4、V は 1..13）。
 // v+step は最大で 13+4 = 17 なので、mod 13 は一度の減算で十分（ループ不要）。
 func calculationNextValue(v, step int) int {

--- a/internal/domain/Calculation_test.go
+++ b/internal/domain/Calculation_test.go
@@ -587,3 +587,59 @@ func TestCalculation_GetNextFoundationRank(t *testing.T) {
 		}
 	})
 }
+
+// #5551: +1/+2/+3/+4 の歩幅を何手も辿るのは暗算負荷が高い。Web は最大6手先まで
+// バッジで出しているのに、CUI は 1 手先しか出していなかった。
+func TestCalculation_GetUpcomingFoundationRanks(t *testing.T) {
+	c := NewDefaultCalculation()
+	c.Reset()
+
+	set := func(fIdx int, values ...int) {
+		f := c.GetFoundations()
+		pile := make([]*Card, 0, len(values))
+		for _, v := range values {
+			pile = append(pile, NewCard(CardDesignSpade, v, false))
+		}
+		f[fIdx] = pile
+		c.SetFoundations(f)
+	}
+
+	// +3 の列 (index 2) が 3 で止まっている: 6, 9, 12, 2, 5, 8。
+	set(2, 3)
+	assert.Equal(t, []int{6, 9, 12, 2, 5, 8}, c.GetUpcomingFoundationRanks(2, 6))
+
+	// +1 の列 (index 0) が 1 のとき: 2, 3, 4。
+	set(0, 1)
+	assert.Equal(t, []int{2, 3, 4}, c.GetUpcomingFoundationRanks(0, 3))
+
+	// **13枚に達したら打ち切る。**残り2枚しか置けない山で6手先は返さない。
+	full := make([]int, 0, 11)
+	for v := 1; v <= 11; v++ {
+		full = append(full, v)
+	}
+	set(0, full...)
+	assert.Len(t, c.GetUpcomingFoundationRanks(0, 6), 2)
+
+	// 完成した山は空。
+	full = append(full, 12, 13)
+	set(0, full...)
+	assert.Empty(t, c.GetUpcomingFoundationRanks(0, 6))
+
+	// 範囲外は空。
+	assert.Empty(t, c.GetUpcomingFoundationRanks(-1, 6))
+	assert.Empty(t, c.GetUpcomingFoundationRanks(CalculationFoundationCnt, 6))
+}
+
+// **1手先は既存の GetNextFoundationRank と一致すること。**別々に計算していると、
+// 同じ画面が 2 つの「次のランク」を出すことになる。
+func TestCalculation_UpcomingRanksAgreeWithNextRank(t *testing.T) {
+	c := NewDefaultCalculation()
+	c.Reset()
+	for i := range CalculationFoundationCnt {
+		upcoming := c.GetUpcomingFoundationRanks(i, 6)
+		if next := c.GetNextFoundationRank(i); next > 0 {
+			require.NotEmpty(t, upcoming, "foundation %d", i)
+			assert.Equal(t, next, upcoming[0], "foundation %d", i)
+		}
+	}
+}

--- a/internal/domain/interfaces/calculation.go
+++ b/internal/domain/interfaces/calculation.go
@@ -33,6 +33,8 @@ type CalculationGame interface {
 	GetFoundations() [domain.CalculationFoundationCnt][]*domain.Card
 	// GetNextFoundationRank そのファンデーションに次に置けるランクを取得する (0=置けない)
 	GetNextFoundationRank(fIdx int) int
+	// GetUpcomingFoundationRanks これから必要になるランクを最大 max 件返す (#5551)
+	GetUpcomingFoundationRanks(fIdx, max int) []int
 	// IsStalemate 手詰まり状態を取得する
 	IsStalemate() bool
 }

--- a/internal/domain/interfaces/calculation_mock.go
+++ b/internal/domain/interfaces/calculation_mock.go
@@ -78,6 +78,15 @@ func (_m *MockCalculationGame) GetNextFoundationRank(fIdx int) int {
 	return args.Int(0)
 }
 
+// GetUpcomingFoundationRanks これから必要になるランクを最大 max 件返す
+func (_m *MockCalculationGame) GetUpcomingFoundationRanks(fIdx, max int) []int {
+	args := _m.Called(fIdx, max)
+	if v, ok := args.Get(0).([]int); ok {
+		return v
+	}
+	return nil
+}
+
 func (_m *MockCalculationGame) IsStalemate() bool { return _m.Called().Bool(0) }
 
 func (_m *MockCalculationGame) GetActionLog() []*domain.ActionLogEntry {

--- a/internal/i18n/locales/en/calculation.json
+++ b/internal/i18n/locales/en/calculation.json
@@ -30,5 +30,7 @@
   "hintWaste": "Hint: waste {{waste}} → foundation {{foundation}}",
   "nextRank": " -> next: {{rank}}",
   "helpExampleHint": "  h                   ask for a move",
-  "helpExampleAuto": "  ac                  play everything that can go up"
+  "helpExampleAuto": "  ac                  play everything that can go up",
+  "upcomingRanks": " upcoming: {{ranks}}",
+  "upcomingRanksLabel": "Upcoming:"
 }

--- a/internal/i18n/locales/ja/calculation.json
+++ b/internal/i18n/locales/ja/calculation.json
@@ -30,5 +30,7 @@
   "hintWaste": "ヒント: ウェイスト{{waste}} → ファンデーション{{foundation}}",
   "nextRank": " → 次: {{rank}}",
   "helpExampleHint": "  h                   次の一手を教えてもらう",
-  "helpExampleAuto": "  ac                  置ける札を自動で送る"
+  "helpExampleAuto": "  ac                  置ける札を自動で送る",
+  "upcomingRanks": " 先読み: {{ranks}}",
+  "upcomingRanksLabel": "先読み:"
 }


### PR DESCRIPTION
Closes #5551

4 つの組札はそれぞれ **+1/+2/+3/+4 を 13 で折り返す**歩幅で進むので、
「+3 の列が 3 手先に何を要るか」を出すのは実際の暗算になる。Web は
`calculationUpcomingRanks` で 6 手先までバッジに出しているのに、CUI は
`GetNextFoundationRank` の**1手先だけ**だった (#4794 は同じ負荷を指摘して半分だけ直していた)。

## 直したこと

- `Calculation.GetUpcomingFoundationRanks(fIdx, max)` — 既存の
  `calculationNextValue` を反復するので、**1手目が `GetNextFoundationRank` と
  食い違うことがない** (そのためのテストを入れた)
- **13枚に達したら打ち切る** — 完成した組札は何も出さない
- CUI の各組札行に `先読み: 6 → 9 → 12 → 2 → 5 → 8` を追記 (ja/en)

## テスト計画

- [x] +3 の列が 3 のとき `[6 9 12 2 5 8]`、+1 の列が 1 のとき `[2 3 4]`
- [x] 残り2枚の山では 2 件、完成した山では空、範囲外は空
- [x] **1手目 == `GetNextFoundationRank`** を4列すべてで確認
- [x] CUI は先読みが空の組札に行を出さない
- [x] `golangci-lint` 0 issues / domain・presenter とも緑

### 変異テスト (3件とも検出)

| 変異 | 落ちたアサーション |
|---|---|
| 13枚の打ち切りを外す | 2 |
| 歩幅を常に +1 にする | 4 |
| 空の先読みでも行を出す | 1 |