### PR TITLE
feat(cassino): show the take/build/trail history on the web page

### DIFF
--- a/frontend/src/i18n/locales/en/cassino.json
+++ b/frontend/src/i18n/locales/en/cassino.json
@@ -43,5 +43,14 @@
   "tutorial.playerHand": "Your hand. Pick one card, then Take / Build / Trail.",
   "tutorial.actions": "Take captures matching cards, Build commits a sum for later, Trail places the card.",
   "tutorial.resetButton": "Reset the game.",
-  "tutorial.welcome": "Welcome to Cassino! Capture cards to score points; first to 21 wins."
+  "tutorial.welcome": "Welcome to Cassino! Capture cards to score points; first to 21 wins.",
+  "action": {
+    "take": "{{name}}: took {{count}} with {{played}}",
+    "takeSweep": "{{name}}: took {{count}} with {{played}} (sweep!)",
+    "build": "{{name}}: built {{value}} with {{played}}",
+    "trail": "{{name}}: trailed {{played}}"
+  },
+  "label": {
+    "actionLog": "Action history"
+  }
 }

--- a/frontend/src/i18n/locales/ja/cassino.json
+++ b/frontend/src/i18n/locales/ja/cassino.json
@@ -43,5 +43,14 @@
   "tutorial.playerHand": "あなたの手札。1枚だけ選んで [取る] [ビルド] [場に置く] のどれかを押します。",
   "tutorial.actions": "[取る] で場札を獲得、[ビルド] で予約、[場に置く] は次のターンに残します。",
   "tutorial.resetButton": "ゲームをリセットします。",
-  "tutorial.welcome": "カッシーノへようこそ! 手札と場札を組み合わせて点数を稼ぎ、21点を先取したプレイヤーが勝ちます。"
+  "tutorial.welcome": "カッシーノへようこそ! 手札と場札を組み合わせて点数を稼ぎ、21点を先取したプレイヤーが勝ちます。",
+  "action": {
+    "take": "{{name}}: {{played}} で {{count}}枚 捕獲",
+    "takeSweep": "{{name}}: {{played}} で {{count}}枚 捕獲 (スイープ!)",
+    "build": "{{name}}: ビルド値 {{value}} ({{played}})",
+    "trail": "{{name}}: {{played}} を場に置く"
+  },
+  "label": {
+    "actionLog": "行動履歴"
+  }
 }

--- a/frontend/src/pages/CassinoPage.test.tsx
+++ b/frontend/src/pages/CassinoPage.test.tsx
@@ -488,6 +488,19 @@ describe('CassinoPage action history', () => {
     expect(log()).toHaveTextContent('場に置');
   });
 
+  // 壊れたレスポンス (playedCard が無い / cpuActions 欠落) でも落ちない。
+  // `a.playedCard ? ... : ''` と `?? []` の短絡側を通す。
+  it('renders an action with no played card, and a response with no cpuActions', async () => {
+    mockExec.mockResolvedValue({
+      ...makeState(),
+      humanAction: { playerIdx: 0, type: 'trail', playedCard: null, capturedCards: [], buildValue: 0, isSweep: false },
+      cpuActions: undefined as never,
+    });
+    renderWithProviders(<CassinoPage />);
+    await waitFor(() => expect(log()).toBeInTheDocument());
+    expect(log()).toHaveTextContent('あなた');
+  });
+
   // **何も起きていないうちは出さない。**
   it('renders nothing before anyone has acted', async () => {
     mockExec.mockResolvedValue(makeState({ cpuActions: [], humanAction: null }));

--- a/frontend/src/pages/CassinoPage.test.tsx
+++ b/frontend/src/pages/CassinoPage.test.tsx
@@ -436,3 +436,63 @@ describe('CassinoPage', () => {
     localStorage.removeItem('cli-mode-cassino');
   });
 });
