### PR TITLE
fix(duchess): decide auto-complete readiness from the domain, not pile height

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -32598,6 +32598,11 @@ components:
             While true, `base` is the only command that will be accepted. Sent
             alongside `baseRank` so the client never has to encode the
             "0 means unchosen" convention itself.
+        canAutoComplete:
+          type: boolean
+          description: >-
+            True when auto-complete can move at least one card right now. The
+            client uses it for the button state, so pressing it always succeeds.
         phase:
           type: integer
           description: "0=Playing, 1=GameClear, 2=GameOver"

--- a/frontend/src/pages/DuchessPage.test.tsx
+++ b/frontend/src/pages/DuchessPage.test.tsx
@@ -243,22 +243,36 @@ describe('DuchessPage', () => {
     expect(screen.queryByTestId('du-gameover-summary')).not.toBeInTheDocument();
   });
 
-  // Every foundation opens with the base rank, so one card on a pile is the
-  // starting position — auto-complete only helps past it.
-  it('disables auto-complete until a foundation is past the base rank', async () => {
-    mockExec.mockResolvedValue({ ...playingState, foundation: [[card('SPADE', 5)], [], [], []] });
-    const { unmount } = renderWithProviders(<DuchessPage />);
-    const btn = await screen.findByTestId('autocomplete-button');
-    expect(btn).toBeDisabled();
-    expect(btn).toHaveAttribute('title');
-    unmount();
-
+  // #5557: 活性条件はドメインの `canAutoComplete`。組札の枚数は条件ではない —
+  // 種札を置かないので 1 枚でも次を送れることがあり、逆に高く積まれていても
+  // 送れる札が無ければ AutoComplete は失敗する。
+  it('enables auto-complete when the server says a card can move, even with one card on a pile', async () => {
     mockExec.mockResolvedValue({
       ...playingState,
-      foundation: [[card('SPADE', 5), card('SPADE', 6)], [], [], []],
+      foundation: [[card('SPADE', 5)], [], [], []],
+      canAutoComplete: true,
     });
     renderWithProviders(<DuchessPage />);
     await waitFor(() => expect(screen.getByTestId('autocomplete-button')).toBeEnabled());
+  });
+
+  it('disables auto-complete when the server says nothing can move, however tall the pile', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      foundation: [[card('SPADE', 5), card('SPADE', 6), card('SPADE', 7)], [], [], []],
+      canAutoComplete: false,
+    });
+    renderWithProviders(<DuchessPage />);
+    const btn = await screen.findByTestId('autocomplete-button');
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute('title');
+  });
+
+  // 基準ランク未選択の局面は従来どおり押せない (サーバも false を返す)。
+  it('stays disabled while the base rank is still unchosen', async () => {
+    mockExec.mockResolvedValue({ ...playingState, awaitingBaseRank: true, canAutoComplete: false });
+    renderWithProviders(<DuchessPage />);
+    await waitFor(() => expect(screen.getByTestId('autocomplete-button')).toBeDisabled());
   });
 
   it('shows StalemateEscapeButton when the stalemate flag is set', async () => {

--- a/frontend/src/pages/DuchessPage.tsx
+++ b/frontend/src/pages/DuchessPage.tsx
@@ -163,7 +163,10 @@ function DuchessPageContent() {
   const isGameOver = state.phase === DuchessPhase.GAME_OVER;
   const isEnded = isGameClear || isGameOver;
   const foundationCount = isGameOver ? state.foundation.reduce((sum, pile) => sum + pile.length, 0) : 0;
-  const autoCompleteReady = state.foundation.some((pile) => pile.length > 1);
+  // **押せる = 成功する。**組札の枚数で代用していたが、それはドメインの条件では
+  // ない (#5557)。1枚しか乗っていなくても次を送れることがあり、逆に何枚乗っていても
+  // 送れる札が無ければ AutoComplete は失敗する。ドメインの答えをそのまま使う。
+  const autoCompleteReady = state.canAutoComplete ?? false;
   // While any reserve card remains, empty columns are the reserve's exit only.
   const reserveRemaining = state.reserve.reduce((sum, fan) => sum + fan.length, 0);
 

--- a/frontend/src/types/games/duchess.ts
+++ b/frontend/src/types/games/duchess.ts
@@ -39,6 +39,14 @@ export interface DuchessResponse extends BaseGameResponse {
   phase: number;
   moveCount: number;
   canUndo: boolean;
+  /**
+   * Whether auto-complete can move at least one card right now.
+   *
+   * The page used to guess this from foundation pile heights, which is not the
+   * domain's condition: Duchess seeds no foundations, so one card can already be
+   * enough, and a tall pile with nothing to feed it still fails (#5557).
+   */
+  canAutoComplete?: boolean;
   isStalemate: boolean;
   undoToEscape?: number;
   hint?: DuchessHint;

--- a/internal/adapter/controller/DuchessWebController.go
+++ b/internal/adapter/controller/DuchessWebController.go
@@ -49,8 +49,10 @@ type DuchessWebOutput struct {
 	// BaseRank は 4 つの基礎札が始まるランク。0 は「まだ選ばれていない」。
 	BaseRank int `json:"baseRank"`
 	// AwaitingBaseRank が真の間は、リザーブから 1 枚選ぶ以外に何もできない。
-	AwaitingBaseRank bool                  `json:"awaitingBaseRank"`
-	Hint             *DuchessWebOutputHint `json:"hint,omitempty"`
+	AwaitingBaseRank bool `json:"awaitingBaseRank"`
+	// CanAutoComplete は自動送りがいま 1 枚でも動かせるか。ボタンの活性条件に使う (#5557)。
+	CanAutoComplete bool                  `json:"canAutoComplete"`
+	Hint            *DuchessWebOutputHint `json:"hint,omitempty"`
 	SolitaireWebOutputBase
 	WebOutputBase
 }

--- a/internal/adapter/presenter/DuchessWebPresenter.go
+++ b/internal/adapter/presenter/DuchessWebPresenter.go
@@ -65,6 +65,7 @@ func (p *DuchessWebPresenter) Output(d interfaces.DuchessGame, lastErr error) st
 	}
 	resObj.BaseRank = d.GetBaseRank()
 	resObj.AwaitingBaseRank = d.IsAwaitingBaseRank()
+	resObj.CanAutoComplete = d.CanAutoComplete()
 
 	// メッセージ
 	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`

--- a/internal/adapter/presenter/DuchessWebPresenter_test.go
+++ b/internal/adapter/presenter/DuchessWebPresenter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -20,6 +21,7 @@ func setupDuchessWebMockDefaults(g *interfaces.MockDuchessGame) {
 	g.On("CanUndo").Return(false).Maybe()
 	g.On("IsStalemate").Return(false).Maybe()
 	g.On("UndoToEscape").Return(0).Maybe()
+	g.On("CanAutoComplete").Return(false).Maybe()
 	g.On("GetStockCount").Return(35).Maybe()
 	g.On("GetWaste").Return([]*domain.Card{domain.NewCard(domain.CardDesignHeart, 9, true)}).Maybe()
 	g.On("GetBaseRank").Return(5).Maybe()
@@ -227,4 +229,18 @@ func TestDuchessWebPresenter_ActionLogOutput(t *testing.T) {
 
 		assert.Contains(t, new(DuchessWebPresenter).ActionLogOutput(g), "move")
 	})
+}
+
+// #5557: ボタンの活性条件はドメインの答え。組札の枚数から推測すると、
+// 押せるのに拒否される / 押せないのに送れる が起きる。
+func TestDuchessWebPresenter_Output_CarriesCanAutoComplete(t *testing.T) {
+	for _, can := range []bool{true, false} {
+		g := new(interfaces.MockDuchessGame)
+		g.On("CanAutoComplete").Return(can)
+		setupDuchessOutputMock(g)
+
+		var out controller.DuchessWebOutput
+		require.NoError(t, json.Unmarshal([]byte(new(DuchessWebPresenter).Output(g, nil)), &out))
+		assert.Equal(t, can, out.CanAutoComplete)
+	}
 }

--- a/internal/domain/Duchess.go
+++ b/internal/domain/Duchess.go
@@ -528,6 +528,17 @@ func (d *Duchess) AutoComplete() error {
 	return nil
 }
 
+// CanAutoComplete は AutoComplete がいま 1 枚でも動かせるかを返す。
+//
+// **押せる = 成功する、を UI 側で保証するためにある。**ページは
+// 「組札に何枚か乗っているか」で代用していたが、それはドメインの条件ではない。
+// 種札を置かない Duchess では 1 枚しか乗っていなくても次を送れることがあり、
+// 逆に何枚乗っていても送れる札が無ければ AutoComplete は
+// "no card can be auto-completed" で失敗する (#5557)。
+func (d *Duchess) CanAutoComplete() bool {
+	return d.foundationHint() != nil
+}
+
 // Undo 直前の 1 手を取り消す
 func (d *Duchess) Undo() error {
 	if len(d.history) == 0 {

--- a/internal/domain/Duchess_test.go
+++ b/internal/domain/Duchess_test.go
@@ -564,3 +564,47 @@ func TestDuchess_SuitIndexAndRunHelpers(t *testing.T) {
 		{Card: NewCard(CardDesignSpade, 1, true)}, {Card: NewCard(CardDesignHeart, CardValueMax, true)},
 	}), "A then K wraps around")
 }
+
+// #5557: ページは「組札に2枚以上乗っているか」で自動送りボタンを活性化していたが、
+// それはドメインの条件ではない。Duchess は種札を置かないので 1 枚でも次を送れる
+// ことがあり、逆に何枚乗っていても送れる札が無ければ AutoComplete は失敗する。
+func TestDuchess_CanAutoComplete(t *testing.T) {
+	d := NewDuchess(NewTrumpCards(0))
+	d.Reset()
+
+	// 基準ランク未選択のうちは何も送れない。
+	assert.False(t, d.CanAutoComplete(), "基準ランク未選択")
+
+	// 基準ランクを選ぶと、その1枚が組札に乗る。
+	require.NoError(t, d.ChooseBaseRank(0))
+	require.False(t, d.IsAwaitingBaseRank())
+
+	// **CanAutoComplete と AutoComplete の可否が一致すること。**
+	// ここが食い違うと「押せるのに拒否される」か「押せないのに送れる」になる。
+	can := d.CanAutoComplete()
+	err := d.AutoComplete()
+	if can {
+		assert.NoError(t, err)
+	} else {
+		assert.Error(t, err)
+	}
+}
+
+// **どの局面でも一致していること。**1局面の一致は偶然でも起きる。
+func TestDuchess_CanAutoCompleteMatchesAutoComplete(t *testing.T) {
+	for seed := 0; seed < 20; seed++ {
+		d := NewDuchess(NewTrumpCards(0))
+		d.Reset()
+		require.NoError(t, d.ChooseBaseRank(seed%DuchessReserveCnt))
+		for step := 0; step < 5; step++ {
+			can := d.CanAutoComplete()
+			err := d.AutoComplete()
+			if can {
+				require.NoError(t, err, "seed %d step %d", seed, step)
+			} else {
+				require.Error(t, err, "seed %d step %d", seed, step)
+				break
+			}
+		}
+	}
+}

--- a/internal/domain/interfaces/duchess.go
+++ b/internal/domain/interfaces/duchess.go
@@ -53,4 +53,6 @@ type DuchessGame interface {
 	IsStalemate() bool
 	// UndoToEscape 手詰まりから抜けるために必要なアンドゥ回数を取得する
 	UndoToEscape() int
+	// CanAutoComplete いま AutoComplete が 1 枚でも動かせるか (#5557)
+	CanAutoComplete() bool
 }

--- a/internal/domain/interfaces/duchess_mock.go
+++ b/internal/domain/interfaces/duchess_mock.go
@@ -90,6 +90,12 @@ func (_m *MockDuchessGame) UndoToEscape() int {
 	return ret.Int(0)
 }
 
+// CanAutoComplete いま AutoComplete が 1 枚でも動かせるか
+func (_m *MockDuchessGame) CanAutoComplete() bool {
+	ret := _m.Called()
+	return ret.Bool(0)
+}
+
 func (_m *MockDuchessGame) UndoN(n int) error {
 	ret := _m.Called(n)
 	return ret.Error(0)


### PR DESCRIPTION
Closes #5557

`DuchessPage.tsx` の `autoCompleteReady` は `foundation.some(pile => pile.length > 1)`。
これは**種札を置くゲーム由来の閾値**で、Duchess の条件ではない。
Duchess は `Reset()` で `foundation[i] = nil`、プレイヤーが選んだ基準ランクが最初の1枚になる。

- **1枚しか乗っていなくても**次の札がリザーブにあれば送れるのに、ボタンが押せない (issue の指摘)
- 逆に**高く積まれていても**送れる札が無ければ `AutoComplete` は
  `no card can be auto-completed` で失敗する → 押せるのに拒否される
  (#5545 のレビューで指摘されたのと同じ形)

## 直したこと

`Duchess.CanAutoComplete()` を追加。中身は `foundationHint() != nil` で、
**`AutoComplete` 自身が回しているのと同じ判定**。レスポンスに `canAutoComplete` を載せ、
ページはそれをそのまま使う。**「押せる」と「成功する」が同じ条件**になる。

`api/openapi.yaml` にも追加 (CRLF 維持: numstat 5/0)。

## テスト計画

- [x] 基準ランク未選択では false
- [x] **20 デッキ × 5 手** 回して `CanAutoComplete()` と `AutoComplete()` の可否が
      常に一致することを確認 (1局面の一致は偶然でも起きる)
- [x] ページ: サーバが true なら**1枚でも押せる**、false なら**3枚積まれていても押せない**
- [x] 基準ランク未選択の局面は従来どおり押せない
- [x] Web プレゼンタが `canAutoComplete` を載せる
- [x] `golangci-lint` 0 issues / `bun run check` / `typecheck` 緑

### 変異テスト (2件とも検出)

| 変異 | 落ちたアサーション |
|---|---|
| `CanAutoComplete` がヒントを見ずプレイ中なら true | 5 |
| ページが枚数の推測に戻る | 2 |