### PR TITLE
feat(napoleonssquare): show foundation progress while the game is still on

### DIFF
--- a/frontend/src/i18n/locales/en/napoleonssquare.json
+++ b/frontend/src/i18n/locales/en/napoleonssquare.json
@@ -47,5 +47,6 @@
     "controls": "Use the draw, hint, undo, and auto-complete buttons."
   },
   "undo": "Undo",
-  "waste": "Waste"
+  "waste": "Waste",
+  "foundationProgress": "Foundations: {{count}}/{{total}} ({{percent}}%)"
 }

--- a/frontend/src/i18n/locales/ja/napoleonssquare.json
+++ b/frontend/src/i18n/locales/ja/napoleonssquare.json
@@ -47,5 +47,6 @@
     "controls": "めくる・ヒント・元に戻す・自動完成などの操作ボタンです。"
   },
   "undo": "元に戻す",
-  "waste": "捨て札"
+  "waste": "捨て札",
+  "foundationProgress": "収納: {{count}}/{{total}} ({{percent}}%)"
 }

--- a/frontend/src/pages/NapoleonsSquarePage.test.tsx
+++ b/frontend/src/pages/NapoleonsSquarePage.test.tsx
@@ -323,3 +323,33 @@ describe('NapoleonsSquarePage keyboard shortcuts', () => {
     expect(mockExec).not.toHaveBeenCalled();
   });
 });
+
+// #5554: 勝利条件は 8 つの組札を積み切ることなのに、その進捗はゲームオーバーに
+// なるまで見えず、ヘッダーには無関係な手数しか出ていなかった。
+describe('NapoleonsSquarePage foundation progress', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useGameHint).mockReturnValue({ hint: null, hintEnabled: false, setHintEnabled: vi.fn() });
+  });
+
+  it('shows the count and percentage during play', async () => {
+    // 8 山にエース + 1 山に 2 枚目 = 9 枚 / 104 = 9%。
+    mockExec.mockResolvedValue({
+      ...playingState,
+      foundation: [[card('SPADE', 1), card('SPADE', 2)], ...aces.slice(1)],
+    });
+    renderWithProviders(<NapoleonsSquarePage />);
+    const progress = await screen.findByTestId('ns-foundation-progress');
+    expect(progress).toHaveTextContent('9/104');
+    expect(progress).toHaveTextContent('9%');
+  });
+
+  it('tracks the foundations rather than the move count', async () => {
+    mockExec.mockResolvedValue({ ...playingState, moveCount: 77 });
+    renderWithProviders(<NapoleonsSquarePage />);
+    const progress = await screen.findByTestId('ns-foundation-progress');
+    // 8 枚のエースだけ = 8/104 (8%)。手数 77 とは無関係。
+    expect(progress).toHaveTextContent('8/104');
+    expect(progress).not.toHaveTextContent('77');
+  });
+});

