### PR TITLE
feat(americantoad): ring the columns and foundations a card can go to

### DIFF
--- a/frontend/src/pages/AmericanToadPage.test.tsx
+++ b/frontend/src/pages/AmericanToadPage.test.tsx
@@ -352,9 +352,9 @@ describe('AmericanToadPage destination highlight', () => {
     fireEvent.click(source);
     await waitFor(() => expect(source).toHaveAttribute('aria-pressed', 'true'));
 
-    // ♠9 の列 (index 1) だけがリング。空列はリザーブが空なので全部合法。
-    const legal = [...targets()].length;
-    expect(legal).toBeGreaterThan(0);
+    // ♠9 の列 (index 1) **だけ**がリング。♣4 は不一致、空列はタブロー由来の札を
+    // 受け取らない (下の回帰テスト)。
+    expect(targets()).toHaveLength(1);
     expect(document.querySelector('[data-preview-target]')).toBeNull();
   });
 
@@ -412,5 +412,36 @@ describe('AmericanToadPage destination highlight', () => {
     await waitFor(() => expect(source).toHaveAttribute('aria-pressed', 'true'));
     // 空列は 7 つあるが、どれも光らない。♠8 の下に置ける札も無い。
     expect(targets()).toHaveLength(0);
+  });
+
+  // **リザーブが尽きても、空列はタブロー由来の札には開かない。**
+  // `MoveTableauToTableau` が拒む (#4417) ので、光らせると押して弾かれる —
+  // このPRが消そうとしているループそのものが残る。
+  it('does not offer an empty column to a tableau card once the reserve is gone', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      reserve: [],
+      tableau: makeTableau([[{ card: card('SPADE', 8), faceUp: true }]]),
+    });
+    renderWithProviders(<AmericanToadPage />);
+    const source = await screen.findByRole('button', { name: /♠ 8/ });
+    fireEvent.click(source);
+    await waitFor(() => expect(source).toHaveAttribute('aria-pressed', 'true'));
+    expect(targets()).toHaveLength(0);
+  });
+
+  // 負のコントロール: 同じ空列が、捨て札からなら開く。上のテストが
+  // 「空列を常に光らせない」だけの実装でも通ってしまわないこと。
+  it('does offer those empty columns to the waste card', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      reserve: [],
+      waste: [card('DIAMOND', 9)],
+      tableau: makeTableau([[{ card: card('SPADE', 8), faceUp: true }]]),
+    });
+    renderWithProviders(<AmericanToadPage />);
+    const waste = await screen.findByRole('button', { name: /♦ 9/ });
+    fireEvent.click(waste);
+    await waitFor(() => expect(targets().length).toBeGreaterThan(0));
   });
 });

--- a/frontend/src/pages/AmericanToadPage.test.tsx
+++ b/frontend/src/pages/AmericanToadPage.test.tsx
@@ -329,3 +329,60 @@ describe('AmericanToadPage keyboard shortcuts', () => {
     expect(mockExec).not.toHaveBeenCalled();
   });
 });
+
+// #5559: 8列 + 8基礎札 + リザーブ + 捨て札と候補が多いのに、どこに置けるかは
+// クリックしてサーバーのエラーを見るまで分からなかった。
+describe('AmericanToadPage destination highlight', () => {
+  const targets = () => document.querySelectorAll('[data-legal-target]');
+
+  it('rings the legal column once a card is selected', async () => {
+    // ♠8 を選ぶと ♠9 の上には置けない (降順なので ♠7 が要る) が、
+    // 別の列の ♣4 の上でもない。合法な列だけが光ること。
+    mockExec.mockResolvedValue({
+      ...playingState,
+      reserve: [],
+      tableau: makeTableau([
+        [{ card: card('SPADE', 8), faceUp: true }],
+        [{ card: card('SPADE', 9), faceUp: true }],
+        [{ card: card('CLOVER', 4), faceUp: true }],
+      ]),
+    });
+    renderWithProviders(<AmericanToadPage />);
+    const source = await screen.findByRole('button', { name: /♠ 8/ });
+    fireEvent.click(source);
+    await waitFor(() => expect(source).toHaveAttribute('aria-pressed', 'true'));
+
+    // ♠9 の列 (index 1) だけがリング。空列はリザーブが空なので全部合法。
+    const legal = [...targets()].length;
+    expect(legal).toBeGreaterThan(0);
+    expect(document.querySelector('[data-preview-target]')).toBeNull();
+  });
+
+  // **判定を二重に持たない。**hover のプレビューも同じ計算を通る。
+  it('previews the same targets on hover, marked as a preview', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      reserve: [],
+      tableau: makeTableau([[{ card: card('SPADE', 8), faceUp: true }], [{ card: card('SPADE', 9), faceUp: true }]]),
+    });
+    renderWithProviders(<AmericanToadPage />);
+    const source = await screen.findByRole('button', { name: /♠ 8/ });
+    fireEvent.mouseEnter(source);
+    await waitFor(() => expect(document.querySelector('[data-preview-target]')).not.toBeNull());
+  });
+
+  // **リザーブが残っている間は空列を光らせない。**自動補充の対象で、手では置けない。
+  it('does not offer an empty column while the reserve holds cards', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      reserve: [card('CLOVER', 3)],
+      tableau: makeTableau([[{ card: card('SPADE', 8), faceUp: true }]]),
+    });
+    renderWithProviders(<AmericanToadPage />);
+    const source = await screen.findByRole('button', { name: /♠ 8/ });
+    fireEvent.click(source);
+    await waitFor(() => expect(source).toHaveAttribute('aria-pressed', 'true'));
+    // 空列は 7 つあるが、どれも光らない。♠8 の下に置ける札も無い。
+    expect(targets()).toHaveLength(0);
+  });
+});

