### PR TITLE
fix(bisley): stop printing English rejections in a Japanese session

### DIFF
--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -2192,7 +2192,18 @@
     "war.round.humanWin": "You won the round.",
     "war.round.cpuWin": "CPU won the round.",
     "war.round.warBury": "War! Each side buries a card and reveals another.",
-    "paigow.foulHighMustBeat": "Foul: the two-card low hand must be weaker than the five-card high hand"
+    "paigow.foulHighMustBeat": "Foul: the two-card low hand must be weaker than the five-card high hand",
+    "bisley.errCannotPlaceAscending": "That card cannot go on the ascending foundation",
+    "bisley.errCannotPlaceDescending": "That card cannot go on the descending foundation",
+    "bisley.errBadToColumn": "Invalid destination column",
+    "bisley.errSameColumn": "Source and destination are the same column",
+    "bisley.errEmptyColumn": "An empty column will not take a card (in Bisley a gap is not a free cell)",
+    "bisley.errNotAdjacentSameSuit": "The tableau builds one up or one down in the same suit",
+    "bisley.errNothingToAutoComplete": "No card can be sent to a foundation",
+    "bisley.errNothingToUndo": "There is nothing to undo",
+    "bisley.errBadColumn": "Invalid column index",
+    "bisley.errColumnEmpty": "That column is empty",
+    "bisley.errNotPlaying": "The game is not in play"
   },
   "manual": {
     "ariaLabel": "Game Manual",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -2192,7 +2192,18 @@
     "war.round.humanWin": "あなたがラウンドに勝ちました。",
     "war.round.cpuWin": "CPU がラウンドに勝ちました。",
     "war.round.warBury": "戦争です。伏せ札と表札を出します。",
-    "paigow.foulHighMustBeat": "ファウルです: ローの2枚はハイの5枚より弱くしてください（ローが強いと反則）"
+    "paigow.foulHighMustBeat": "ファウルです: ローの2枚はハイの5枚より弱くしてください（ローが強いと反則）",
+    "bisley.errCannotPlaceAscending": "その札は昇順の基礎札に置けません",
+    "bisley.errCannotPlaceDescending": "その札は降順の基礎札に置けません",
+    "bisley.errBadToColumn": "移動先の列番号が不正です",
+    "bisley.errSameColumn": "移動元と移動先が同じ列です",
+    "bisley.errEmptyColumn": "空いた列には置けません（ビズリーの空き列は自由置き場ではありません）",
+    "bisley.errNotAdjacentSameSuit": "タブローは同じスートで1つ上か1つ下の札にしか重ねられません",
+    "bisley.errNothingToAutoComplete": "自動で基礎札に送れる札がありません",
+    "bisley.errNothingToUndo": "取り消せる手がありません",
+    "bisley.errBadColumn": "列番号が不正です",
+    "bisley.errColumnEmpty": "その列は空です",
+    "bisley.errNotPlaying": "プレイ中ではありません"
   },
   "manual": {
     "ariaLabel": "ゲームマニュアル",

--- a/internal/adapter/presenter/BisleyWebPresenter.go
+++ b/internal/adapter/presenter/BisleyWebPresenter.go
@@ -64,7 +64,15 @@ func (p *BisleyWebPresenter) Output(b interfaces.BisleyGame, lastErr error) stri
 	}
 
 	if lastErr != nil {
-		resObj.Message = lastErr.Error()
+		// コードを持つエラーはクライアントの i18n に組み立てさせる。ここで
+		// Error() をそのまま入れると、キーを名乗るエラーはキー文字列が画面に
+		// 出る (#5553)。
+		if code, params := domain.ErrorMessageCode(lastErr); code != "" {
+			resObj.MessageCode = code
+			resObj.MessageParams = params
+		} else {
+			resObj.Message = lastErr.Error()
+		}
 	} else {
 		switch b.GetPhase() {
 		case domain.BisleyPhasePlaying:

--- a/internal/adapter/presenter/BisleyWebPresenter_test.go
+++ b/internal/adapter/presenter/BisleyWebPresenter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -198,4 +199,18 @@ func TestBisleyWebPresenter_ActionLogOutput(t *testing.T) {
 		result := p.ActionLogOutput(bg)
 		assert.Contains(t, result, "move")
 	})
+}
+
+// #5553: ドメインのエラーが i18n キーを名乗るようになった。Error() をそのまま
+// Message に入れると、画面に "bisley.errEmptyColumn" が出る。
+func TestBisleyWebPresenter_Output_CodedErrorGoesOutAsACode(t *testing.T) {
+	bg := new(interfaces.MockBisleyGame)
+	setupBisleyOutputMock(bg)
+
+	err := domain.NewDomainErrorCode(domain.ErrInvalidPlay, "bisley.errEmptyColumn", nil)
+	var out controller.BisleyWebOutput
+	require.NoError(t, json.Unmarshal([]byte(new(BisleyWebPresenter).Output(bg, err)), &out))
+
+	assert.Equal(t, "bisley.errEmptyColumn", out.MessageCode)
+	assert.Empty(t, out.Message, "生のキーを message に入れない")
 }