+
+// #5549: CUI は「誰が何のカードでテイク(何枚・スイープか)/ビルド/トレイルしたか」を
+// 毎ターン出しているのに、Web はどちらのフィールドも読んでいなかった。
+describe('CassinoPage action history', () => {
+  const log = () => screen.getByTestId('cs-action-log');
+  const card = (design: string, value: number) => ({ design, value }) as never;
+
+  it('shows each action with its kind, and the capture count on a take', async () => {
+    mockExec.mockResolvedValue(
+      makeState({
+        humanAction: {
+          playerIdx: 0,
+          type: 'take',
+          playedCard: card('SPADE', 7),
+          capturedCards: [card('HEART', 3), card('CLOVER', 4)],
+          buildValue: 0,
+          isSweep: true,
+        },
+        cpuActions: [
+          {
+            playerIdx: 1,
+            type: 'build',
+            playedCard: card('DIAMOND', 5),
+            capturedCards: [],
+            buildValue: 9,
+            isSweep: false,
+          },
+          {
+            playerIdx: 2,
+            type: 'trail',
+            playedCard: card('HEART', 2),
+            capturedCards: [],
+            buildValue: 0,
+            isSweep: false,
+          },
+        ],
+      }),
+    );
+    renderWithProviders(<CassinoPage />);
+    await waitFor(() => expect(log()).toBeInTheDocument());
+
+    expect(log()).toHaveTextContent('あなた');
+    expect(log()).toHaveTextContent('CPU 1');
+    expect(log()).toHaveTextContent('CPU 2');
+    // テイクは捕獲枚数とスイープを出す。
+    expect(log()).toHaveTextContent('2');
+    expect(log()).toHaveTextContent('スイープ');
+    // ビルドは値、トレイルはその旨。
+    expect(log()).toHaveTextContent('9');
+    expect(log()).toHaveTextContent('場に置');
+  });
+
+  // **何も起きていないうちは出さない。**
+  it('renders nothing before anyone has acted', async () => {
+    mockExec.mockResolvedValue(makeState({ cpuActions: [], humanAction: null }));
+    renderWithProviders(<CassinoPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    expect(screen.queryByTestId('cs-action-log')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/CassinoPage.tsx
+++ b/frontend/src/pages/CassinoPage.tsx
@@ -18,7 +18,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { gameTheme } from '../styles/gameTheme';
-import type { CassinoResponse } from '../types/card';
+import type { CassinoAction, CassinoResponse } from '../types/card';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { cassinoTakeCandidates } from '../utils/cassinoTakeCandidates';
@@ -130,6 +130,27 @@ function CassinoPageContent() {
   // is still null.
   const human = state && state.players.length >= 4 ? state.players[0] : null;
   const isHumanTurn = !!state && state.currentTurn === 0 && !state.gameEndFlag;
+  // 自分と CPU の手を 1 本の時系列に。文言は CUI の cassinoActionStr と同じ組み立て
+  // (テイクは捕獲枚数とスイープ、ビルドは値、トレイルはその旨)。
+  const describeAction = (a: CassinoAction): string => {
+    const name = a.playerIdx === 0 ? tc('player.you') : tc('player.cpu', { id: a.playerIdx });
+    const played = a.playedCard ? cardAlt(a.playedCard) : '';
+    switch (a.type) {
+      case 'take':
+        return t(a.isSweep ? 'action.takeSweep' : 'action.take', {
+          name,
+          played,
+          count: a.capturedCards.length,
+        });
+      case 'build':
+        return t('action.build', { name, played, value: a.buildValue });
+      default:
+        return t('action.trail', { name, played });
+    }
+  };
+  const actionHistory = [...(state?.humanAction ? [state.humanAction] : []), ...(state?.cpuActions ?? [])].map(
+    describeAction,
+  );
 
   const suggestion = useMemo(
     () =>
@@ -299,6 +320,22 @@ function CassinoPageContent() {
                 </div>
               )}
             </div>
+
+            {/* Action history: CUI は毎ターン「誰が何のカードでテイク(何枚・スイープか)/
+                ビルド/トレイルしたか」を出しているのに、Web はどちらのフィールドも
+                読んでいなかった (#5549)。テイク・ビルド・トレイルと選択肢が多く、
+                場の変化を追いにくいゲームなので効く。 */}
+            {actionHistory.length > 0 && (
+              <div
+                role="log"
+                aria-live="polite"
+                aria-label={t('label.actionLog')}
+                className="bg-black/40 rounded-lg text-ds-text-primary py-2 px-3.5 my-2 whitespace-pre-line text-xs"
+                data-testid="cs-action-log"
+              >
+                {actionHistory.join('\n')}
+              </div>
+            )}
 
             {/* Human hand */}
             <div className="text-center" data-tutorial="cs-player-hand">


### PR DESCRIPTION
Closes #5549

`CassinoResponse` は `cpuActions` / `humanAction` を持ち、CUI は
`cassinoActionStr` で「誰が何のカードでテイク (何枚・スイープか) / ビルド /
トレイルしたか」を毎ターン出している。**ページはどちらも参照していなかった。**
テイク・ビルド・トレイルと選択肢が多く場の変化を追いにくいゲームなので、
この欠落は効く。

## 直したこと

卓の下に行動履歴を出す (`role="log"` / `aria-live="polite"`)。文言は CUI と同じ組み立て:

- テイク: **捕獲枚数**と**スイープ**を出し分け
- ビルド: ビルド値
- トレイル: 置いた札

自分の手も同じ 1 本の時系列に含める。誰も動いていなければ表示自体が無い。

## テスト計画

- [x] テイク(スイープ)/ビルド/トレイルの 3 種が種別付きで並ぶ
- [x] 捕獲枚数とスイープが出る、ビルド値が出る
- [x] human の手が同じ一覧に入る
- [x] 誰も動いていなければ出ない
- [x] 既存 24 件緑 / `bun run check` / `typecheck` 緑

### 変異テスト (2件とも検出)

| 変異 | 落ちたテスト |
|---|---|
| スイープを出し分けない | 1 |
| human の手を一覧から外す | 1 |