--- a/frontend/src/pages/NapoleonsSquarePage.tsx
+++ b/frontend/src/pages/NapoleonsSquarePage.tsx
@@ -166,8 +166,10 @@ function NapoleonsSquarePageContent() {
   const isGameClear = state.phase === NapoleonsSquarePhase.GAME_CLEAR;
   const isGameOver = state.phase === NapoleonsSquarePhase.GAME_OVER;
   const isEnded = isGameClear || isGameOver;
-  // Only needed on game over, so skip the reduce during normal play.
-  const foundationCount = isGameOver ? state.foundation.reduce((sum, pile) => sum + pile.length, 0) : 0;
+  // 勝利条件は 8 つの組札を積み切ること。その進捗がゲームが終わるまで見えず、
+  // ヘッダーには無関係な手数しか出ていなかった (#5554)。プレイ中も数える。
+  const foundationCount = state.foundation.reduce((sum, pile) => sum + pile.length, 0);
+  const foundationPercent = Math.round((foundationCount / TOTAL_CARDS) * 100);
   // Every foundation starts seeded with its Ace, so "progress" means a pile grew
   // past that — that is when auto-complete is worth pulsing.
   const autoCompleteReady = state.foundation.some((pile) => pile.length > 1);
@@ -277,6 +279,13 @@ function NapoleonsSquarePageContent() {
         <>
           <span className="text-sm text-ds-text-muted">
             {t('moveCount')}: {state.moveCount}
+          </span>
+          <span className="text-sm text-ds-text-muted" data-testid="ns-foundation-progress">
+            {t('foundationProgress', {
+              count: foundationCount,
+              total: TOTAL_CARDS,
+              percent: foundationPercent,
+            })}
           </span>
           <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
         </>
@@ -410,10 +419,7 @@ function NapoleonsSquarePageContent() {
 
             {isGameOver && (
               <p data-testid="ns-gameover-summary" className="text-ds-text-muted text-sm text-center mt-1">
-                {t('gameOverSummary', {
-                  count: foundationCount,
-                  percent: Math.round((foundationCount / TOTAL_CARDS) * 100),
-                })}
+                {t('gameOverSummary', { count: foundationCount, percent: foundationPercent })}
               </p>
             )}
 

--- a/internal/adapter/presenter/NapoleonsSquareCuiPresenter.go
+++ b/internal/adapter/presenter/NapoleonsSquareCuiPresenter.go
@@ -13,6 +13,20 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
+// napoleonsSquareProgressStr は組札に収まっている枚数と割合を返す。
+func napoleonsSquareProgressStr(ns interfaces.NapoleonsSquareGame) string {
+	count := 0
+	for _, pile := range ns.GetFoundation() {
+		count += len(pile)
+	}
+	return i18n.Tf("napoleonssquare.foundationProgress",
+		"count", strconv.Itoa(count),
+		"total", strconv.Itoa(domain.NapoleonsSquareTotalCards),
+		// **Web と同じ丸め。**切り捨てにすると 9/104 が 8% と 9% に割れて、
+		// 同じ局面で 2 つの進捗が出る。
+		"percent", strconv.Itoa((count*100+domain.NapoleonsSquareTotalCards/2)/domain.NapoleonsSquareTotalCards))
+}
+
 // napoleonsSquareColumnStr returns the display string for one tableau column.
 func napoleonsSquareColumnStr(colCards []*domain.NapoleonsSquareTableauCard) string {
 	parts := make([]string, len(colCards))
@@ -89,6 +103,9 @@ func (p *NapoleonsSquareCuiPresenter) Output(ns interfaces.NapoleonsSquareGame, 
 			}
 			b.WriteString(i18n.Tf("cuiSolitaireMoves",
 				"count", strconv.Itoa(ns.GetMoveCount())) + "\n")
+			// 勝利条件は 8 つの組札を積み切ること。その進捗が、ゲームが終わるまで
+			// どちらの UI にも出ていなかった (#5554)。
+			b.WriteString(napoleonsSquareProgressStr(ns) + "\n")
 		case domain.NapoleonsSquarePhaseGameClear:
 			b.WriteString(color.Green(i18n.T("cuiSolitaireGameClear")) + " " +
 				i18n.Tf("cuiSolitaireMoves", "count", strconv.Itoa(ns.GetMoveCount())) + "\n")

--- a/internal/adapter/presenter/NapoleonsSquareCuiPresenter_test.go
+++ b/internal/adapter/presenter/NapoleonsSquareCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter
 
 import (
 	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -188,4 +189,24 @@ func TestNapoleonsSquareCuiPresenter_ActionLogOutput(t *testing.T) {
 
 		assert.Contains(t, new(NapoleonsSquareCuiPresenter).ActionLogOutput(g), "move")
 	})
+}
+
+// #5554: 勝利条件は 8 つの組札を積み切ることなのに、進捗 (収納枚数) は
+// ゲームオーバーになるまでどちらの UI にも出ていなかった。
+func TestNapoleonsSquareCuiPresenter_Output_FoundationProgress(t *testing.T) {
+	g := new(interfaces.MockNapoleonsSquareGame)
+	// 8 山に 1 枚ずつ + 1 山に 2 枚目 = 9 枚。先に登録した期待が優先される。
+	var f [domain.NapoleonsSquareFoundationCnt][]*domain.Card
+	for i := range domain.NapoleonsSquareFoundationCnt {
+		f[i] = []*domain.Card{domain.NewCard(domain.CardDesignSpade, 1, false)}
+	}
+	f[0] = append(f[0], domain.NewCard(domain.CardDesignSpade, 2, false))
+	g.On("GetFoundation").Return(f)
+	setupNapoleonsSquareCuiMockDefaults(g)
+
+	out := new(NapoleonsSquareCuiPresenter).Output(g, nil)
+	assert.Contains(t, out, i18n.Tf("napoleonssquare.foundationProgress",
+		"count", "9",
+		"total", strconv.Itoa(domain.NapoleonsSquareTotalCards),
+		"percent", "9"))
 }

--- a/internal/domain/NapoleonsSquare.go
+++ b/internal/domain/NapoleonsSquare.go
@@ -676,8 +676,12 @@ func (ns *NapoleonsSquare) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// napoleonsSquareTotalCards 2 デッキ分の総枚数
-const napoleonsSquareTotalCards = CardCnt * 2
+// NapoleonsSquareTotalCards 2 デッキ分の総枚数。勝利は 8 つの組札にこの枚数を
+// 積み切ることなので、進捗の分母そのもの (#5554)。
+const NapoleonsSquareTotalCards = CardCnt * 2
+
+// napoleonsSquareTotalCards は旧名。内部の境界チェックが使う。
+const napoleonsSquareTotalCards = NapoleonsSquareTotalCards
 
 // UnmarshalJSON KV スナップショットからの復元。KV には以前のバージョンが書いた任意の
 // バイト列が入りうるので、壊れた状態でゲームを開始させないよう値域を検証する。

--- a/internal/i18n/locales/en/napoleonssquare.json
+++ b/internal/i18n/locales/en/napoleonssquare.json
@@ -28,5 +28,6 @@
   "hintLine": "Hint: {{from}} → {{to}}",
   "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)",
   "helpExampleHint": "  h                        ask for a move",
-  "helpExampleAuto": "  ac                       send everything that can go to a foundation"
+  "helpExampleAuto": "  ac                       send everything that can go to a foundation",
+  "foundationProgress": "On foundations: {{count}}/{{total}} ({{percent}}%)"
 }

--- a/internal/i18n/locales/ja/napoleonssquare.json
+++ b/internal/i18n/locales/ja/napoleonssquare.json
@@ -28,5 +28,6 @@
   "hintLine": "ヒント: {{from}} → {{to}}",
   "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）",
   "helpExampleHint": "  h                        次の一手を教えてもらう",
-  "helpExampleAuto": "  ac                       組札へ送れる札を自動で送る"
+  "helpExampleAuto": "  ac                       組札へ送れる札を自動で送る",
+  "foundationProgress": "収納: {{count}}/{{total}} 枚 ({{percent}}%)"
 }


### PR DESCRIPTION
Closes #5554

勝利条件は **8 つの組札に 104 枚を積み切ること**。ところが `foundationCount` は
`isGameOver ? reduce(...) : 0` で、**ゲームオーバー時にしか計算していなかった**。
プレイ中のヘッダーに出るのは手数だけで、進み具合がまったく見えない。

## 直したこと

- Web: ヘッダーの手数の隣に `収納: 9/104 (9%)` を常時表示
- CUI: Playing 分岐に同じ集計を出力
- **CUI は Web と同じ丸め** (`Math.round` 相当)。切り捨てだと同じ 9 枚が
  8% と 9% に割れて、同じ局面で 2 つの進捗が出る
- ゲームオーバー時の `ns-gameover-summary` は**同じ値を使い回すだけ**で表示は不変
  (既存テスト `counts the summary against 104 cards, not 52` が守っている)

## テスト計画

- [x] Web: 9 枚で `9/104` と `9%`
- [x] **手数ではなく組札を数えている**こと (手数 77 でも `8/104`)
- [x] CUI: `収納: 9/104 枚 (9%)`
- [x] `golangci-lint` 0 issues / `bun run check` / `typecheck` 緑

### 変異テスト (2件とも検出)

| 変異 | 落ちたテスト |
|---|---|
| ページが手数を数える | 3 |
| CUI が切り捨てる (Web と食い違う) | 1 |