### PR TITLE
feat(sirtommy): advise which waste to bury the card on

### DIFF
--- a/frontend/src/pages/SirTommyPage.test.tsx
+++ b/frontend/src/pages/SirTommyPage.test.tsx
@@ -284,6 +284,22 @@ describe('SirTommyPage', () => {
     expect(screen.getByText(/ストック → ファンデーション 2/)).toBeInTheDocument();
   });
 
+  // #5552: ファンデーションに置けない局面 — このゲームで最頻出 — では
+  // どのウェイストに置くかを助言する。
+  it('shows the waste-placement hint and rings the destination pile', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      hint: { fromZone: 'stock', wasteIdx: 2, foundationIdx: -1, toZone: 'waste' },
+      messageCode: 'sirtommy.hintAvailable',
+    });
+    renderWithProviders(<SirTommyPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+    expect(screen.getByText(/ストック → ウェイスト 2/)).toBeInTheDocument();
+    // **-1 を出さない。**移動の体裁に落とすと foundationIdx が漏れる。
+    expect(screen.queryByText(/-1/)).not.toBeInTheDocument();
+    expect(document.querySelectorAll('[data-hint-waste-target]')).toHaveLength(1);
+  });
+
   // **押していない人にヒントを見せない。**#4483 以降 `Output()` が毎回
   // ヒントを載せるので、`state.hint` だけを見て描画すると常時表示になる (#4605)。
   it('hides the hint when it was not requested', async () => {

--- a/frontend/src/pages/SirTommyPage.tsx
+++ b/frontend/src/pages/SirTommyPage.tsx
@@ -329,8 +329,12 @@ function SirTommyPageContent() {
   // 二重に書くと、ゲートされていない別の変数に貼り付けても安全に見えてしまう
   // (#4608 のレビュー指摘)。
   const requestedHint = isRequestedHint(state) ? state.hint : undefined;
-  const hintFoundation = requestedHint ? requestedHint.foundationIdx : -1;
-  const hintWaste = requestedHint?.fromZone === 'waste' ? requestedHint.wasteIdx : -1;
+  // 置き場所の助言 (#5552) は移動元ではなく**置き先**のウェイストを指す。
+  // 同じ wasteIdx を移動元として光らせると、逆の操作を勧めることになる。
+  const hintPlacesOnWaste = requestedHint?.toZone === 'waste';
+  const hintFoundation = requestedHint && !hintPlacesOnWaste ? requestedHint.foundationIdx : -1;
+  const hintWaste = requestedHint?.fromZone === 'waste' && !hintPlacesOnWaste ? requestedHint.wasteIdx : -1;
+  const hintWasteTarget = hintPlacesOnWaste ? (requestedHint?.wasteIdx ?? -1) : -1;
   const hintStock = requestedHint?.fromZone === 'stock';
 
   return (
@@ -491,6 +495,7 @@ function SirTommyPageContent() {
                 const top = pile[pile.length - 1];
                 const selected = isWasteSelected(idx);
                 const isHintSource = hintWaste === idx;
+                const isHintTarget = hintWasteTarget === idx;
                 const canAcceptStock = sourceIsStock && isPlaying && !loading;
                 // Compact preview of the pile's upper cards (last <=3 array
                 // elements, ending at the playable top) for the hover/focus
@@ -524,7 +529,8 @@ function SirTommyPageContent() {
                       title={wasteRanksLabel}
                       aria-label={wasteAriaLabel}
                       data-testid={`calc-waste-button-${idx.toString()}`}
-                      className={`p-0 border-0 bg-transparent rounded ${focusRingWhite} ${selected ? 'ring-2 ring-ds-warning' : ''} ${isHintSource ? 'ring-2 ring-ds-success animate-pulse' : ''} ${canAcceptStock ? 'ring-2 ring-ds-info/70' : ''}`}
+                      className={`p-0 border-0 bg-transparent rounded ${focusRingWhite} ${selected ? 'ring-2 ring-ds-warning' : ''} ${isHintSource || isHintTarget ? 'ring-2 ring-ds-success animate-pulse' : ''} ${canAcceptStock ? 'ring-2 ring-ds-info/70' : ''}`}
+                      data-hint-waste-target={isHintTarget || undefined}
                     >
                       {top ? (
                         <AnimatedCard card={top} width={cardWidth} />
@@ -556,9 +562,13 @@ function SirTommyPageContent() {
                   aria-live="polite"
                 >
                   {t('hintAvailable')}:{' '}
-                  {requestedHint.fromZone === 'stock'
-                    ? `${t('stock')} → ${t('foundation')} ${requestedHint.foundationIdx.toString()}`
-                    : `${t('waste')} ${requestedHint.wasteIdx.toString()} → ${t('foundation')} ${requestedHint.foundationIdx.toString()}`}
+                  {/* 置き場所の助言はファンデーションを指さない。移動の体裁に
+                      落とすと foundationIdx の -1 が出る (#5552)。 */}
+                  {hintPlacesOnWaste
+                    ? `${t('stock')} → ${t('waste')} ${requestedHint.wasteIdx.toString()}`
+                    : requestedHint.fromZone === 'stock'
+                      ? `${t('stock')} → ${t('foundation')} ${requestedHint.foundationIdx.toString()}`
+                      : `${t('waste')} ${requestedHint.wasteIdx.toString()} → ${t('foundation')} ${requestedHint.foundationIdx.toString()}`}
                 </div>
               )}
               <FrontendHintTooltip hint={frontendHint} enabled={frontendHintEnabled} t={t} />

--- a/frontend/src/types/games/sirtommy.ts
+++ b/frontend/src/types/games/sirtommy.ts
@@ -8,6 +8,13 @@ export interface SirTommyHint {
   fromZone: string;
   wasteIdx: number;
   foundationIdx: number;
+  /**
+   * Where the card should go: `'foundation'`, or `'waste'` when the advice is
+   * about which waste to bury the stock card on — the only strategic choice
+   * this game has, and the one the hint used to stay silent about (#5552).
+   * With `'waste'`, `wasteIdx` is the destination.
+   */
+  toZone?: string;
 }
 
 /** Full SirTommy game state returned from the API. */

--- a/internal/adapter/controller/SirTommyWebController.go
+++ b/internal/adapter/controller/SirTommyWebController.go
@@ -26,6 +26,8 @@ type SirTommyWebOutputHint struct {
 	FromZone      string `json:"fromZone"`
 	WasteIdx      int    `json:"wasteIdx"`
 	FoundationIdx int    `json:"foundationIdx"`
+	// ToZone は "foundation" か "waste"。"waste" のとき WasteIdx は**置き先** (#5552)。
+	ToZone string `json:"toZone"`
 }
 
 // SirTommyWebOutput サー・トミーWebアウトプット

--- a/internal/adapter/presenter/SirTommyCuiPresenter.go
+++ b/internal/adapter/presenter/SirTommyCuiPresenter.go
@@ -107,6 +107,12 @@ func (p *SirTommyCuiPresenter) HintOutput(g interfaces.SirTommyGame) string {
 	if hint == nil {
 		return i18n.T("cuiHintNone") + "\n"
 	}
+	// ファンデーションに置ける手が無い局面では、山札の札をどのウェイストに
+	// 置くべきかを助言する。ここがこのゲーム唯一の戦略的判断 (#5552)。
+	if hint.ToZone == "waste" {
+		return i18n.Tf("sirtommy.hintPlaceWaste",
+			"waste", strconv.Itoa(hint.WasteIdx)) + "\n"
+	}
 	switch hint.FromZone {
 	case "stock":
 		return i18n.Tf("sirtommy.hintStock",

--- a/internal/adapter/presenter/SirTommyCuiPresenter_test.go
+++ b/internal/adapter/presenter/SirTommyCuiPresenter_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupSirTommyCuiMockDefaults(g *interfaces.MockSirTommyGame) {
@@ -131,15 +132,26 @@ func TestSirTommyCuiPresenter_Output(t *testing.T) {
 func TestSirTommyCuiPresenter_HintOutput(t *testing.T) {
 	t.Run("stock hint", func(t *testing.T) {
 		g := new(interfaces.MockSirTommyGame)
-		g.On("GetHint").Return(&domain.SirTommyHint{FromZone: "stock", WasteIdx: -1, FoundationIdx: 2})
+		g.On("GetHint").Return(&domain.SirTommyHint{FromZone: "stock", WasteIdx: -1, FoundationIdx: 2, ToZone: "foundation"})
 		result := new(SirTommyCuiPresenter).HintOutput(g)
 		assert.Contains(t, result, "ストック")
 		assert.Contains(t, result, "ファンデーション2")
 	})
 
+	// #5552: ファンデーションに置けない局面 — このゲームで最も頻繁に起きる —
+	// では、どのウェイストに置くかを助言する。
+	t.Run("waste placement hint", func(t *testing.T) {
+		g := new(interfaces.MockSirTommyGame)
+		g.On("GetHint").Return(&domain.SirTommyHint{FromZone: "stock", WasteIdx: 3, FoundationIdx: -1, ToZone: "waste"})
+		result := new(SirTommyCuiPresenter).HintOutput(g)
+		assert.Contains(t, result, i18n.Tf("sirtommy.hintPlaceWaste", "waste", "3"))
+		// **ファンデーションの案内には落とさない。**-1 が漏れる。
+		assert.NotContains(t, result, "-1")
+	})
+
 	t.Run("waste hint", func(t *testing.T) {
 		g := new(interfaces.MockSirTommyGame)
-		g.On("GetHint").Return(&domain.SirTommyHint{FromZone: "waste", WasteIdx: 1, FoundationIdx: 0})
+		g.On("GetHint").Return(&domain.SirTommyHint{FromZone: "waste", WasteIdx: 1, FoundationIdx: 0, ToZone: "foundation"})
 		result := new(SirTommyCuiPresenter).HintOutput(g)
 		assert.Contains(t, result, "ウェイスト1")
 		assert.Contains(t, result, "ファンデーション0")

--- a/internal/adapter/presenter/SirTommyWebPresenter.go
+++ b/internal/adapter/presenter/SirTommyWebPresenter.go
@@ -26,6 +26,7 @@ func (p *SirTommyWebPresenter) Output(g interfaces.SirTommyGame, lastErr error) 
 				FromZone:      hint.FromZone,
 				WasteIdx:      hint.WasteIdx,
 				FoundationIdx: hint.FoundationIdx,
+				ToZone:        hint.ToZone,
 			}
 		}
 	}
@@ -62,6 +63,7 @@ func (p *SirTommyWebPresenter) HintOutput(g interfaces.SirTommyGame) string {
 			FromZone:      hint.FromZone,
 			WasteIdx:      hint.WasteIdx,
 			FoundationIdx: hint.FoundationIdx,
+			ToZone:        hint.ToZone,
 		}
 		resObj.MessageCode = "sirtommy.hintAvailable"
 	} else {

--- a/internal/domain/SirTommy.go
+++ b/internal/domain/SirTommy.go
@@ -31,10 +31,17 @@ const SirTommyWasteCnt = 4
 type SirTommyHint struct {
 	// FromZone 移動元ゾーン "stock" または "waste"
 	FromZone string
-	// WasteIdx 移動元がウェイストの場合のインデックス、stock の場合は -1
+	// WasteIdx ウェイストのインデックス。ToZone が "foundation" なら移動元
+	// (stock からなら -1)、"waste" なら**置き先**。
 	WasteIdx int
-	// FoundationIdx 移動先ファンデーションのインデックス
+	// FoundationIdx 移動先ファンデーションのインデックス。ToZone が "waste" なら -1。
 	FoundationIdx int
+	// ToZone 移動先ゾーン "foundation" または "waste"。
+	//
+	// **置き場所の助言がこのゲームの本体。**ウェイストは4つあり最上段しか動かせず、
+	// 入れ替えもできないので、山札から引いた非エース札をどこに置くかが唯一の
+	// 戦略的判断。それを扱わないヒントは、最頻出の局面で毎回 nil を返していた (#5552)。
+	ToZone string
 }
 
 // SirTommy サー・トミーゲームクラス。
@@ -191,7 +198,7 @@ func (s *SirTommy) GetHint() *SirTommyHint {
 	if len(s.stock) > 0 {
 		card := s.stock[len(s.stock)-1]
 		if fIdx := s.findFoundation(card); fIdx >= 0 {
-			return &SirTommyHint{FromZone: "stock", WasteIdx: -1, FoundationIdx: fIdx}
+			return &SirTommyHint{FromZone: "stock", WasteIdx: -1, FoundationIdx: fIdx, ToZone: "foundation"}
 		}
 	}
 	for wIdx := range SirTommyWasteCnt {
@@ -200,10 +207,60 @@ func (s *SirTommy) GetHint() *SirTommyHint {
 			continue
 		}
 		if fIdx := s.findFoundation(pile[len(pile)-1]); fIdx >= 0 {
-			return &SirTommyHint{FromZone: "waste", WasteIdx: wIdx, FoundationIdx: fIdx}
+			return &SirTommyHint{FromZone: "waste", WasteIdx: wIdx, FoundationIdx: fIdx, ToZone: "foundation"}
 		}
 	}
+	// ファンデーションに置ける手が無いときは、山札の札をどのウェイストに置くかを
+	// 助言する。ここがこのゲームで唯一の戦略的判断 (#5552)。
+	if wIdx := s.suggestWaste(); wIdx >= 0 {
+		return &SirTommyHint{FromZone: "stock", WasteIdx: wIdx, FoundationIdx: -1, ToZone: "waste"}
+	}
 	return nil
+}
+
+// suggestWaste は山札の一番上の札を置くべきウェイストを選ぶ。山札が空なら -1。
+//
+// 優先順位は「掘り出せなくなる札を作らない」こと:
+//
+//  1. 自分より**上位の札が最上段にあるウェイスト**のうち、差がいちばん小さいもの。
+//     ウェイストは降順に積むほど、下の札が先に必要にならずに済む。
+//  2. 空のウェイスト。
+//  3. どれも埋まっていて自分より下位なら、**最上段がいちばん高い**ウェイスト。
+//     低い札を埋めると、それが必要になったときに掘り出せない。
+func (s *SirTommy) suggestWaste() int {
+	if len(s.stock) == 0 {
+		return -1
+	}
+	v := s.stock[len(s.stock)-1].GetValue()
+	best, bestGap := -1, 0
+	empty := -1
+	highest, highestVal := -1, 0
+	for wIdx := range SirTommyWasteCnt {
+		pile := s.wastes[wIdx]
+		if len(pile) == 0 {
+			if empty < 0 {
+				empty = wIdx
+			}
+			continue
+		}
+		top := pile[len(pile)-1].GetValue()
+		if top > v {
+			if gap := top - v; best < 0 || gap < bestGap {
+				best, bestGap = wIdx, gap
+			}
+		}
+		if top > highestVal {
+			highest, highestVal = wIdx, top
+		}
+	}
+	switch {
+	case best >= 0:
+		return best
+	case empty >= 0:
+		return empty
+	default:
+		return highest
+	}
 }
 
 // AutoComplete 置けるカードがなくなるまで自動でファンデーションへ積む

--- a/internal/domain/SirTommy_test.go
+++ b/internal/domain/SirTommy_test.go
@@ -179,17 +179,26 @@ func TestSirTommy_Hint(t *testing.T) {
 	s := newTestSirTommy()
 
 	// Deal a stock whose top is not an Ace, with every foundation empty, so
-	// nothing is playable. Asserting this on a freshly shuffled deck would be a
-	// 4-in-52 flake: a real Reset leaves whatever the shuffle put on top, and an
-	// Ace there is a legitimate hint.
+	// nothing can go to a foundation. Asserting this on a freshly shuffled deck
+	// would be a 4-in-52 flake: a real Reset leaves whatever the shuffle put on
+	// top, and an Ace there is a legitimate hint.
+	//
+	// #5552 以降、この局面は **nil ではなく置き場所の助言**を返す。ウェイストに
+	// どう置くかがこのゲーム唯一の戦略的判断で、そこを黙るヒントは最頻出の
+	// 局面で役に立っていなかった。
 	stackDeck(s, []*Card{NewCard(0, 9, true)})
-	assert.Nil(t, s.GetHint(), "no hint while nothing is playable")
+	placement := s.GetHint()
+	require.NotNil(t, placement, "置き場所の助言を返す")
+	assert.Equal(t, "waste", placement.ToZone)
+	assert.GreaterOrEqual(t, placement.WasteIdx, 0)
+	assert.Less(t, placement.WasteIdx, SirTommyWasteCnt)
 
 	// stock top is an Ace -> hint points at the stock
 	stackDeck(s, []*Card{NewCard(0, 1, true)})
 	h := s.GetHint()
 	require.NotNil(t, h)
 	assert.Equal(t, "stock", h.FromZone)
+	assert.Equal(t, "foundation", h.ToZone)
 	assert.Equal(t, -1, h.WasteIdx)
 
 	// waste top fits -> hint points at that waste
@@ -328,4 +337,67 @@ func TestSirTommy_AutoCompleteRefusesWhileStockRemains(t *testing.T) {
 	require.Error(t, s.AutoComplete(), "stock is not empty")
 	assert.Equal(t, 2, s.GetStockCount(), "a refused auto-complete changes nothing")
 	assert.Equal(t, 0, s.GetMoveCount())
+}
+
+// #5552: ドキュメントが「置き場所を選ぶ判断がゲーム性の中心」と書いている当の
+// 局面 — ストックの札をどのウェイストに置くか — でヒントが常に nil だった。
+func TestSirTommy_GetHint_WastePlacement(t *testing.T) {
+	newGame := func(stockTop int, wastes [][]int) *SirTommy {
+		s := newTestSirTommy()
+		s.Reset()
+		s.stock = []*Card{NewCard(CardDesignSpade, stockTop, false)}
+		for i := range SirTommyWasteCnt {
+			pile := make([]*Card, 0, len(wastes[i]))
+			for _, v := range wastes[i] {
+				pile = append(pile, NewCard(CardDesignHeart, v, false))
+			}
+			s.wastes[i] = pile
+		}
+		for i := range SirTommyFoundationCnt {
+			s.foundations[i] = nil
+		}
+		return s
+	}
+
+	t.Run("keeps a waste descending by choosing the tightest higher top", func(t *testing.T) {
+		// 7 を置く。上が 13 / 9 / 3 / 空 → 9 が最も近い上位。
+		s := newGame(7, [][]int{{13}, {9}, {3}, {}})
+		h := s.GetHint()
+		require.NotNil(t, h)
+		assert.Equal(t, "stock", h.FromZone)
+		assert.Equal(t, "waste", h.ToZone)
+		assert.Equal(t, 1, h.WasteIdx)
+		assert.Equal(t, -1, h.FoundationIdx)
+	})
+
+	t.Run("uses an empty pile when nothing higher is on top", func(t *testing.T) {
+		s := newGame(9, [][]int{{5}, {3}, {}, {2}})
+		h := s.GetHint()
+		require.NotNil(t, h)
+		assert.Equal(t, 2, h.WasteIdx)
+	})
+
+	// **どれかを埋めるしかないなら、いちばん高い札の上に置く。**低い札を
+	// 埋めると、それが必要になったときに掘り出せない。
+	t.Run("buries the highest top when every pile is occupied and lower", func(t *testing.T) {
+		s := newGame(9, [][]int{{5}, {8}, {2}, {6}})
+		h := s.GetHint()
+		require.NotNil(t, h)
+		assert.Equal(t, 1, h.WasteIdx)
+	})
+
+	// **ファンデーションに置ける手が優先。**置き場所の助言はその次。
+	t.Run("prefers a foundation move when one exists", func(t *testing.T) {
+		s := newGame(1, [][]int{{5}, {8}, {2}, {6}}) // A はファンデーションへ
+		h := s.GetHint()
+		require.NotNil(t, h)
+		assert.Equal(t, "foundation", h.ToZone)
+		assert.Equal(t, 0, h.FoundationIdx)
+	})
+
+	t.Run("no hint once the stock is empty and nothing plays", func(t *testing.T) {
+		s := newGame(9, [][]int{{5}, {8}, {2}, {6}})
+		s.stock = nil
+		assert.Nil(t, s.GetHint())
+	})
 }

--- a/internal/i18n/locales/en/sirtommy.json
+++ b/internal/i18n/locales/en/sirtommy.json
@@ -31,5 +31,6 @@
   "hintStock": "Hint: stock → foundation {{foundation}}",
   "hintWaste": "Hint: waste {{waste}} → foundation {{foundation}}",
   "helpExampleHint": "  h                   ask for a move",
-  "helpExampleAuto": "  ac                  play everything that can go up"
+  "helpExampleAuto": "  ac                  play everything that can go up",
+  "hintPlaceWaste": "Hint: put the stock card on waste {{waste}} (nothing can go to a foundation)"
 }

--- a/internal/i18n/locales/ja/sirtommy.json
+++ b/internal/i18n/locales/ja/sirtommy.json
@@ -31,5 +31,6 @@
   "hintStock": "ヒント: ストック → ファンデーション{{foundation}}",
   "hintWaste": "ヒント: ウェイスト{{waste}} → ファンデーション{{foundation}}",
   "helpExampleHint": "  h                   次の一手を教えてもらう",
-  "helpExampleAuto": "  ac                  置ける札を自動で送る"
+  "helpExampleAuto": "  ac                  置ける札を自動で送る",
+  "hintPlaceWaste": "ヒント: 山札の札はウェイスト {{waste}} に置きましょう (ファンデーションに置ける札はありません)"
 }


### PR DESCRIPTION
Closes #5552

`SirTommy.go` のドキュメントコメント自身が「置き場所を選ぶ判断が**ゲーム性の中心**」
と書いている。ウェイストは4つ、最上段しか動かせず、入れ替えもできない。
それなのに `GetHint` は**ファンデーションに置ける手しか返さず**、最頻出の局面
(引いた札をどこに置くか) では常に `nil` だった。CUI も Web も「ヒントなし」と出る。

## 直したこと

ファンデーション移動が無いときだけ、置き先のウェイストを助言する。
優先順位は**掘り出せなくなる札を作らない**こと:

1. 自分より**上位の札が最上段**のウェイストのうち、差が最小のもの (降順を保つ)
2. 空のウェイスト
3. どれも埋まっていて下位なら、**最上段がいちばん高い**ウェイスト
   (低い札を埋めると、それが必要なときに掘り出せない)

`SirTommyHint.ToZone` (`"foundation"` / `"waste"`) を追加し、CUI・Web・API で
同じ値を読む。**Web は置き先のパイルを光らせる** — 同じ `wasteIdx` を移動元として
光らせると逆の操作を勧めることになるので、そこは明示的に分けた。

## 既存契約の変更 (意図的)

`TestSirTommy_Hint` の「置ける手が無ければ nil」は**この issue が問題視している
挙動そのもの**なので、置き場所の助言を返すよう更新した。

## テスト計画

- [x] 7 を置く局面 (上が 13/9/3/空) → **9 の山** (最も近い上位)
- [x] 上位が無ければ空の山
- [x] 全部埋まって下位なら**最上段が最も高い山**
- [x] ファンデーションに置けるときはそちらが優先
- [x] 山札が空なら nil のまま
- [x] CUI は専用文言 (**`-1` を出さない**)、Web はバナーと置き先のリング
- [x] `golangci-lint` 0 issues / `bun run check` / `typecheck` 緑

### 変異テスト (3件とも検出)

| 変異 | 落ちたアサーション |
|---|---|
| 最小差でなく最大差を選ぶ | 1 |
| 空の山を最優先にする | 1 |
| ページが置き先を光らせない | 1 |