### PR TITLE
feat(spiteandmalice): mark the King as the wild it is

### DIFF
--- a/frontend/src/i18n/locales/en/spiteandmalice.json
+++ b/frontend/src/i18n/locales/en/spiteandmalice.json
@@ -18,7 +18,8 @@
     "cpuGoal": "CPU goal: {{count}}",
     "foundation": "Foundation",
     "stock": "Stock",
-    "completed": "Completed"
+    "completed": "Completed",
+    "wild": "wild"
   },
   "moveCount": "Moves",
   "endTurn": "End turn",

--- a/frontend/src/i18n/locales/ja/spiteandmalice.json
+++ b/frontend/src/i18n/locales/ja/spiteandmalice.json
@@ -18,7 +18,8 @@
     "cpuGoal": "CPUゴール: {{count}}",
     "foundation": "ファウンデーション",
     "stock": "ストック",
-    "completed": "完成済み"
+    "completed": "完成済み",
+    "wild": "ワイルド"
   },
   "moveCount": "手数",
   "endTurn": "ターン終了",

--- a/frontend/src/pages/SpiteAndMalicePage.test.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.test.tsx
@@ -303,3 +303,23 @@ describe('SpiteAndMalicePage', () => {
     }
   });
 });
+
+// #5560: K はどの基礎札にも出せるワイルドだが、その規則が表示にも読み上げにも
+// 出ておらず、初見では気付けなかった。
+describe('SpiteAndMalicePage wild king', () => {
+  it('badges the King in hand and says so in the label', async () => {
+    mockExec.mockResolvedValue(baseState); // 手札に ♣K がある
+    renderWithProviders(<SpiteAndMalicePage />);
+    await waitFor(() => expect(screen.getAllByTestId('sam-wild-badge').length).toBeGreaterThan(0));
+    // 読み上げにも入る。
+    expect(screen.getByRole('button', { name: /♣ K.*ワイルド/ })).toBeInTheDocument();
+  });
+
+  // **K 以外には付かない。**全部に付いたら区別にならない。
+  it('leaves other ranks alone', async () => {
+    mockExec.mockResolvedValue(baseState);
+    renderWithProviders(<SpiteAndMalicePage />);
+    await waitFor(() => expect(screen.getAllByTestId('sam-wild-badge')).toHaveLength(1));
+    expect(screen.queryByRole('button', { name: /♠ 5.*ワイルド/ })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/SpiteAndMalicePage.tsx
+++ b/frontend/src/pages/SpiteAndMalicePage.tsx
@@ -29,7 +29,7 @@ import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import type { CliGameConfig, CliParseResult } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
-import { isGoalTopPlayableToFoundation } from '../utils/spiteAndMaliceUtils';
+import { isGoalTopPlayableToFoundation, isSpiteAndMaliceWild } from '../utils/spiteAndMaliceUtils';
 
 const samRunner = spiteAndMaliceApi;
 
@@ -387,6 +387,7 @@ function SpiteAndMalicePageContent() {
               label={t('label.hand')}
               emptyLabel={t('empty')}
               hiddenLabel={t('label.hidden')}
+              wildLabel={t('label.wild')}
             />
 
             <SideRow
@@ -620,6 +621,7 @@ function HandRow({
   label,
   emptyLabel,
   hiddenLabel,
+  wildLabel,
 }: {
   hand: (Card | null)[];
   cardWidth: number;
@@ -631,6 +633,7 @@ function HandRow({
   label: string;
   emptyLabel: string;
   hiddenLabel: string;
+  wildLabel: string;
 }) {
   return (
     <div className="flex flex-col items-center" data-tutorial={dataTutorial}>
@@ -651,9 +654,22 @@ function HandRow({
                 className={`${focusRingWhite} relative rounded-lg transition-transform ${ring}`}
                 onClick={() => onSelect(idx)}
                 disabled={card === null}
-                aria-label={`${label} ${(idx + 1).toString()}: ${card ? cardAlt(card) : hiddenLabel}`}
+                aria-label={`${label} ${(idx + 1).toString()}: ${
+                  card ? `${cardAlt(card)}${isSpiteAndMaliceWild(card) ? ` (${wildLabel})` : ''}` : hiddenLabel
+                }`}
               >
                 {card ? <AnimatedCard card={card} width={cardWidth} /> : <FaceDownSlot label="?" width={cardWidth} />}
+                {/* K はどの基礎札にも出せるワイルド。規則はドメインにあるのに、
+                    表示にも読み上げにも出ていなかった (#5560)。 */}
+                {isSpiteAndMaliceWild(card) && (
+                  <span
+                    aria-hidden="true"
+                    data-testid="sam-wild-badge"
+                    className="absolute -top-1 -right-1 rounded px-1 text-[0.6rem] font-bold bg-ds-surface text-ds-warning border border-ds-warning"
+                  >
+                    {wildLabel}
+                  </span>
+                )}
               </button>
             );
           })

--- a/frontend/src/utils/spiteAndMaliceUtils.test.ts
+++ b/frontend/src/utils/spiteAndMaliceUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Card } from '../types/card';
-import { isGoalTopPlayableToFoundation } from './spiteAndMaliceUtils';
+import { isGoalTopPlayableToFoundation, isSpiteAndMaliceWild } from './spiteAndMaliceUtils';
 
 const card = (value: number, design: Card['design'] = 'SPADE'): Card => ({ design, value });
 
@@ -29,5 +29,20 @@ describe('isGoalTopPlayableToFoundation', () => {
 
   it('non-K cannot exceed +1 of any foundation top', () => {
     expect(isGoalTopPlayableToFoundation(card(7), [4, 4, 4, 4])).toBe(false);
+  });
+});
+
+// #5560: K がワイルドという規則が表示に一切出ていなかった。判定はユーティリティ側に
+// 置いて、画面がもう一度 13 を書かないようにする。
+describe('isSpiteAndMaliceWild', () => {
+  it('is true only for the King', () => {
+    expect(isSpiteAndMaliceWild({ value: 13 })).toBe(true);
+    expect(isSpiteAndMaliceWild({ value: 12 })).toBe(false);
+    expect(isSpiteAndMaliceWild({ value: 1 })).toBe(false);
+  });
+
+  it('is false for a missing card', () => {
+    expect(isSpiteAndMaliceWild(null)).toBe(false);
+    expect(isSpiteAndMaliceWild(undefined)).toBe(false);
   });
 });

--- a/frontend/src/utils/spiteAndMaliceUtils.ts
+++ b/frontend/src/utils/spiteAndMaliceUtils.ts
@@ -1,7 +1,17 @@
 import type { Card } from '../types/card';
 
 /** Spite & Malice: K (13) acts as a wild that fills any foundation slot. */
-const KING_VALUE = 13;
+export const KING_VALUE = 13;
+
+/**
+ * True when the card is the wild King.
+ *
+ * **同じ 13 を画面側にも書かない (#5560)。**ワイルドという規則はここが持ち主で、
+ * 表示がその規則を自前で持つと、片方だけ直したときに黙って食い違う。
+ */
+export function isSpiteAndMaliceWild(card: { value: number } | null | undefined): boolean {
+  return card?.value === KING_VALUE;
+}
 /** Spite & Malice: a foundation completes at Q (12) — the next card cannot stack on a full foundation. */
 const FOUNDATION_TOP_COMPLETE = 12;
 

--- a/internal/adapter/presenter/SpiteAndMaliceCuiPresenter.go
+++ b/internal/adapter/presenter/SpiteAndMaliceCuiPresenter.go
@@ -73,9 +73,15 @@ func (p *SpiteAndMaliceCuiPresenter) Output(g interfaces.SpiteAndMaliceGame, las
 				} else {
 					parts := make([]string, len(hand))
 					for k, c := range hand {
+						// K はどの基礎札にも出せるワイルド。規則はドメインにあるのに、
+						// 手札の表記からは他の札と区別が付かなかった (#5560)。
+						cardStr := cuiCardStr(c)
+						if c != nil && c.GetValue() == domain.SpiteAndMaliceWildValue {
+							cardStr += i18n.T("spiteandmalice.wildMark")
+						}
 						parts[k] = i18n.Tf("spiteandmalice.humanHandEntry",
 							"idx", strconv.Itoa(k),
-							"card", cuiCardStr(c))
+							"card", cardStr)
 					}
 					b.WriteString(strings.Join(parts, " "))
 				}

--- a/internal/adapter/presenter/SpiteAndMaliceCuiPresenter_test.go
+++ b/internal/adapter/presenter/SpiteAndMaliceCuiPresenter_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupSpiteAndMaliceCuiMockDefaults(g *interfaces.MockSpiteAndMaliceGame) {
@@ -211,4 +212,24 @@ func TestSpiteAndMaliceCuiPresenter_ActionLogOutput(t *testing.T) {
 		g.On("GetActionLog").Return([]*domain.ActionLogEntry{{TurnNumber: 1, ActionType: "playHand", Detail: "test"}})
 		assert.NotEmpty(t, new(SpiteAndMaliceCuiPresenter).ActionLogOutput(g))
 	})
+}
+
+// #5560: K はどの基礎札にも出せるワイルドなのに、手札の表記では他の札と
+// 見分けが付かなかった。
+func TestSpiteAndMaliceCuiPresenter_MarksTheWildKing(t *testing.T) {
+	g := new(interfaces.MockSpiteAndMaliceGame)
+	human := domain.NewSpiteAndMalicePlayer(false)
+	human.AddToHand(domain.NewCard(domain.CardDesignClover, domain.SpiteAndMaliceWildValue, false))
+	human.AddToHand(domain.NewCard(domain.CardDesignSpade, 5, false))
+	cpu := domain.NewSpiteAndMalicePlayer(true)
+	g.On("GetPlayer", 0).Return(human)
+	g.On("GetPlayer", 1).Return(cpu)
+	setupSpiteAndMaliceCuiMockDefaults(g)
+
+	result := new(SpiteAndMaliceCuiPresenter).Output(g, nil)
+	mark := i18n.T("spiteandmalice.wildMark")
+	assert.Contains(t, result, "CLOVER 13"+mark)
+	// **K 以外には付かない。**全部に付いたら区別にならない。
+	assert.NotContains(t, result, "SPADE 5"+mark)
+	assert.Equal(t, 1, strings.Count(result, mark))
 }

--- a/internal/i18n/locales/en/spiteandmalice.json
+++ b/internal/i18n/locales/en/spiteandmalice.json
@@ -39,5 +39,6 @@
   "hintHand": "Hint: hand[{{idx}}] → foundation {{foundation}}",
   "hintSide": "Hint: side[{{idx}}] → foundation {{foundation}}",
   "helpExampleHint": "  h                   ask for a move",
-  "helpAutoPlay": "  ac                  play automatically"
+  "helpAutoPlay": "  ac                  play automatically",
+  "wildMark": "*"
 }

--- a/internal/i18n/locales/ja/spiteandmalice.json
+++ b/internal/i18n/locales/ja/spiteandmalice.json
@@ -39,5 +39,6 @@
   "hintHand": "ヒント: 手札{{idx}} → ファウンデーション{{foundation}}",
   "hintSide": "ヒント: サイド{{idx}} → ファウンデーション{{foundation}}",
   "helpExampleHint": "  h                   次の一手を教えてもらう",
-  "helpAutoPlay": "  ac                  自動で進める"
+  "helpAutoPlay": "  ac                  自動で進める",
+  "wildMark": "*"
 }


### PR DESCRIPTION
Closes #5560

`SpiteAndMaliceWildValue = 13` で K はどの基礎札にも出せる。**この重要な規則が
Web にも CUI にも一切出ていなかった** — 絵柄も表記も他の札と同じ。
`spiteAndMaliceUtils.ts` のコメントには「K is wild」と書いてあるのに、
初見のプレイヤーは試すまで気付けない。

## 直したこと

- 手札の K にバッジ (`sam-wild-badge`) と、`aria-label` に「ワイルド」
- CUI の手札表記に `*`
- 判定は `isSpiteAndMaliceWild()` として**規則の持ち主 (util) 側に置く** —
  画面がもう一度 13 を書くと、片方だけ直したときに黙って食い違う

## テスト計画

- [x] util: K だけ true、Q/A は false、カード無しも false
- [x] Web: 手札の K にバッジが付き、ラベルに「ワイルド」が入る
- [x] **K 以外には付かない** (バッジは 1 つだけ)
- [x] CUI: `CLOVER 13*` が出て `SPADE 5*` は出ない、印は 1 つだけ
- [x] `golangci-lint` 0 issues / `bun run check` / `typecheck` 緑

### 変異テスト (2件とも検出)

| 変異 | 落ちたテスト |
|---|---|
| 判定が全ランクに true | 2 |
| CUI が全札に印を付ける | 2 |