--- a/frontend/src/pages/AmericanToadPage.test.tsx
+++ b/frontend/src/pages/AmericanToadPage.test.tsx
@@ -371,6 +371,34 @@ describe('AmericanToadPage destination highlight', () => {
     await waitFor(() => expect(document.querySelector('[data-preview-target]')).not.toBeNull());
   });
 
+  // 山札由来の札 (捨て札) を選んでも同じ判定を通る。ページの previewedCard は
+  // ゾーンごとに分岐しているので、tableau 以外も一度通しておく。
+  it('highlights targets for the waste card too', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      reserve: [],
+      waste: [card('SPADE', 7)],
+      tableau: makeTableau([[{ card: card('SPADE', 8), faceUp: true }]]),
+    });
+    renderWithProviders(<AmericanToadPage />);
+    const waste = await screen.findByRole('button', { name: /♠ 7/ });
+    fireEvent.click(waste);
+    await waitFor(() => expect(document.querySelectorAll('[data-legal-target]').length).toBeGreaterThan(0));
+  });
+
+  // リザーブの札を選んだときも同じ。
+  it('highlights targets for the reserve card too', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      reserve: [card('SPADE', 7)],
+      tableau: makeTableau([[{ card: card('SPADE', 8), faceUp: true }]]),
+    });
+    renderWithProviders(<AmericanToadPage />);
+    const reserve = await screen.findByRole('button', { name: /リザーブ 残り/ });
+    fireEvent.click(reserve);
+    await waitFor(() => expect(document.querySelectorAll('[data-legal-target]').length).toBeGreaterThan(0));
+  });
+
   // **リザーブが残っている間は空列を光らせない。**自動補充の対象で、手では置けない。
   it('does not offer an empty column while the reserve holds cards', async () => {
     mockExec.mockResolvedValue({

--- a/frontend/src/pages/AmericanToadPage.tsx
+++ b/frontend/src/pages/AmericanToadPage.tsx
@@ -22,14 +22,16 @@ import { useAmericanToadGame } from '../hooks/useAmericanToadGame';
 import { useCardDimensions, useWindowWidth } from '../hooks/useCardDimensions';
 import { useCliGame } from '../hooks/useCliGame';
 import { useCliMode } from '../hooks/useCliMode';
+import { useDestinationPreview } from '../hooks/useDestinationPreview';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { AmericanToadMoveZone, AmericanToadResponse } from '../types/card';
+import type { AmericanToadMoveZone, AmericanToadResponse, Card } from '../types/card';
 import { AmericanToadPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { americanToadLegalTargets } from '../utils/americanToadLegalTargets';
 import { cardAlt } from '../utils/cardAlt';
 import { AMERICANTOAD_HELP, parseAmericanToadCommand } from '../utils/cli/commands/americantoadCommands';
 import { formatAmericanToadState } from '../utils/cli/formatters/americantoadFormatter';
@@ -153,6 +155,10 @@ function AmericanToadPageContent() {
 
   useActionKeyboardNav({ bindings: actionBindings, enabled: !!isPlayingForKbd && !loading });
 
+  // **フックは早期 return より前に。**移動先プレビューは選択状態しか見ないので、
+  // state が null の初回描画でも安全に呼べる。
+  const preview = useDestinationPreview<AmericanToadMoveZone>(selectedSource);
+
   if (!state) {
     return <GameSkeleton gameKey="americantoad" layout={{ kind: 'tableau', topRow: 8, tableau: TABLEAU_COLS }} />;
   }
@@ -170,6 +176,34 @@ function AmericanToadPageContent() {
   // The stock button doubles as the redeal once the stock runs out.
   const stockActs = state.stockCount > 0 || state.canRedeal;
 
+  // **選択後は押すまで正誤が分からず、クリック→サーバーエラーのループになる
+  // (#5559)。**8列 + 8基礎札 + リザーブ + 捨て札と候補が多く、基礎札は同スート
+  // 2つずつという構造なので、なおさら分かりにくい。
+  //
+  // hover / フォーカス中の札にも**まったく同じ計算**を当てる ── 判定を二重に
+  // 持たないので、プレビューと選択後の表示が食い違わない。
+  const previewSource = preview.source;
+  const previewedCard = ((): Card | undefined => {
+    if (!previewSource) return undefined;
+    if (previewSource.zone === 'reserve') return reserveTop ?? undefined;
+    if (previewSource.zone === 'waste') return state.waste[state.waste.length - 1];
+    if (previewSource.zone === 'tableau' && previewSource.col !== undefined) {
+      const pile = state.tableau[previewSource.col] ?? [];
+      const idx = previewSource.cardIndex ?? pile.length - 1;
+      return pile[idx]?.card ?? undefined;
+    }
+    return undefined;
+  })();
+  const legalTargets = americanToadLegalTargets(
+    state.tableau,
+    state.foundation,
+    state.reserve,
+    state.baseRank,
+    previewedCard,
+  );
+  /** Ring for a legal destination: softer while it is only a hover preview. */
+  const targetRing = preview.isPreview ? ' rounded ring-2 ring-ds-success/70' : ' rounded ring-2 ring-ds-success';
+
   const isSourceSelected = (zone: string, col?: number, cardIndex?: number) =>
     selectedSource !== null &&
     selectedSource.zone === zone &&
@@ -180,7 +214,12 @@ function AmericanToadPageContent() {
     const col = state.tableau[colIdx] ?? [];
     const tableauColZone: AmericanToadMoveZone = { zone: 'tableau', col: colIdx };
     return (
-      <div key={`col-${colIdx.toString()}`} className="flex-1 min-w-0">
+      <div
+        key={`col-${colIdx.toString()}`}
+        className={`flex-1 min-w-0${legalTargets.tableau.has(colIdx) ? targetRing : ''}`}
+        data-legal-target={legalTargets.tableau.has(colIdx) ? 'true' : undefined}
+        data-preview-target={legalTargets.tableau.has(colIdx) && preview.isPreview ? 'true' : undefined}
+      >
         <div className="text-center text-xs text-ds-text-muted mb-0.5" aria-hidden="true">
           #{colIdx}
         </div>
@@ -234,6 +273,7 @@ function AmericanToadPageContent() {
                         draggable={isPlaying && !loading}
                         onDragStart={dnd.handleDragStart(cardZone)}
                         onDragEnd={dnd.handleDragEnd}
+                        {...preview.previewProps(cardZone)}
                         className={`p-0 border-0 bg-transparent w-full rounded cursor-pointer ${focusRingWhite} ${isSelected ? 'ring-2 ring-ds-warning' : ''} ${dnd.isDragSource(cardZone) ? 'opacity-50' : ''}`}
                       >
                         <AnimatedCard
@@ -307,6 +347,7 @@ function AmericanToadPageContent() {
                     draggable={isPlaying && !loading}
                     onDragStart={dnd.handleDragStart(reserveZone)}
                     onDragEnd={dnd.handleDragEnd}
+                    {...preview.previewProps(reserveZone)}
                     className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${isSourceSelected('reserve', undefined, undefined) ? 'ring-2 ring-ds-warning' : ''}`}
                   >
                     <AnimatedCard card={reserveTop} width={dims.cw} draggable={false} />
@@ -328,7 +369,12 @@ function AmericanToadPageContent() {
                 {state.foundation.map((pile, idx) => {
                   const foundationZone: AmericanToadMoveZone = { zone: 'foundation', col: idx };
                   return (
-                    <div key={`f-${idx.toString()}`} className="text-center">
+                    <div
+                      key={`f-${idx.toString()}`}
+                      className={`text-center${legalTargets.foundation.has(idx) ? targetRing : ''}`}
+                      data-legal-target={legalTargets.foundation.has(idx) ? 'true' : undefined}
+                      data-preview-target={legalTargets.foundation.has(idx) && preview.isPreview ? 'true' : undefined}
+                    >
                       <div className="text-game-text-muted text-xs mb-1">{FOUNDATION_SUITS[idx]}</div>
                       <DropZone
                         isDropTarget={dnd.isDropTarget(foundationZone)}

--- a/frontend/src/pages/AmericanToadPage.tsx
+++ b/frontend/src/pages/AmericanToadPage.tsx
@@ -28,10 +28,10 @@ import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { AmericanToadMoveZone, AmericanToadResponse, Card } from '../types/card';
+import type { AmericanToadMoveZone, AmericanToadResponse } from '../types/card';
 import { AmericanToadPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
-import { americanToadLegalTargets } from '../utils/americanToadLegalTargets';
+import { americanToadLegalTargets, americanToadSourceCard } from '../utils/americanToadLegalTargets';
 import { cardAlt } from '../utils/cardAlt';
 import { AMERICANTOAD_HELP, parseAmericanToadCommand } from '../utils/cli/commands/americantoadCommands';
 import { formatAmericanToadState } from '../utils/cli/formatters/americantoadFormatter';
@@ -183,23 +183,14 @@ function AmericanToadPageContent() {
   // hover / フォーカス中の札にも**まったく同じ計算**を当てる ── 判定を二重に
   // 持たないので、プレビューと選択後の表示が食い違わない。
   const previewSource = preview.source;
-  const previewedCard = ((): Card | undefined => {
-    if (!previewSource) return undefined;
-    if (previewSource.zone === 'reserve') return reserveTop ?? undefined;
-    if (previewSource.zone === 'waste') return state.waste[state.waste.length - 1];
-    if (previewSource.zone === 'tableau' && previewSource.col !== undefined) {
-      const pile = state.tableau[previewSource.col] ?? [];
-      const idx = previewSource.cardIndex ?? pile.length - 1;
-      return pile[idx]?.card ?? undefined;
-    }
-    return undefined;
-  })();
+  const previewedCard = americanToadSourceCard(state.tableau, state.reserve, state.waste, previewSource);
   const legalTargets = americanToadLegalTargets(
     state.tableau,
     state.foundation,
     state.reserve,
     state.baseRank,
     previewedCard,
+    previewSource?.zone,
   );
   /** Ring for a legal destination: softer while it is only a hover preview. */
   const targetRing = preview.isPreview ? ' rounded ring-2 ring-ds-success/70' : ' rounded ring-2 ring-ds-success';

--- a/frontend/src/utils/americanToadLegalTargets.test.ts
+++ b/frontend/src/utils/americanToadLegalTargets.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { AmericanToadTableauCard, Card, CardDesign } from '../types/card';
-import { americanToadLegalTargets } from './americanToadLegalTargets';
+import { americanToadLegalTargets, americanToadSourceCard } from './americanToadLegalTargets';
 
 const card = (design: CardDesign, value: number): Card => ({ design, value }) as Card;
 const col = (...cards: Card[]): AmericanToadTableauCard[] => cards.map((c) => ({ card: c, faceUp: true }));
@@ -47,6 +47,34 @@ describe('americanToadLegalTargets', () => {
     expect(noReserve.tableau.size).toBe(8);
   });
 
+  // **空列はタブロー同士の組み替えでは埋められない** — リザーブと捨て札の出口
+  // だから (`MoveTableauToTableau`, #4417)。出どころを渡さないと表現できない。
+  it('never offers an empty column to a card coming from another column', () => {
+    const fromTableau = americanToadLegalTargets(
+      emptyTableau(),
+      emptyFoundations(),
+      [],
+      5,
+      card('HEART', 4),
+      'tableau',
+    );
+    expect(fromTableau.tableau.size).toBe(0);
+
+    // 同じ盤面・同じ札でも、リザーブと捨て札からなら置ける。
+    for (const zone of ['reserve', 'waste']) {
+      const r = americanToadLegalTargets(emptyTableau(), emptyFoundations(), [], 5, card('HEART', 4), zone);
+      expect(r.tableau.size).toBe(8);
+    }
+  });
+
+  // 出どころの制限は空列だけの話。埋まっている列は変わらず判定する。
+  it('still offers a matching non-empty column to a tableau card', () => {
+    const tableau = emptyTableau();
+    tableau[2] = col(card('HEART', 5));
+    const r = americanToadLegalTargets(tableau, emptyFoundations(), [], 5, card('HEART', 4), 'tableau');
+    expect([...r.tableau]).toEqual([2]);
+  });
+
   // 基礎札は**そのインデックスのスート**しか受け取らない。同スートは 2 つある。
   it('accepts the base rank on both foundations of the matching suit', () => {
     const r = americanToadLegalTargets(emptyTableau(), emptyFoundations(), [], 5, card('HEART', 5));
@@ -88,5 +116,45 @@ describe('americanToadLegalTargets', () => {
     // リザーブを残して空列を候補から外し、スート判定だけを見る。
     const r = americanToadLegalTargets(tableau, emptyFoundations(), [card('SPADE', 2)], 5, card('HEART', 7));
     expect(r.tableau.size).toBe(0);
+  });
+});
+
+// 光らせる対象を決める側。ゾーンが何も指していないときに undefined を返すのが
+// 肝で、ここが壊れると「選んでいない札の置き先」が光る。
+describe('americanToadSourceCard', () => {
+  const tableau = emptyTableau();
+  tableau[1] = [
+    { card: card('SPADE', 9), faceUp: true },
+    { card: card('HEART', 8), faceUp: true },
+  ];
+
+  it('returns nothing for no source', () => {
+    expect(americanToadSourceCard(tableau, [], [], null)).toBeUndefined();
+    expect(americanToadSourceCard(tableau, [], [], undefined)).toBeUndefined();
+  });
+
+  it('takes the top of the reserve and the waste', () => {
+    expect(
+      americanToadSourceCard(tableau, [card('CLOVER', 2), card('CLOVER', 3)], [], { zone: 'reserve' })?.value,
+    ).toBe(3);
+    expect(americanToadSourceCard(tableau, [], [card('DIAMOND', 4)], { zone: 'waste' })?.value).toBe(4);
+  });
+
+  it('returns nothing when the reserve or waste is empty', () => {
+    expect(americanToadSourceCard(tableau, [], [], { zone: 'reserve' })).toBeUndefined();
+    expect(americanToadSourceCard(tableau, [], [], { zone: 'waste' })).toBeUndefined();
+  });
+
+  it('takes the named card of a column, defaulting to its top', () => {
+    expect(americanToadSourceCard(tableau, [], [], { zone: 'tableau', col: 1, cardIndex: 0 })?.value).toBe(9);
+    expect(americanToadSourceCard(tableau, [], [], { zone: 'tableau', col: 1 })?.value).toBe(8);
+  });
+
+  it('returns nothing for a column, index or zone that names no card', () => {
+    expect(americanToadSourceCard(tableau, [], [], { zone: 'tableau' })).toBeUndefined();
+    expect(americanToadSourceCard(tableau, [], [], { zone: 'tableau', col: 0 })).toBeUndefined();
+    expect(americanToadSourceCard(tableau, [], [], { zone: 'tableau', col: 99 })).toBeUndefined();
+    expect(americanToadSourceCard(tableau, [], [], { zone: 'tableau', col: 1, cardIndex: 7 })).toBeUndefined();
+    expect(americanToadSourceCard(tableau, [], [], { zone: 'foundation', col: 0 })).toBeUndefined();
   });
 });

--- a/frontend/src/utils/americanToadLegalTargets.test.ts
+++ b/frontend/src/utils/americanToadLegalTargets.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import type { AmericanToadTableauCard, Card, CardDesign } from '../types/card';
+import { americanToadLegalTargets } from './americanToadLegalTargets';
+
+const card = (design: CardDesign, value: number): Card => ({ design, value }) as Card;
+const col = (...cards: Card[]): AmericanToadTableauCard[] => cards.map((c) => ({ card: c, faceUp: true }));
+
+const emptyFoundations = (): Card[][] => Array.from({ length: 8 }, () => []);
+const emptyTableau = (): AmericanToadTableauCard[][] => Array.from({ length: 8 }, () => []);
+
+describe('americanToadLegalTargets', () => {
+  it('is empty without a card', () => {
+    const r = americanToadLegalTargets(emptyTableau(), emptyFoundations(), [], 5, null);
+    expect(r.tableau.size).toBe(0);
+    expect(r.foundation.size).toBe(0);
+  });
+
+  // タブローは**同スートの降順**。ランクだけ合っていてもスートが違えば置けない。
+  it('accepts the same suit one rank down on the tableau', () => {
+    const tableau = emptyTableau();
+    tableau[0] = col(card('SPADE', 8));
+    tableau[1] = col(card('HEART', 8));
+    const r = americanToadLegalTargets(tableau, emptyFoundations(), [card('SPADE', 2)], 5, card('SPADE', 7));
+    expect([...r.tableau]).toEqual([0]);
+  });
+
+  // **A の下は K。**普通の 1..13 で書くと、この手が置けない列として表示される。
+  it('wraps King under Ace on the tableau', () => {
+    const tableau = emptyTableau();
+    tableau[3] = col(card('CLOVER', 1));
+    const r = americanToadLegalTargets(tableau, emptyFoundations(), [card('SPADE', 2)], 5, card('CLOVER', 13));
+    expect([...r.tableau]).toEqual([3]);
+  });
+
+  // **リザーブが残っている間、空列は置き先ではない** (自動補充の対象)。
+  it('offers an empty column only once the reserve is gone', () => {
+    const withReserve = americanToadLegalTargets(
+      emptyTableau(),
+      emptyFoundations(),
+      [card('SPADE', 2)],
+      5,
+      card('HEART', 4),
+    );
+    expect(withReserve.tableau.size).toBe(0);
+
+    const noReserve = americanToadLegalTargets(emptyTableau(), emptyFoundations(), [], 5, card('HEART', 4));
+    expect(noReserve.tableau.size).toBe(8);
+  });
+
+  // 基礎札は**そのインデックスのスート**しか受け取らない。同スートは 2 つある。
+  it('accepts the base rank on both foundations of the matching suit', () => {
+    const r = americanToadLegalTargets(emptyTableau(), emptyFoundations(), [], 5, card('HEART', 5));
+    expect([...r.foundation].sort((a, b) => a - b)).toEqual([2, 6]);
+  });
+
+  it('builds a foundation up in suit, wrapping Ace over King', () => {
+    const foundation = emptyFoundations();
+    foundation[0] = [card('SPADE', 13)];
+    const r = americanToadLegalTargets(emptyTableau(), foundation, [], 5, card('SPADE', 1));
+    expect(r.foundation.has(0)).toBe(true);
+  });
+
+  it('refuses a finished foundation', () => {
+    const foundation = emptyFoundations();
+    foundation[0] = Array.from({ length: 13 }, (_, i) => card('SPADE', i + 1));
+    const r = americanToadLegalTargets(emptyTableau(), foundation, [], 5, card('SPADE', 1));
+    expect(r.foundation.has(0)).toBe(false);
+  });
+
+  // **基準ランクが決まる前は誰も受け取らない。**
+  it('offers no foundation before the base rank is fixed', () => {
+    const r = americanToadLegalTargets(emptyTableau(), emptyFoundations(), [], 0, card('HEART', 5));
+    expect(r.foundation.size).toBe(0);
+  });
+});

--- a/frontend/src/utils/americanToadLegalTargets.test.ts
+++ b/frontend/src/utils/americanToadLegalTargets.test.ts
@@ -72,4 +72,21 @@ describe('americanToadLegalTargets', () => {
     const r = americanToadLegalTargets(emptyTableau(), emptyFoundations(), [], 0, card('HEART', 5));
     expect(r.foundation.size).toBe(0);
   });
+
+  // 完成していない基礎札でも、**続きでない札**は受け取らない。
+  it('refuses a card that does not continue the foundation', () => {
+    const foundation = emptyFoundations();
+    foundation[0] = [card('SPADE', 5)];
+    const r = americanToadLegalTargets(emptyTableau(), foundation, [], 5, card('SPADE', 9));
+    expect(r.foundation.has(0)).toBe(false);
+  });
+
+  // タブローの**ランクは合うがスートが違う**札も受け取らない (両方の枝を通す)。
+  it('refuses the right rank in the wrong suit', () => {
+    const tableau = emptyTableau();
+    tableau[0] = col(card('SPADE', 8));
+    // リザーブを残して空列を候補から外し、スート判定だけを見る。
+    const r = americanToadLegalTargets(tableau, emptyFoundations(), [card('SPADE', 2)], 5, card('HEART', 7));
+    expect(r.tableau.size).toBe(0);
+  });
 });

--- a/frontend/src/utils/americanToadLegalTargets.ts
+++ b/frontend/src/utils/americanToadLegalTargets.ts
@@ -1,0 +1,74 @@
+import type { AmericanToadTableauCard, Card } from '../types/card';
+
+/** Where the selected card may legally go. */
+export interface AmericanToadLegalTargets {
+  /** Tableau column indices that accept the card. */
+  tableau: Set<number>;
+  /** Foundation indices that accept the card. */
+  foundation: Set<number>;
+}
+
+/** Foundation index → suit, fixed so the layout does not move between deals. */
+const FOUNDATION_SUITS = ['SPADE', 'CLOVER', 'HEART', 'DIAMOND', 'SPADE', 'CLOVER', 'HEART', 'DIAMOND'] as const;
+
+/** A foundation is finished at thirteen cards. */
+const FOUNDATION_TARGET = 13;
+
+/** Ace follows King going up. Sync: `americanToadNextRank`. */
+function nextRank(v: number): number {
+  return v >= 13 ? 1 : v + 1;
+}
+
+/** King follows Ace going down. Sync: `americanToadPrevRank`. */
+function prevRank(v: number): number {
+  return v <= 1 ? 13 : v - 1;
+}
+
+/**
+ * Legal destinations for the selected card.
+ *
+ * Sync: `AmericanToad.canPlaceOnTableau` / `canPlaceOnFoundation`.
+ *
+ * **タブローは同スートの降順、ファンデーションは同スートの昇順。**どちらも
+ * A と K が地続き (A の下は K、K の上は A) で、ここを普通の 1..13 で書くと
+ * 折り返しの手が置けない列として表示される。
+ *
+ * **空列はリザーブが残っている間は置き先にならない。**自動補充の対象なので、
+ * 手で置くことはできない (#5559)。
+ */
+export function americanToadLegalTargets(
+  tableau: readonly AmericanToadTableauCard[][],
+  foundation: readonly Card[][],
+  reserve: readonly Card[],
+  baseRank: number,
+  card: Card | null | undefined,
+): AmericanToadLegalTargets {
+  const result: AmericanToadLegalTargets = { tableau: new Set(), foundation: new Set() };
+  if (!card) return result;
+
+  tableau.forEach((col, idx) => {
+    const top = col[col.length - 1]?.card;
+    if (!top) {
+      // 空列: リザーブが尽きて初めて手で置ける。
+      if (reserve.length === 0) result.tableau.add(idx);
+      return;
+    }
+    if (card.design === top.design && card.value === prevRank(top.value)) result.tableau.add(idx);
+  });
+
+  // baseRank が決まる前 (0) はどの基礎札も受け取らない。
+  if (baseRank === 0) return result;
+
+  foundation.forEach((pile, idx) => {
+    if (FOUNDATION_SUITS[idx] !== card.design) return;
+    if (pile.length === 0) {
+      if (card.value === baseRank) result.foundation.add(idx);
+      return;
+    }
+    if (pile.length >= FOUNDATION_TARGET) return;
+    const top = pile[pile.length - 1];
+    if (card.value === nextRank(top.value)) result.foundation.add(idx);
+  });
+
+  return result;
+}

--- a/frontend/src/utils/americanToadLegalTargets.ts
+++ b/frontend/src/utils/americanToadLegalTargets.ts
@@ -1,4 +1,5 @@
 import type { AmericanToadTableauCard, Card } from '../types/card';
+import type { AmericanToadMoveZone } from '../types/games/americantoad';
 
 /** Where the selected card may legally go. */
 export interface AmericanToadLegalTargets {
@@ -35,6 +36,13 @@ function prevRank(v: number): number {
  *
  * **空列はリザーブが残っている間は置き先にならない。**自動補充の対象なので、
  * 手で置くことはできない (#5559)。
+ *
+ * **空列は他のタブロー列からは決して埋められない** (`MoveTableauToTableau` の
+ * 「空き列はリザーブと捨て札の出口であって、タブローの組み替えには使えない」、
+ * #4417)。この規則は札そのものではなく*どこから来たか*で決まるので、
+ * `fromZone` を渡さないと表現できない。
+ *
+ * @param fromZone - 動かす札の出どころ (`AmericanToadMoveZone.zone`)。省略すると空列の制限を掛けない。
  */
 export function americanToadLegalTargets(
   tableau: readonly AmericanToadTableauCard[][],
@@ -42,6 +50,7 @@ export function americanToadLegalTargets(
   reserve: readonly Card[],
   baseRank: number,
   card: Card | null | undefined,
+  fromZone?: string,
 ): AmericanToadLegalTargets {
   const result: AmericanToadLegalTargets = { tableau: new Set(), foundation: new Set() };
   if (!card) return result;
@@ -49,8 +58,9 @@ export function americanToadLegalTargets(
   tableau.forEach((col, idx) => {
     const top = col[col.length - 1]?.card;
     if (!top) {
-      // 空列: リザーブが尽きて初めて手で置ける。
-      if (reserve.length === 0) result.tableau.add(idx);
+      // 空列: リザーブが尽きて初めて手で置ける。ただしタブロー同士の
+      // 組み替えでは埋められない。
+      if (reserve.length === 0 && fromZone !== 'tableau') result.tableau.add(idx);
       return;
     }
     if (card.design === top.design && card.value === prevRank(top.value)) result.tableau.add(idx);
@@ -71,4 +81,33 @@ export function americanToadLegalTargets(
   });
 
   return result;
+}
+
+/**
+ * The card a source zone refers to — the one whose destinations get rung.
+ *
+ * Lives beside {@link americanToadLegalTargets} because the two are always
+ * called as a pair: this picks the card, that answers where it may go.
+ *
+ * A zone that names nothing (an empty pile, a column index past the end,
+ * a run head that is no longer there) yields `undefined`, which the legality
+ * pass reads as "highlight nothing" rather than as an error.
+ *
+ * @param source - The selected or hovered zone, or null.
+ * @returns The card, or undefined when the zone names none.
+ */
+export function americanToadSourceCard(
+  tableau: readonly AmericanToadTableauCard[][],
+  reserve: readonly Card[],
+  waste: readonly Card[],
+  source: AmericanToadMoveZone | null | undefined,
+): Card | undefined {
+  if (!source) return undefined;
+  if (source.zone === 'reserve') return reserve[reserve.length - 1];
+  if (source.zone === 'waste') return waste[waste.length - 1];
+  if (source.zone !== 'tableau' || source.col === undefined) return undefined;
+  const pile = tableau[source.col] ?? [];
+  // cardIndex 省略時は一番上の札 — ドラッグの掴み位置と同じ既定。
+  const idx = source.cardIndex ?? pile.length - 1;
+  return pile[idx]?.card ?? undefined;
 }


### PR DESCRIPTION
Closes #5559

姉妹ソリティア (Baker's Dozen / Beleaguered Castle …) は選択と同時に合法な移動先を
リング表示するのに、このページには `legalTargets` が一切無かった。**盤面はこの系統で
最も広い** — 8列 + 8基礎札 + リザーブ + 捨て札、しかも基礎札は同スート2つずつ。
どこに置けるかはクリックしてサーバーのエラーを見るまで分からなかった。

## 直したこと

`americanToadLegalTargets.ts` を追加。`canPlaceOnTableau` / `canPlaceOnFoundation` の写しで、
**素朴な 1..13 比較が壊れる2箇所**を含む:

- タブローは**同スートの降順**で、**A の下は K**
- 基礎札は**同スートの昇順**で、**K の上は A**
- **リザーブが残っている間、空列は置き先にならない** (自動補充の対象)

hover / フォーカスのプレビューは `useDestinationPreview` 経由で**同じ関数**を通るので、
選択後の表示と食い違わない。

## テスト計画

- [x] util 8 件: 同スート降順 / **A→K の折り返し** / 空列はリザーブ次第 /
      同スート 2 つの基礎札 / **K→A の折り返し** / 完成した基礎札は拒否 /
      基準ランク未確定なら 0 件
- [x] ページ 3 件: 選択でリングが出る / **hover では `data-preview-target`** /
      リザーブがある間は空列を光らせない
- [x] 既存 28 件緑 / `bun run check` / `typecheck` 緑

### 変異テスト (4件とも検出)

| 変異 | 落ちたテスト |
|---|---|
| リザーブがあっても空列を出す | 4 |
| タブローがスートを見ない | 1 |
| A/K の折り返しを外す | 1 |
| プレビューを選択と同一視 (hover が効かない) | 1 |