--- a/internal/domain/Bisley.go
+++ b/internal/domain/Bisley.go
@@ -153,7 +153,7 @@ func (b *Bisley) MoveTableauToAceFoundation(col int) error {
 	}
 	fIdx := BisleySuitIndex(card.GetDesign())
 	if fIdx < 0 || !b.canPlaceOnAce(card, fIdx) {
-		return errors.New("cannot place card on ascending foundation")
+		return NewDomainErrorCode(ErrInvalidPlay, "bisley.errCannotPlaceAscending", nil)
 	}
 	b.takeSnapshot()
 	b.popTop(col)
@@ -170,7 +170,7 @@ func (b *Bisley) MoveTableauToKingFoundation(col int) error {
 	}
 	fIdx := BisleySuitIndex(card.GetDesign())
 	if fIdx < 0 || !b.canPlaceOnKing(card, fIdx) {
-		return errors.New("cannot place card on descending foundation")
+		return NewDomainErrorCode(ErrInvalidPlay, "bisley.errCannotPlaceDescending", nil)
 	}
 	b.takeSnapshot()
 	b.popTop(col)
@@ -186,19 +186,19 @@ func (b *Bisley) MoveTableauToTableau(fromCol, toCol int) error {
 		return err
 	}
 	if toCol < 0 || toCol >= BisleyTableauCnt {
-		return errors.New("invalid destination column")
+		return NewDomainErrorCode(ErrInvalidPlay, "bisley.errBadToColumn", nil)
 	}
 	if fromCol == toCol {
-		return errors.New("source and destination are the same column")
+		return NewDomainErrorCode(ErrInvalidPlay, "bisley.errSameColumn", nil)
 	}
 	dst := b.tableau[toCol]
 	if len(dst) == 0 {
 		// 空き列は自由置き場ではない。ここを許すと事実上どの札でも掘り出せる。
-		return errors.New("cannot move onto an empty column")
+		return NewDomainErrorCode(ErrInvalidPlay, "bisley.errEmptyColumn", nil)
 	}
 	top := dst[len(dst)-1].Card
 	if top.GetDesign() != card.GetDesign() || abs(top.GetValue()-card.GetValue()) != 1 {
-		return errors.New("tableau builds up or down by one in the same suit")
+		return NewDomainErrorCode(ErrInvalidPlay, "bisley.errNotAdjacentSameSuit", nil)
 	}
 	b.takeSnapshot()
 	b.popTop(fromCol)
