### PR TITLE
fix(grandfathersclock): keep a finished clock face readable

### DIFF
--- a/frontend/src/pages/GrandfathersClockPage.test.tsx
+++ b/frontend/src/pages/GrandfathersClockPage.test.tsx
@@ -116,13 +116,46 @@ describe('GrandfathersClockPage', () => {
   });
 
   // A finished face accepts nothing more, so it must not be a click target.
-  it('disables a completed face as a destination', async () => {
+  //
+  // #5555: ただし native `disabled` はアクセシビリティツリーからボタンごと
+  // 外すので、目標ランクと枚数を含む faceAriaLabel が読み上げられなくなる。
+  // フォーカスは残したまま `aria-disabled` で拒否する。
+  it('marks a completed face aria-disabled but keeps it focusable', async () => {
     mockExec.mockResolvedValue({
       ...playingState,
       foundation: faces.map((f, i) => ({ ...f, complete: i === 0 })),
     });
     renderWithProviders(<GrandfathersClockPage />);
-    await waitFor(() => expect(screen.getByLabelText(/文字盤0 \(1時\)/)).toBeDisabled());
+    // 移動元を選ぶまでは「選択待ち」で全部の文字盤が native disabled。
+    // 完成した文字盤だけが別の理由で拒否されることを見たいので、まず選ぶ。
+    const source = await screen.findByRole('button', { name: /^♠ 6（/ });
+    fireEvent.click(source);
+    await waitFor(() => expect(source).toHaveAttribute('aria-pressed', 'true'));
+
+    const face = screen.getByLabelText(/文字盤0 \(1時\)/);
+    expect(face).toHaveAttribute('aria-disabled', 'true');
+    expect(face).not.toBeDisabled();
+    // ラベルは読み上げ可能なまま (目標ランクと枚数を含む)。
+    expect(face.getAttribute('aria-label')).toMatch(/1時/);
+  });
+
+  // **拒否は維持する。**フォーカスできることと、動かせることは別。
+  it('does not move a card onto a completed face', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      foundation: faces.map((f, i) => ({ ...f, complete: i === 0 })),
+    });
+    renderWithProviders(<GrandfathersClockPage />);
+    const source = await screen.findByRole('button', { name: /^♠ 6（/ });
+    fireEvent.click(source);
+    await waitFor(() => expect(source).toHaveAttribute('aria-pressed', 'true'));
+    mockExec.mockClear();
+
+    fireEvent.click(screen.getByLabelText(/文字盤0 \(1時\)/));
+    // ヒントなど別の呼び出しが挟まっても、move だけは飛ばない。
+    fireEvent.click(screen.getByLabelText(/文字盤4 \(5時\)/));
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(mockExec).not.toHaveBeenCalledWith('move', expect.anything(), { zone: 'foundation', col: 0 });
   });
 
   it('sends the face index with the move', async () => {

--- a/frontend/src/pages/GrandfathersClockPage.tsx
+++ b/frontend/src/pages/GrandfathersClockPage.tsx
@@ -296,8 +296,16 @@ function GrandfathersClockPageContent() {
                       {top ? (
                         <button
                           type="button"
-                          onClick={() => game.handleSelectTarget(faceZone)}
-                          disabled={!isPlaying || loading || isAutoCompleting || !selectedSource || face.complete}
+                          // 完成した文字盤は受け取らないが、**フォーカスは残す**。
+                          // native disabled はアクセシビリティツリーからボタンごと
+                          // 外すので、目標ランクと枚数を含む faceAriaLabel が
+                          // 読み上げられなくなる (#5555)。
+                          onClick={() => {
+                            if (face.complete) return;
+                            game.handleSelectTarget(faceZone);
+                          }}
+                          disabled={!isPlaying || loading || isAutoCompleting || !selectedSource}
+                          aria-disabled={face.complete || undefined}
                           aria-label={t('faceAriaLabel', {
                             idx,
                             hour: CLOCK_HOURS[idx],


### PR DESCRIPTION
Closes #5555

完成した文字盤のボタンに native `disabled` が付いていた。**native disabled は
アクセシビリティツリーからボタンごと外す**ので、時刻・目標ランク・枚数を含む
`faceAriaLabel` が読み上げられなくなる。「この面は何で終わったのか」を
確認したい場面で、ちょうど読めなくなっていた。

## 直したこと

`face.complete` のときは `aria-disabled="true"` + クリックハンドラのガードにする。
**拒否は維持**したままフォーカスとラベルが残る。

他の非活性理由 (プレイ中でない / 通信中 / 移動元未選択) は **native のまま** —
それらのボタンには読み上げるべき固有の情報が無い。

## テスト計画

- [x] 完成した文字盤が `aria-disabled="true"` で、**native disabled ではない**
- [x] ラベル (時刻を含む) が読める
- [x] **完成した文字盤には移動しない** (`move` が飛ばない)
- [x] 既存 24 件緑 / `bun run check` / `typecheck` 緑

### 変異テスト (2件とも検出)

| 変異 | 落ちたテスト |
|---|---|
| native disabled に戻す | 1 |
| クリックガードを外す (完成面が有効な移動先になる) | 1 |