### PR TITLE
feat(windmill): say that an empty corner takes kings only

### DIFF
--- a/internal/adapter/presenter/WindmillCuiPresenter.go
+++ b/internal/adapter/presenter/WindmillCuiPresenter.go
@@ -41,7 +41,9 @@ func (p *WindmillCuiPresenter) Output(w interfaces.WindmillGame, lastErr error) 
 			pile := corners[i]
 			b.WriteString("#" + strconv.Itoa(i) + " ")
 			if len(pile) == 0 {
-				b.WriteString(i18n.T("cuiEmptyCol"))
+				// 四隅は K しか受け取らない。この固有ルールが CUI では出力にも
+				// ヘルプにも無く、試行錯誤でしか学べなかった (#5558)。
+				b.WriteString(i18n.T("cuiEmptyCol") + i18n.T("windmill.cornerKingsOnly"))
 			} else {
 				b.WriteString(i18n.Tf("windmill.pileEntry",
 					"card", cuiCardStr(pile[len(pile)-1]),

--- a/internal/adapter/presenter/WindmillCuiPresenter_test.go
+++ b/internal/adapter/presenter/WindmillCuiPresenter_test.go
@@ -186,3 +186,23 @@ func TestWindmillCuiPresenter_ActionLogOutput(t *testing.T) {
 		assert.Contains(t, new(WindmillCuiPresenter).ActionLogOutput(g), "move")
 	})
 }
+
+// #5558: 四隅は K しか受け取らないというウィンドミル固有のルールが、CUI では
+// 出力にもヘルプにも出ておらず、試行錯誤でしか学べなかった。
+func TestWindmillCuiPresenter_Output_EmptyCornerSaysKingsOnly(t *testing.T) {
+	g := new(interfaces.MockWindmillGame)
+	setupWindmillCuiMockDefaults(g)
+
+	out := new(WindmillCuiPresenter).Output(g, nil)
+	assert.Contains(t, out, i18n.T("windmill.cornerKingsOnly"))
+
+	// **埋まっている四隅の表示は変えない。**カードが乗っていれば規則は自明。
+	filled := new(interfaces.MockWindmillGame)
+	var corners [domain.WindmillCornerCnt][]*domain.Card
+	for i := range domain.WindmillCornerCnt {
+		corners[i] = []*domain.Card{domain.NewCard(domain.CardDesignSpade, 13, true)}
+	}
+	filled.On("GetCorners").Return(corners)
+	setupWindmillCuiMockDefaults(filled)
+	assert.NotContains(t, new(WindmillCuiPresenter).Output(filled, nil), i18n.T("windmill.cornerKingsOnly"))
+}

--- a/internal/i18n/locales/en/windmill.json
+++ b/internal/i18n/locales/en/windmill.json
@@ -36,5 +36,6 @@
   "hintLine": "Hint: {{from}} → {{to}}",
   "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)",
   "helpExampleHint": "  h                        ask for a move",
-  "helpExampleAuto": "  ac                       send everything that can go to a foundation"
+  "helpExampleAuto": "  ac                       send everything that can go to a foundation",
+  "cornerKingsOnly": " (kings only)"
 }

--- a/internal/i18n/locales/ja/windmill.json
+++ b/internal/i18n/locales/ja/windmill.json
@@ -37,5 +37,5 @@
   "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）",
   "helpExampleHint": "  h                        次の一手を教えてもらう",
   "helpExampleAuto": "  ac                       組札へ送れる札を自動で送る",
-  "cornerKingsOnly": "(Kのみ)"
+  "cornerKingsOnly": " (Kのみ)"
 }

--- a/internal/i18n/locales/ja/windmill.json
+++ b/internal/i18n/locales/ja/windmill.json
@@ -36,5 +36,6 @@
   "hintLine": "ヒント: {{from}} → {{to}}",
   "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）",
   "helpExampleHint": "  h                        次の一手を教えてもらう",
-  "helpExampleAuto": "  ac                       組札へ送れる札を自動で送る"
+  "helpExampleAuto": "  ac                       組札へ送れる札を自動で送る",
+  "cornerKingsOnly": "(Kのみ)"
 }


### PR DESCRIPTION
Closes #5558

Web は空の四隅に `K のみ` を出し、`emptyCornerAriaLabel` にも書いている。CUI は
共通の「空」しか出さず、**四隅は K しか受け取らない**というウィンドミル固有の規則が
出力にもヘルプにも無かった。ソリティアの一般則ではないので、拒否されて初めて分かる。

## 直したこと

空の四隅の表示に `(Kのみ)` を足した (ja/en)。

**埋まっている四隅は変更しない** — 札が乗っていれば規則を繰り返す必要はない。

## テスト計画

- [x] 空の四隅に文言が出る
- [x] **埋まっている四隅には出ない** (負のコントロール)
- [x] 既存の Windmill CUI テスト緑 / `golangci-lint` 0 issues

### 変異テスト (2件とも検出)

| 変異 | 落ちたアサーション |
|---|---|
| 埋まっている四隅にも出す | 2 |
| 文言を出さない | 1 |