@@ -280,7 +280,7 @@ func (b *Bisley) tableauHint() *BisleyHint {
 // タブロー上の移動は行わないので、GetHint ではなく foundationHint を使う。
 func (b *Bisley) AutoComplete() error {
 	if b.phase != BisleyPhasePlaying {
-		return errors.New("game is not in playing phase")
+		return NewDomainErrorCode(ErrWrongPhase, "bisley.errNotPlaying", nil)
 	}
 	moved := false
 	for {
@@ -300,7 +300,7 @@ func (b *Bisley) AutoComplete() error {
 		moved = true
 	}
 	if !moved {
-		return errors.New("no card can be auto-completed")
+		return NewDomainErrorCode(ErrInvalidPlay, "bisley.errNothingToAutoComplete", nil)
 	}
 	return nil
 }
@@ -308,7 +308,7 @@ func (b *Bisley) AutoComplete() error {
 // Undo 直前の 1 手を取り消す
 func (b *Bisley) Undo() error {
 	if len(b.history) == 0 {
-		return errors.New("nothing to undo")
+		return NewDomainErrorCode(ErrInvalidPlay, "bisley.errNothingToUndo", nil)
 	}
 	snap := b.history[len(b.history)-1]
 	b.history = b.history[:len(b.history)-1]
@@ -370,14 +370,14 @@ func abs(v int) int {
 // topOf 指定列の最上段カードを返す（列が空・範囲外ならエラー）
 func (b *Bisley) topOf(col int) (*Card, error) {
 	if b.phase != BisleyPhasePlaying {
-		return nil, errors.New("game is not in playing phase")
+		return nil, NewDomainErrorCode(ErrWrongPhase, "bisley.errNotPlaying", nil)
 	}
 	if col < 0 || col >= BisleyTableauCnt {
-		return nil, errors.New("invalid column index")
+		return nil, NewDomainErrorCode(ErrInvalidPlay, "bisley.errBadColumn", nil)
 	}
 	pile := b.tableau[col]
 	if len(pile) == 0 {
-		return nil, errors.New("column is empty")
+		return nil, NewDomainErrorCode(ErrInvalidPlay, "bisley.errColumnEmpty", nil)
 	}
 	return pile[len(pile)-1].Card, nil
 }

--- a/internal/domain/Bisley_test.go
+++ b/internal/domain/Bisley_test.go
@@ -397,3 +397,39 @@ func TestBisley_AutoCompleteIgnoresTableauMoves(t *testing.T) {
 	assert.Len(t, b.GetTableau()[0], 1, "the board is untouched")
 	assert.Len(t, b.GetTableau()[1], 1)
 }
+
+// #5553: 空列への移動は `errors.New("cannot move onto an empty column")` を返し、
+// cuiErrorBlock がそれをそのまま赤字で出していた。日本語でプレイしていても
+// 英語の一文が画面に混ざる。
+func TestBisley_ErrorsNameI18nKeys(t *testing.T) {
+	b := newTestBisley()
+	b.Reset()
+
+	// 空列への移動。片方の列を空にしてから試す。
+	b.tableau[0] = nil
+	err := b.MoveTableauToTableau(1, 0)
+	require.Error(t, err)
+	code, _ := ErrorMessageCode(err)
+	assert.Equal(t, "bisley.errEmptyColumn", code)
+	// **生の英文が残っていないこと。**
+	assert.NotContains(t, err.Error(), "empty column")
+
+	// 同じ列への移動。
+	code, _ = ErrorMessageCode(b.MoveTableauToTableau(1, 1))
+	assert.Equal(t, "bisley.errSameColumn", code)
+
+	// 範囲外の列。
+	code, _ = ErrorMessageCode(b.MoveTableauToTableau(1, BisleyTableauCnt))
+	assert.Equal(t, "bisley.errBadToColumn", code)
+
+	// 取り消せる手が無いとき。
+	fresh := newTestBisley()
+	fresh.Reset()
+	code, _ = ErrorMessageCode(fresh.Undo())
+	assert.Equal(t, "bisley.errNothingToUndo", code)
+
+	// **プレイ中でないときも。**
+	fresh.GiveUp()
+	code, _ = ErrorMessageCode(fresh.MoveTableauToAceFoundation(0))
+	assert.Equal(t, "bisley.errNotPlaying", code)
+}

--- a/internal/i18n/locales/en/bisley.json
+++ b/internal/i18n/locales/en/bisley.json
@@ -18,5 +18,16 @@
   "hintLine": "Hint: {{from}} → {{to}}",
   "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)",
   "helpExampleHint": "  h                    ask for a move",
-  "helpExampleAuto": "  ac                   send everything that can go to a foundation"
+  "helpExampleAuto": "  ac                   send everything that can go to a foundation",
+  "errCannotPlaceAscending": "That card cannot go on the ascending foundation",
+  "errCannotPlaceDescending": "That card cannot go on the descending foundation",
+  "errBadToColumn": "Invalid destination column",
+  "errSameColumn": "Source and destination are the same column",
+  "errEmptyColumn": "An empty column will not take a card (in Bisley a gap is not a free cell)",
+  "errNotAdjacentSameSuit": "The tableau builds one up or one down in the same suit",
+  "errNothingToAutoComplete": "No card can be sent to a foundation",
+  "errNothingToUndo": "There is nothing to undo",
+  "errBadColumn": "Invalid column index",
+  "errColumnEmpty": "That column is empty",
+  "errNotPlaying": "The game is not in play"
 }

--- a/internal/i18n/locales/ja/bisley.json
+++ b/internal/i18n/locales/ja/bisley.json
@@ -18,5 +18,16 @@
   "hintLine": "ヒント: {{from}} → {{to}}",
   "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）",
   "helpExampleHint": "  h                    次の一手を教えてもらう",
-  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る"
+  "helpExampleAuto": "  ac                   組札へ送れる札を自動で送る",
+  "errCannotPlaceAscending": "その札は昇順の基礎札に置けません",
+  "errCannotPlaceDescending": "その札は降順の基礎札に置けません",
+  "errBadToColumn": "移動先の列番号が不正です",
+  "errSameColumn": "移動元と移動先が同じ列です",
+  "errEmptyColumn": "空いた列には置けません（ビズリーの空き列は自由置き場ではありません）",
+  "errNotAdjacentSameSuit": "タブローは同じスートで1つ上か1つ下の札にしか重ねられません",
+  "errNothingToAutoComplete": "自動で基礎札に送れる札がありません",
+  "errNothingToUndo": "取り消せる手がありません",
+  "errBadColumn": "列番号が不正です",
+  "errColumnEmpty": "その列は空です",
+  "errNotPlaying": "プレイ中ではありません"
 }


### PR DESCRIPTION
Closes #5553

`MoveTableauToTableau` の空列拒否は `errors.New("cannot move onto an empty column")`
で、`cuiErrorBlock` はそれをそのまま赤字で出す。**日本語でプレイしていても英語の
一文が混ざる。** ビズリーは「同スート±1」の双方向ルールで移動先ハイライトも無いので、
不正移動を試す頻度が高く、遭遇しやすい。

## 直したこと

issue は空列の 1 件を挙げているが、**同じファイルに同じ形が 11 件**あった
(基礎札への不正配置、列番号不正、同一列、隣接違反、undo 対象なし、自動完成対象なし、
空列、範囲外、空列参照、プレイ中でない)。全部 `NewDomainErrorCode` に変換した。

**キーにするだけでは足りなかった**: `BisleyWebPresenter` は PaiGow と同じく
`Error()` を `Message` に直接入れていたので、そのままだと Web に
`bisley.errEmptyColumn` という文字列が出る。`MessageCode` に振り分けた。

デシリアライズ時のガード 4 件は**プレイヤー宛てではない**ので生のまま残した。

## テスト計画

- [x] 空列 / 同一列 / 範囲外 / undo 対象なし / プレイ中でない の 5 局面で
      `ErrorMessageCode` が期待のキーを返す
- [x] **生の英文が残っていないこと** (`"empty column"` を含まない)
- [x] Web は `messageCode` に入り `message` は空
- [x] ja/en を CUI (`internal/i18n/.../bisley.json`) と
      Web (`common.json` の `messageCode`) の**両方**に追加
- [x] `golangci-lint` 0 issues / `bun run check` 緑 (`check-message-codes` を含む)

### 変異テスト (2件とも検出)

| 変異 | 落ちたアサーション |
|---|---|
| 空列エラーを生の英文に戻す | 2 |
| Web が `message` にキーを入れる | 2 |