### PR TITLE
feat(skat): show how the round score was built

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -16550,6 +16550,11 @@ paths:
                         type: boolean
                       overbid:
                         type: boolean
+                      bid:
+                        type: integer
+                        description: >-
+                          The final bid. Only meaningful when `overbid` is set:
+                          `value` is `bid * 2`.
                       value:
                         type: integer
                       "null":

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -16527,6 +16527,33 @@ paths:
                     type: integer
                   gameValue:
                     type: integer
+                  scoreBreakdown:
+                    type: object
+                    description: >-
+                      How the round score was built. `value` always equals
+                      `gameValue`; the breakdown explains that number rather
+                      than recomputing it.
+                    properties:
+                      base:
+                        type: integer
+                      matadors:
+                        type: integer
+                      multiplier:
+                        type: integer
+                      hand:
+                        type: boolean
+                      schneider:
+                        type: boolean
+                      schwarz:
+                        type: boolean
+                      doubled:
+                        type: boolean
+                      overbid:
+                        type: boolean
+                      value:
+                        type: integer
+                      "null":
+                        type: boolean
                   gameEndFlag:
                     type: boolean
                   leadPlayerIdx:

--- a/frontend/src/i18n/locales/en/skat.json
+++ b/frontend/src/i18n/locales/en/skat.json
@@ -67,8 +67,8 @@
   "bonus": {
     "hand": "hand",
     "schneider": "schneider",
-    "schwarz": "schwarz",
-    "doubled": "doubled on a loss",
-    "overbid": "overbid"
-  }
+    "schwarz": "schwarz"
+  },
+  "scoreBreakdownDoubled": "Breakdown: base {{base}} x multiplier {{multiplier}} x 2 (doubled on a loss, matadors {{matadors}}) = {{value}}",
+  "scoreBreakdownOverbid": "Breakdown: overbid - bid {{bid}} x 2 = {{value}} (base {{base}} x multiplier {{multiplier}} did not reach the bid)"
 }

--- a/frontend/src/i18n/locales/en/skat.json
+++ b/frontend/src/i18n/locales/en/skat.json
@@ -62,5 +62,13 @@
     "trickDisplay": "The trick area shows the cards each of the three players plays.",
     "playerHand": "Your hand. Select a card to play.",
     "resetButton": "Resets the game."
+  },
+  "scoreBreakdown": "Breakdown: base {{base}} x multiplier {{multiplier}} (matadors {{matadors}}) = {{value}}",
+  "bonus": {
+    "hand": "hand",
+    "schneider": "schneider",
+    "schwarz": "schwarz",
+    "doubled": "doubled on a loss",
+    "overbid": "overbid"
   }
 }

--- a/frontend/src/i18n/locales/ja/skat.json
+++ b/frontend/src/i18n/locales/ja/skat.json
@@ -62,5 +62,13 @@
     "trickDisplay": "トリックエリア。3人の出した札がここに並びます。",
     "playerHand": "あなたの手札。出すカードを選択します。",
     "resetButton": "ゲームをリセットします。"
+  },
+  "scoreBreakdown": "内訳: 基礎点 {{base}} × 乗数 {{multiplier}} (マタドール {{matadors}}) = {{value}}",
+  "bonus": {
+    "hand": "ハンド",
+    "schneider": "シュナイダー",
+    "schwarz": "シュヴァルツ",
+    "doubled": "敗北で2倍",
+    "overbid": "オーバービッド"
   }
 }

--- a/frontend/src/i18n/locales/ja/skat.json
+++ b/frontend/src/i18n/locales/ja/skat.json
@@ -63,12 +63,12 @@
     "playerHand": "あなたの手札。出すカードを選択します。",
     "resetButton": "ゲームをリセットします。"
   },
-  "scoreBreakdown": "内訳: 基礎点 {{base}} × 乗数 {{multiplier}} (マタドール {{matadors}}) = {{value}}",
+  "scoreBreakdown": "内訳: 基礎点 {{base}} × 乗数 {{multiplier}}（マタドール {{matadors}}）= {{value}}",
   "bonus": {
     "hand": "ハンド",
     "schneider": "シュナイダー",
-    "schwarz": "シュヴァルツ",
-    "doubled": "敗北で2倍",
-    "overbid": "オーバービッド"
-  }
+    "schwarz": "シュヴァルツ"
+  },
+  "scoreBreakdownDoubled": "内訳: 基礎点 {{base}} × 乗数 {{multiplier}} × 2（敗北のため2倍・マタドール {{matadors}}）= {{value}}",
+  "scoreBreakdownOverbid": "内訳: オーバービッド — 入札 {{bid}} × 2 = {{value}}（基礎点 {{base}} × 乗数 {{multiplier}} では入札に届かなかった）"
 }

--- a/frontend/src/pages/SkatPage.test.tsx
+++ b/frontend/src/pages/SkatPage.test.tsx
@@ -653,6 +653,7 @@ describe('SkatPage score breakdown', () => {
         schwarz: false,
         doubled: false,
         overbid: false,
+        bid: 18,
         value: 44,
         null: false,
       }),
@@ -680,6 +681,7 @@ describe('SkatPage score breakdown', () => {
         schwarz: false,
         doubled: false,
         overbid: false,
+        bid: 18,
         value: 23,
         null: true,
       }),
@@ -687,6 +689,56 @@ describe('SkatPage score breakdown', () => {
     renderWithProviders(<SkatPage />);
     await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
     expect(screen.queryByTestId('skat-score-breakdown')).not.toBeInTheDocument();
+  });
+
+  // **負けたラウンドは 2 倍。**基礎点×乗数だけを書くと嘘の式になる
+  // (#5561 のレビュー指摘)。
+  it('says the doubling on a loss', async () => {
+    mockExec.mockResolvedValue(
+      withBreakdown({
+        base: 11,
+        matadors: 2,
+        multiplier: 3,
+        hand: false,
+        schneider: false,
+        schwarz: false,
+        doubled: true,
+        overbid: false,
+        bid: 18,
+        value: 66,
+        null: false,
+      }),
+    );
+    renderWithProviders(<SkatPage />);
+    const bd = await screen.findByTestId('skat-score-breakdown');
+    expect(bd).toHaveTextContent('66');
+    expect(bd).toHaveTextContent('2倍');
+    // 11 × 3 = 33 では 66 にならない。その式を書いていないこと。
+    expect(bd).not.toHaveTextContent('（マタドール 2）= 66');
+  });
+
+  // オーバービッドは基礎点と無関係な入札×2 に置き換わる。
+  it('says the bid on an overbid', async () => {
+    mockExec.mockResolvedValue(
+      withBreakdown({
+        base: 11,
+        matadors: 2,
+        multiplier: 3,
+        hand: false,
+        schneider: false,
+        schwarz: false,
+        doubled: false,
+        overbid: true,
+        bid: 40,
+        value: 80,
+        null: false,
+      }),
+    );
+    renderWithProviders(<SkatPage />);
+    const bd = await screen.findByTestId('skat-score-breakdown');
+    expect(bd).toHaveTextContent('40');
+    expect(bd).toHaveTextContent('80');
+    expect(bd).toHaveTextContent('オーバービッド');
   });
 
   // ラウンド途中では出さない。

--- a/frontend/src/pages/SkatPage.test.tsx
+++ b/frontend/src/pages/SkatPage.test.tsx
@@ -632,3 +632,68 @@ describe('SkatPage', () => {
     expect(estimate.textContent).toContain('⚠️');
   });
 });
+
+// #5561: 「なぜ 44 点なのか」を説明していなかった。マタドールはスカートで最も
+// 分かりにくい規則なので、内訳が出ないと学びようがない。
+describe('SkatPage score breakdown', () => {
+  const withBreakdown = (bd: NonNullable<SkatResponse['scoreBreakdown']>): SkatResponse => ({
+    ...roundEndPhase,
+    gameValue: bd.value,
+    scoreBreakdown: bd,
+  });
+
+  it('shows base, matadors, multiplier and the bonuses at round end', async () => {
+    mockExec.mockResolvedValue(
+      withBreakdown({
+        base: 11,
+        matadors: 2,
+        multiplier: 4,
+        hand: true,
+        schneider: false,
+        schwarz: false,
+        doubled: false,
+        overbid: false,
+        value: 44,
+        null: false,
+      }),
+    );
+    renderWithProviders(<SkatPage />);
+    const bd = await screen.findByTestId('skat-score-breakdown');
+    expect(bd).toHaveTextContent('11');
+    expect(bd).toHaveTextContent('2');
+    expect(bd).toHaveTextContent('4');
+    expect(bd).toHaveTextContent('44');
+    expect(bd).toHaveTextContent('ハンド');
+    // 付いていないボーナスは書かない。
+    expect(bd).not.toHaveTextContent('シュヴァルツ');
+  });
+
+  // **ヌル契約には乗数の概念が無い。**内訳を出すと嘘になる。
+  it('stays hidden for a Null contract', async () => {
+    mockExec.mockResolvedValue(
+      withBreakdown({
+        base: 23,
+        matadors: 0,
+        multiplier: 1,
+        hand: false,
+        schneider: false,
+        schwarz: false,
+        doubled: false,
+        overbid: false,
+        value: 23,
+        null: true,
+      }),
+    );
+    renderWithProviders(<SkatPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    expect(screen.queryByTestId('skat-score-breakdown')).not.toBeInTheDocument();
+  });
+
+  // ラウンド途中では出さない。
+  it('stays hidden during play', async () => {
+    mockExec.mockResolvedValue({ ...playPhaseHumanTurn, scoreBreakdown: undefined });
+    renderWithProviders(<SkatPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    expect(screen.queryByTestId('skat-score-breakdown')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/SkatPage.tsx
+++ b/frontend/src/pages/SkatPage.tsx
@@ -31,6 +31,7 @@ import { formatSkatState } from '../utils/cli/formatters/skatFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 import { skatBestBidEstimate } from '../utils/skatBidEstimate';
+import { skatScoreBonusKeys } from '../utils/skatScoreBonuses';
 
 /** Suit identifiers matching internal/domain/Card.go (1=Spade, 2=Clover, 3=Heart, 4=Diamond). */
 const SUIT_SPADE = 1;
@@ -314,27 +315,11 @@ function SkatPageContent() {
                   multiplier: state.scoreBreakdown.multiplier,
                   value: state.scoreBreakdown.value,
                 })}
-                {[
-                  state.scoreBreakdown.hand && t('bonus.hand'),
-                  state.scoreBreakdown.schneider && t('bonus.schneider'),
-                  state.scoreBreakdown.schwarz && t('bonus.schwarz'),
-                  state.scoreBreakdown.doubled && t('bonus.doubled'),
-                  state.scoreBreakdown.overbid && t('bonus.overbid'),
-                ].filter(Boolean).length > 0 && (
-                  <span>
-                    {' ('}
-                    {[
-                      state.scoreBreakdown.hand && t('bonus.hand'),
-                      state.scoreBreakdown.schneider && t('bonus.schneider'),
-                      state.scoreBreakdown.schwarz && t('bonus.schwarz'),
-                      state.scoreBreakdown.doubled && t('bonus.doubled'),
-                      state.scoreBreakdown.overbid && t('bonus.overbid'),
-                    ]
-                      .filter(Boolean)
-                      .join(', ')}
-                    {')'}
-                  </span>
-                )}
+                {/* 付いていないボーナスは書かない。丸括弧ごと消える。 */}
+                {skatScoreBonusKeys(state.scoreBreakdown).length > 0 &&
+                  ` (${skatScoreBonusKeys(state.scoreBreakdown)
+                    .map((key) => t(key))
+                    .join(', ')})`}
               </div>
             )}
 

--- a/frontend/src/pages/SkatPage.tsx
+++ b/frontend/src/pages/SkatPage.tsx
@@ -303,6 +303,41 @@ function SkatPageContent() {
               </table>
             </div>
 
+            {/* 得点の内訳。マタドール (切り札の連続所持/不所持) はスカートで最も
+                分かりにくい規則なのに、どちらの UI も最終値しか出していなかった
+                (#5561)。計算はサーバが済ませているので数字をそのまま並べる。 */}
+            {(isRoundEnd || isGameEnd) && state.scoreBreakdown && !state.scoreBreakdown.null && (
+              <div className="text-ds-text-muted text-xs mt-2" data-testid="skat-score-breakdown">
+                {t('scoreBreakdown', {
+                  base: state.scoreBreakdown.base,
+                  matadors: state.scoreBreakdown.matadors,
+                  multiplier: state.scoreBreakdown.multiplier,
+                  value: state.scoreBreakdown.value,
+                })}
+                {[
+                  state.scoreBreakdown.hand && t('bonus.hand'),
+                  state.scoreBreakdown.schneider && t('bonus.schneider'),
+                  state.scoreBreakdown.schwarz && t('bonus.schwarz'),
+                  state.scoreBreakdown.doubled && t('bonus.doubled'),
+                  state.scoreBreakdown.overbid && t('bonus.overbid'),
+                ].filter(Boolean).length > 0 && (
+                  <span>
+                    {' ('}
+                    {[
+                      state.scoreBreakdown.hand && t('bonus.hand'),
+                      state.scoreBreakdown.schneider && t('bonus.schneider'),
+                      state.scoreBreakdown.schwarz && t('bonus.schwarz'),
+                      state.scoreBreakdown.doubled && t('bonus.doubled'),
+                      state.scoreBreakdown.overbid && t('bonus.overbid'),
+                    ]
+                      .filter(Boolean)
+                      .join(', ')}
+                    {')'}
+                  </span>
+                )}
+              </div>
+            )}
+
             <ActionLogSection
               isEndPhase={isRoundEnd || isGameEnd}
               actionLog={actionLog}

--- a/frontend/src/pages/SkatPage.tsx
+++ b/frontend/src/pages/SkatPage.tsx
@@ -31,7 +31,7 @@ import { formatSkatState } from '../utils/cli/formatters/skatFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
 import { hintCheckboxItem } from '../utils/settingsItems';
 import { skatBestBidEstimate } from '../utils/skatBidEstimate';
-import { skatScoreBonusKeys } from '../utils/skatScoreBonuses';
+import { skatScoreBonusKeys, skatScoreFormulaKey } from '../utils/skatScoreBonuses';
 
 /** Suit identifiers matching internal/domain/Card.go (1=Spade, 2=Clover, 3=Heart, 4=Diamond). */
 const SUIT_SPADE = 1;
@@ -309,10 +309,11 @@ function SkatPageContent() {
                 (#5561)。計算はサーバが済ませているので数字をそのまま並べる。 */}
             {(isRoundEnd || isGameEnd) && state.scoreBreakdown && !state.scoreBreakdown.null && (
               <div className="text-ds-text-muted text-xs mt-2" data-testid="skat-score-breakdown">
-                {t('scoreBreakdown', {
+                {t(skatScoreFormulaKey(state.scoreBreakdown), {
                   base: state.scoreBreakdown.base,
                   matadors: state.scoreBreakdown.matadors,
                   multiplier: state.scoreBreakdown.multiplier,
+                  bid: state.scoreBreakdown.bid,
                   value: state.scoreBreakdown.value,
                 })}
                 {/* 付いていないボーナスは書かない。丸括弧ごと消える。 */}

--- a/frontend/src/types/games/skat.ts
+++ b/frontend/src/types/games/skat.ts
@@ -80,6 +80,8 @@ export interface SkatResponse extends BaseGameResponse {
     schwarz: boolean;
     doubled: boolean;
     overbid: boolean;
+    /** The final bid. Only meaningful when `overbid` is set: `value` is `bid * 2`. */
+    bid: number;
     value: number;
     null: boolean;
   };

--- a/frontend/src/types/games/skat.ts
+++ b/frontend/src/types/games/skat.ts
@@ -66,6 +66,23 @@ export interface SkatResponse extends BaseGameResponse {
   defendersCardPoints: number;
   winnerSide: number;
   gameValue: number;
+  /**
+   * How the round's score was built: base value, matadors, multiplier and the
+   * bonuses that raised it. `value` always equals {@link SkatResponse.gameValue}
+   * — the breakdown explains that number rather than recomputing it (#5561).
+   */
+  scoreBreakdown?: {
+    base: number;
+    matadors: number;
+    multiplier: number;
+    hand: boolean;
+    schneider: boolean;
+    schwarz: boolean;
+    doubled: boolean;
+    overbid: boolean;
+    value: number;
+    null: boolean;
+  };
   gameEndFlag: boolean;
   leadPlayerIdx: number;
   config: SkatConfig;

--- a/frontend/src/utils/skatScoreBonuses.test.ts
+++ b/frontend/src/utils/skatScoreBonuses.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { skatScoreBonusKeys } from './skatScoreBonuses';
+
+const none = {
+  base: 11,
+  matadors: 2,
+  multiplier: 4,
+  hand: false,
+  schneider: false,
+  schwarz: false,
+  doubled: false,
+  overbid: false,
+  value: 44,
+  null: false,
+};
+
+describe('skatScoreBonusKeys', () => {
+  it('lists nothing when no bonus applies', () => {
+    expect(skatScoreBonusKeys(none)).toEqual([]);
+  });
+
+  // **1 件ずつ独立に見る。**まとめて 1 本にすると、フラグを 1 つ落とす変異が
+  // 他のフラグの出力に隠れる。
+  it.each([
+    ['hand', 'bonus.hand'],
+    ['schneider', 'bonus.schneider'],
+    ['schwarz', 'bonus.schwarz'],
+    ['doubled', 'bonus.doubled'],
+    ['overbid', 'bonus.overbid'],
+  ])('lists %s on its own', (flag, key) => {
+    expect(skatScoreBonusKeys({ ...none, [flag]: true })).toEqual([key]);
+  });
+
+  it('keeps the announcement order when several apply', () => {
+    expect(skatScoreBonusKeys({ ...none, overbid: true, hand: true, schwarz: true })).toEqual([
+      'bonus.hand',
+      'bonus.schwarz',
+      'bonus.overbid',
+    ]);
+  });
+});

--- a/frontend/src/utils/skatScoreBonuses.test.ts
+++ b/frontend/src/utils/skatScoreBonuses.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { skatScoreBonusKeys } from './skatScoreBonuses';
+import { skatScoreBonusKeys, skatScoreFormulaKey } from './skatScoreBonuses';
 
 const none = {
   base: 11,
@@ -10,6 +10,7 @@ const none = {
   schwarz: false,
   doubled: false,
   overbid: false,
+  bid: 18,
   value: 44,
   null: false,
 };
@@ -25,17 +26,43 @@ describe('skatScoreBonusKeys', () => {
     ['hand', 'bonus.hand'],
     ['schneider', 'bonus.schneider'],
     ['schwarz', 'bonus.schwarz'],
-    ['doubled', 'bonus.doubled'],
-    ['overbid', 'bonus.overbid'],
   ])('lists %s on its own', (flag, key) => {
     expect(skatScoreBonusKeys({ ...none, [flag]: true })).toEqual([key]);
   });
 
+  // **敗北の2倍とオーバービッドは乗数のボーナスではない。**式そのものが変わるので
+  // skatScoreFormulaKey が言う。ここに混ぜると同じことを二度言う。
+  it('does not list the doubling or the overbid', () => {
+    expect(skatScoreBonusKeys({ ...none, doubled: true, overbid: true })).toEqual([]);
+  });
+
   it('keeps the announcement order when several apply', () => {
-    expect(skatScoreBonusKeys({ ...none, overbid: true, hand: true, schwarz: true })).toEqual([
+    expect(skatScoreBonusKeys({ ...none, schneider: true, hand: true, schwarz: true })).toEqual([
       'bonus.hand',
+      'bonus.schneider',
       'bonus.schwarz',
-      'bonus.overbid',
     ]);
+  });
+});
+
+// **式は 3 通りある。**1 つに固定すると、負けたラウンド (およそ半分) で
+// 「11 × 3 = 66」という嘘の式が出る (#5561 のレビュー指摘)。
+describe('skatScoreFormulaKey', () => {
+  it('states base x multiplier for a win', () => {
+    expect(skatScoreFormulaKey(none)).toBe('scoreBreakdown');
+  });
+
+  it('states the doubling for a loss', () => {
+    expect(skatScoreFormulaKey({ ...none, doubled: true })).toBe('scoreBreakdownDoubled');
+  });
+
+  it('states the bid for an overbid', () => {
+    expect(skatScoreFormulaKey({ ...none, overbid: true })).toBe('scoreBreakdownOverbid');
+  });
+
+  // オーバービッドは基礎点と無関係な値に置き換わるので、2倍より優先する。
+  // (現状ドメインでは同時に立たないが、優先順位を決めておかないと将来沈黙する。)
+  it('prefers the overbid sentence when both are set', () => {
+    expect(skatScoreFormulaKey({ ...none, doubled: true, overbid: true })).toBe('scoreBreakdownOverbid');
   });
 });

--- a/frontend/src/utils/skatScoreBonuses.ts
+++ b/frontend/src/utils/skatScoreBonuses.ts
@@ -9,6 +9,10 @@ type SkatScoreBreakdown = NonNullable<SkatResponse['scoreBreakdown']>;
  * The order is fixed rather than derived from the object so the same contract
  * always reads the same way; a caller renders the labels it gets back.
  *
+ * The doubling on a loss and the overbid replacement are deliberately absent:
+ * neither is a multiplier bonus, and both change the equation itself, which
+ * {@link skatScoreFormulaKey} states instead.
+ *
  * @param bd - The breakdown from the server.
  * @returns The translation keys of the bonuses that apply, possibly empty.
  */
@@ -17,7 +21,23 @@ export function skatScoreBonusKeys(bd: SkatScoreBreakdown): string[] {
   if (bd.hand) keys.push('bonus.hand');
   if (bd.schneider) keys.push('bonus.schneider');
   if (bd.schwarz) keys.push('bonus.schwarz');
-  if (bd.doubled) keys.push('bonus.doubled');
-  if (bd.overbid) keys.push('bonus.overbid');
   return keys;
+}
+
+/**
+ * Which sentence states this round's arithmetic.
+ *
+ * **There are three, and picking one is not cosmetic.** A win is
+ * `base x multiplier`; a loss is that doubled; an overbid throws the product
+ * away and pays `bid x 2`. One fixed sentence would print "11 x 3 = 66" for
+ * every lost round, which is false and is exactly the confusion the breakdown
+ * exists to remove.
+ *
+ * @param bd - The breakdown from the server.
+ * @returns The i18n key of the line to render.
+ */
+export function skatScoreFormulaKey(bd: SkatScoreBreakdown): string {
+  if (bd.overbid) return 'scoreBreakdownOverbid';
+  if (bd.doubled) return 'scoreBreakdownDoubled';
+  return 'scoreBreakdown';
 }

--- a/frontend/src/utils/skatScoreBonuses.ts
+++ b/frontend/src/utils/skatScoreBonuses.ts
@@ -1,0 +1,23 @@
+import type { SkatResponse } from '../types/games/skat';
+
+/** The score breakdown a finished Skat round carries. */
+type SkatScoreBreakdown = NonNullable<SkatResponse['scoreBreakdown']>;
+
+/**
+ * Which bonuses raised the round's multiplier, in the order they are announced.
+ *
+ * The order is fixed rather than derived from the object so the same contract
+ * always reads the same way; a caller renders the labels it gets back.
+ *
+ * @param bd - The breakdown from the server.
+ * @returns The translation keys of the bonuses that apply, possibly empty.
+ */
+export function skatScoreBonusKeys(bd: SkatScoreBreakdown): string[] {
+  const keys: string[] = [];
+  if (bd.hand) keys.push('bonus.hand');
+  if (bd.schneider) keys.push('bonus.schneider');
+  if (bd.schwarz) keys.push('bonus.schwarz');
+  if (bd.doubled) keys.push('bonus.doubled');
+  if (bd.overbid) keys.push('bonus.overbid');
+  return keys;
+}

--- a/internal/adapter/controller/SkatWebController.go
+++ b/internal/adapter/controller/SkatWebController.go
@@ -29,6 +29,20 @@ type SkatWebConfig struct {
 	TargetScore   *int `json:"targetScore,omitempty"`
 }
 
+// SkatWebOutputScoreBreakdown はラウンド得点がどう積み上がったか (#5561)。
+type SkatWebOutputScoreBreakdown struct {
+	Base       int  `json:"base"`
+	Matadors   int  `json:"matadors"`
+	Multiplier int  `json:"multiplier"`
+	Hand       bool `json:"hand"`
+	Schneider  bool `json:"schneider"`
+	Schwarz    bool `json:"schwarz"`
+	Doubled    bool `json:"doubled"`
+	Overbid    bool `json:"overbid"`
+	Value      int  `json:"value"`
+	Null       bool `json:"null"`
+}
+
 // SkatWebOutputPlayer Skat web output player.
 type SkatWebOutputPlayer struct {
 	ID              int              `json:"id"`
@@ -80,9 +94,11 @@ type SkatWebOutput struct {
 	DefendersCardPoints int                    `json:"defendersCardPoints"`
 	WinnerSide          int                    `json:"winnerSide"`
 	GameValue           int                    `json:"gameValue"`
-	GameEndFlag         bool                   `json:"gameEndFlag"`
-	LeadPlayerIdx       int                    `json:"leadPlayerIdx"`
-	Hint                *SkatWebOutputHint     `json:"hint,omitempty"`
+	// ScoreBreakdown はラウンド得点の内訳 (#5561)。ラウンド前は null。
+	ScoreBreakdown *SkatWebOutputScoreBreakdown `json:"scoreBreakdown,omitempty"`
+	GameEndFlag    bool                         `json:"gameEndFlag"`
+	LeadPlayerIdx  int                          `json:"leadPlayerIdx"`
+	Hint           *SkatWebOutputHint           `json:"hint,omitempty"`
 	WebOutputBase
 	Config SkatWebOutputConfig `json:"config"`
 }

--- a/internal/adapter/controller/SkatWebController.go
+++ b/internal/adapter/controller/SkatWebController.go
@@ -39,8 +39,11 @@ type SkatWebOutputScoreBreakdown struct {
 	Schwarz    bool `json:"schwarz"`
 	Doubled    bool `json:"doubled"`
 	Overbid    bool `json:"overbid"`
-	Value      int  `json:"value"`
-	Null       bool `json:"null"`
+	// Bid は Overbid のときの最終入札。Value = Bid*2 なので、これが無いと
+	// クライアントは式を書けない。
+	Bid   int  `json:"bid"`
+	Value int  `json:"value"`
+	Null  bool `json:"null"`
 }
 
 // SkatWebOutputPlayer Skat web output player.

--- a/internal/adapter/presenter/SkatCuiPresenter.go
+++ b/internal/adapter/presenter/SkatCuiPresenter.go
@@ -42,6 +42,30 @@ func skatPlayerStr(player *domain.SkatPlayer, i int) string {
 	return b.String()
 }
 
+// skatBonusStr は乗数に加算された理由を並べる。何も無ければ空。
+func skatBonusStr(bd *domain.SkatScoreBreakdown) string {
+	parts := make([]string, 0, 4)
+	if bd.Hand {
+		parts = append(parts, i18n.T("skat.bonusHand"))
+	}
+	if bd.Schneider {
+		parts = append(parts, i18n.T("skat.bonusSchneider"))
+	}
+	if bd.Schwarz {
+		parts = append(parts, i18n.T("skat.bonusSchwarz"))
+	}
+	if bd.Doubled {
+		parts = append(parts, i18n.T("skat.bonusDoubled"))
+	}
+	if bd.Overbid {
+		parts = append(parts, i18n.T("skat.bonusOverbid"))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " (" + strings.Join(parts, ", ") + ")"
+}
+
 // SkatCuiPresenter Skat CUI presenter.
 type SkatCuiPresenter struct{}
 
@@ -133,6 +157,15 @@ func (p *SkatCuiPresenter) Output(s interfaces.SkatGame, lastErr error) string {
 				"declarer", strconv.Itoa(s.GetDeclarerCardPoints()),
 				"defenders", strconv.Itoa(s.GetDefendersCardPoints()),
 				"value", strconv.Itoa(s.GetGameValue())) + "\n")
+			// **なぜこの点数なのか。**マタドール (切り札の連続所持/不所持) は
+			// スカートで最も分かりにくい規則なのに、最終値しか出ていなかった (#5561)。
+			if bd := s.GetScoreBreakdown(); bd != nil && !bd.Null {
+				b.WriteString(i18n.Tf("skat.scoreBreakdownLine",
+					"base", strconv.Itoa(bd.Base),
+					"matadors", strconv.Itoa(bd.Matadors),
+					"multiplier", strconv.Itoa(bd.Multiplier),
+					"bonuses", skatBonusStr(bd)) + "\n")
+			}
 			b.WriteString(i18n.T("skat.promptNextRound") + "\n")
 		}
 	})

--- a/internal/adapter/presenter/SkatCuiPresenter.go
+++ b/internal/adapter/presenter/SkatCuiPresenter.go
@@ -43,8 +43,11 @@ func skatPlayerStr(player *domain.SkatPlayer, i int) string {
 }
 
 // skatBonusStr は乗数に加算された理由を並べる。何も無ければ空。
+//
+// 敗北の 2 倍とオーバービッドはここには入れない。どちらも乗数ではなく**式そのもの**を
+// 変えるので、skatBreakdownLine が別の文で言う。
 func skatBonusStr(bd *domain.SkatScoreBreakdown) string {
-	parts := make([]string, 0, 4)
+	parts := make([]string, 0, 3)
 	if bd.Hand {
 		parts = append(parts, i18n.T("skat.bonusHand"))
 	}
@@ -54,16 +57,35 @@ func skatBonusStr(bd *domain.SkatScoreBreakdown) string {
 	if bd.Schwarz {
 		parts = append(parts, i18n.T("skat.bonusSchwarz"))
 	}
-	if bd.Doubled {
-		parts = append(parts, i18n.T("skat.bonusDoubled"))
-	}
-	if bd.Overbid {
-		parts = append(parts, i18n.T("skat.bonusOverbid"))
-	}
 	if len(parts) == 0 {
 		return ""
 	}
 	return " (" + strings.Join(parts, ", ") + ")"
+}
+
+// skatBreakdownLine は得点の式を書く。**式は 3 通りある。**
+//
+// 勝ちなら 基礎点×乗数、負けならその 2 倍、オーバービッドなら基礎点と無関係な
+// 入札×2 に置き換わる。1 つの文に固定すると、負けたラウンド (全体のおよそ半分) で
+// 「11 × 3 = 66」という嘘の式が出る。
+func skatBreakdownLine(bd *domain.SkatScoreBreakdown) string {
+	if bd.Overbid {
+		return i18n.Tf("skat.scoreBreakdownLineOverbid",
+			"bid", strconv.Itoa(bd.Bid),
+			"value", strconv.Itoa(bd.Value),
+			"base", strconv.Itoa(bd.Base),
+			"multiplier", strconv.Itoa(bd.Multiplier))
+	}
+	key := "skat.scoreBreakdownLine"
+	if bd.Doubled {
+		key = "skat.scoreBreakdownLineDoubled"
+	}
+	return i18n.Tf(key,
+		"base", strconv.Itoa(bd.Base),
+		"matadors", strconv.Itoa(bd.Matadors),
+		"multiplier", strconv.Itoa(bd.Multiplier),
+		"value", strconv.Itoa(bd.Value),
+		"bonuses", skatBonusStr(bd))
 }
 
 // SkatCuiPresenter Skat CUI presenter.
@@ -160,11 +182,7 @@ func (p *SkatCuiPresenter) Output(s interfaces.SkatGame, lastErr error) string {
 			// **なぜこの点数なのか。**マタドール (切り札の連続所持/不所持) は
 			// スカートで最も分かりにくい規則なのに、最終値しか出ていなかった (#5561)。
 			if bd := s.GetScoreBreakdown(); bd != nil && !bd.Null {
-				b.WriteString(i18n.Tf("skat.scoreBreakdownLine",
-					"base", strconv.Itoa(bd.Base),
-					"matadors", strconv.Itoa(bd.Matadors),
-					"multiplier", strconv.Itoa(bd.Multiplier),
-					"bonuses", skatBonusStr(bd)) + "\n")
+				b.WriteString(skatBreakdownLine(bd) + "\n")
 			}
 			b.WriteString(i18n.T("skat.promptNextRound") + "\n")
 		}

--- a/internal/adapter/presenter/SkatCuiPresenter_test.go
+++ b/internal/adapter/presenter/SkatCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,6 +35,7 @@ func setupSkatCuiMock() *interfaces.MockSkatGame {
 	m.On("GetDefendersCardPoints").Return(0)
 	m.On("GetWinnerSide").Return(domain.SkatWinnerUndecided)
 	m.On("GetGameValue").Return(0)
+	m.On("GetScoreBreakdown").Return((*domain.SkatScoreBreakdown)(nil)).Maybe()
 	m.On("GetGameEndFlag").Return(false)
 	m.On("GetLeadPlayerIdx").Return(-1)
 	m.On("GetCurrentTrick").Return(([]*domain.TrickCard)(nil))
@@ -416,4 +418,28 @@ func TestSkatCuiPresenter_ShowsTheHandBidEstimate(t *testing.T) {
 
 	// 手札が無い局面では出さない。
 	assert.NotContains(t, p.Output(build(0, nil), nil), "Hand estimate")
+}
+
+// #5561: ラウンド終了行は最終値しか出さず、「なぜこの点数なのか」— とくに
+// マタドール — を説明していなかった。
+func TestSkatCuiPresenter_Output_ScoreBreakdown(t *testing.T) {
+	build := func(bd *domain.SkatScoreBreakdown) string {
+		m := setupSkatCuiMock()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetScoreBreakdown")
+		m.On("GetScoreBreakdown").Return(bd)
+		setupSkatCuiMockPhase(m, domain.SkatPhaseRoundEnd)
+		return new(presenter.SkatCuiPresenter).Output(m, nil)
+	}
+
+	out := build(&domain.SkatScoreBreakdown{Base: 11, Matadors: 2, Multiplier: 4, Hand: true, Value: 44})
+	assert.Contains(t, out, i18n.Tf("skat.scoreBreakdownLine",
+		"base", "11", "matadors", "2", "multiplier", "4",
+		"bonuses", " ("+i18n.T("skat.bonusHand")+")"))
+
+	// **ヌル契約には乗数の概念が無い。**内訳を出すと嘘になる。
+	assert.NotContains(t, build(&domain.SkatScoreBreakdown{Base: 23, Multiplier: 1, Value: 23, Null: true}),
+		strings.SplitN(i18n.T("skat.scoreBreakdownLine"), "{{", 2)[0])
+
+	// 内訳が無いラウンド (未計算) でも落ちない。
+	assert.NotContains(t, build(nil), strings.SplitN(i18n.T("skat.scoreBreakdownLine"), "{{", 2)[0])
 }

--- a/internal/adapter/presenter/SkatCuiPresenter_test.go
+++ b/internal/adapter/presenter/SkatCuiPresenter_test.go
@@ -433,7 +433,7 @@ func TestSkatCuiPresenter_Output_ScoreBreakdown(t *testing.T) {
 
 	out := build(&domain.SkatScoreBreakdown{Base: 11, Matadors: 2, Multiplier: 4, Hand: true, Value: 44})
 	assert.Contains(t, out, i18n.Tf("skat.scoreBreakdownLine",
-		"base", "11", "matadors", "2", "multiplier", "4",
+		"base", "11", "matadors", "2", "multiplier", "4", "value", "44",
 		"bonuses", " ("+i18n.T("skat.bonusHand")+")"))
 
 	// **ヌル契約には乗数の概念が無い。**内訳を出すと嘘になる。
@@ -456,7 +456,7 @@ func TestSkatCuiPresenter_ScoreBreakdownListsEachBonusIndependently(t *testing.T
 	}
 	line := func(bonuses string) string {
 		return i18n.Tf("skat.scoreBreakdownLine",
-			"base", "11", "matadors", "2", "multiplier", "4", "bonuses", bonuses)
+			"base", "11", "matadors", "2", "multiplier", "4", "value", "44", "bonuses", bonuses)
 	}
 
 	for _, tc := range []struct {
@@ -467,8 +467,6 @@ func TestSkatCuiPresenter_ScoreBreakdownListsEachBonusIndependently(t *testing.T
 		{"hand", domain.SkatScoreBreakdown{Hand: true}, "skat.bonusHand"},
 		{"schneider", domain.SkatScoreBreakdown{Schneider: true}, "skat.bonusSchneider"},
 		{"schwarz", domain.SkatScoreBreakdown{Schwarz: true}, "skat.bonusSchwarz"},
-		{"doubled", domain.SkatScoreBreakdown{Doubled: true}, "skat.bonusDoubled"},
-		{"overbid", domain.SkatScoreBreakdown{Overbid: true}, "skat.bonusOverbid"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			bd := tc.bd
@@ -482,6 +480,38 @@ func TestSkatCuiPresenter_ScoreBreakdownListsEachBonusIndependently(t *testing.T
 	assert.Contains(t, build(&domain.SkatScoreBreakdown{Base: 11, Matadors: 2, Multiplier: 4, Value: 44}), line(""))
 
 	// 複数付いたらカンマ区切りで、順序は固定 (同じ局面なら毎回同じ行)。
-	multi := domain.SkatScoreBreakdown{Base: 11, Matadors: 2, Multiplier: 4, Value: 44, Hand: true, Schwarz: true, Overbid: true}
-	assert.Contains(t, build(&multi), line(" ("+i18n.T("skat.bonusHand")+", "+i18n.T("skat.bonusSchwarz")+", "+i18n.T("skat.bonusOverbid")+")"))
+	multi := domain.SkatScoreBreakdown{Base: 11, Matadors: 2, Multiplier: 4, Value: 44, Hand: true, Schneider: true, Schwarz: true}
+	assert.Contains(t, build(&multi), line(" ("+i18n.T("skat.bonusHand")+", "+i18n.T("skat.bonusSchneider")+", "+i18n.T("skat.bonusSchwarz")+")"))
+}
+
+// **式は 3 通りある。**勝ちは 基礎点×乗数、負けはその 2 倍、オーバービッドは
+// 基礎点と無関係な 入札×2。1 つの文に固定すると、負けたラウンド (およそ半分) で
+// 「11 × 3 = 66」という嘘の式が出る (#5561 のレビュー指摘)。
+func TestSkatCuiPresenter_ScoreBreakdownStatesTheRightFormula(t *testing.T) {
+	build := func(bd *domain.SkatScoreBreakdown) string {
+		m := setupSkatCuiMock()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetScoreBreakdown")
+		m.On("GetScoreBreakdown").Return(bd)
+		setupSkatCuiMockPhase(m, domain.SkatPhaseRoundEnd)
+		return new(presenter.SkatCuiPresenter).Output(m, nil)
+	}
+
+	won := &domain.SkatScoreBreakdown{Base: 11, Matadors: 2, Multiplier: 3, Value: 33}
+	assert.Contains(t, build(won), i18n.Tf("skat.scoreBreakdownLine",
+		"base", "11", "matadors", "2", "multiplier", "3", "value", "33", "bonuses", ""))
+
+	lost := &domain.SkatScoreBreakdown{Base: 11, Matadors: 2, Multiplier: 3, Value: 66, Doubled: true}
+	out := build(lost)
+	assert.Contains(t, out, i18n.Tf("skat.scoreBreakdownLineDoubled",
+		"base", "11", "matadors", "2", "multiplier", "3", "value", "66", "bonuses", ""))
+	// 勝ちの式 (2 倍を言わない形) が出ていないこと。
+	assert.NotContains(t, out, i18n.Tf("skat.scoreBreakdownLine",
+		"base", "11", "matadors", "2", "multiplier", "3", "value", "66", "bonuses", ""))
+
+	over := &domain.SkatScoreBreakdown{Base: 11, Matadors: 2, Multiplier: 3, Bid: 40, Value: 80, Overbid: true}
+	outOver := build(over)
+	assert.Contains(t, outOver, i18n.Tf("skat.scoreBreakdownLineOverbid",
+		"bid", "40", "value", "80", "base", "11", "multiplier", "3"))
+	assert.NotContains(t, outOver, i18n.Tf("skat.scoreBreakdownLineDoubled",
+		"base", "11", "matadors", "2", "multiplier", "3", "value", "80", "bonuses", ""))
 }

--- a/internal/adapter/presenter/SkatCuiPresenter_test.go
+++ b/internal/adapter/presenter/SkatCuiPresenter_test.go
@@ -443,3 +443,45 @@ func TestSkatCuiPresenter_Output_ScoreBreakdown(t *testing.T) {
 	// 内訳が無いラウンド (未計算) でも落ちない。
 	assert.NotContains(t, build(nil), strings.SplitN(i18n.T("skat.scoreBreakdownLine"), "{{", 2)[0])
 }
+
+// 各ボーナスが独立して並ぶこと。1 本にまとめると、フラグを 1 つ落とす変異が
+// 別のフラグの出力に隠れる。出力面から見るので、内部関数は名指ししない。
+func TestSkatCuiPresenter_ScoreBreakdownListsEachBonusIndependently(t *testing.T) {
+	build := func(bd *domain.SkatScoreBreakdown) string {
+		m := setupSkatCuiMock()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetScoreBreakdown")
+		m.On("GetScoreBreakdown").Return(bd)
+		setupSkatCuiMockPhase(m, domain.SkatPhaseRoundEnd)
+		return new(presenter.SkatCuiPresenter).Output(m, nil)
+	}
+	line := func(bonuses string) string {
+		return i18n.Tf("skat.scoreBreakdownLine",
+			"base", "11", "matadors", "2", "multiplier", "4", "bonuses", bonuses)
+	}
+
+	for _, tc := range []struct {
+		name string
+		bd   domain.SkatScoreBreakdown
+		key  string
+	}{
+		{"hand", domain.SkatScoreBreakdown{Hand: true}, "skat.bonusHand"},
+		{"schneider", domain.SkatScoreBreakdown{Schneider: true}, "skat.bonusSchneider"},
+		{"schwarz", domain.SkatScoreBreakdown{Schwarz: true}, "skat.bonusSchwarz"},
+		{"doubled", domain.SkatScoreBreakdown{Doubled: true}, "skat.bonusDoubled"},
+		{"overbid", domain.SkatScoreBreakdown{Overbid: true}, "skat.bonusOverbid"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bd := tc.bd
+			bd.Base, bd.Matadors, bd.Multiplier, bd.Value = 11, 2, 4, 44
+			// **完全一致で見る。**「含む」だけだと、全ボーナスを常に並べる実装でも通る。
+			assert.Contains(t, build(&bd), line(" ("+i18n.T(tc.key)+")"))
+		})
+	}
+
+	// 何も付いていなければ丸括弧ごと消えること。空文字を返さないと "… ()" と出る。
+	assert.Contains(t, build(&domain.SkatScoreBreakdown{Base: 11, Matadors: 2, Multiplier: 4, Value: 44}), line(""))
+
+	// 複数付いたらカンマ区切りで、順序は固定 (同じ局面なら毎回同じ行)。
+	multi := domain.SkatScoreBreakdown{Base: 11, Matadors: 2, Multiplier: 4, Value: 44, Hand: true, Schwarz: true, Overbid: true}
+	assert.Contains(t, build(&multi), line(" ("+i18n.T("skat.bonusHand")+", "+i18n.T("skat.bonusSchwarz")+", "+i18n.T("skat.bonusOverbid")+")"))
+}

--- a/internal/adapter/presenter/SkatWebPresenter.go
+++ b/internal/adapter/presenter/SkatWebPresenter.go
@@ -57,6 +57,22 @@ func (p *SkatWebPresenter) buildBaseOutput(s interfaces.SkatGame) *controller.Sk
 	resObj.DefendersCardPoints = s.GetDefendersCardPoints()
 	resObj.WinnerSide = s.GetWinnerSide()
 	resObj.GameValue = s.GetGameValue()
+	// 得点の内訳。マタドールはスカートで最も分かりにくい規則なのに、最終値しか
+	// 出ていなかった (#5561)。計算はドメインが済ませているのでそのまま渡す。
+	if bd := s.GetScoreBreakdown(); bd != nil {
+		resObj.ScoreBreakdown = &controller.SkatWebOutputScoreBreakdown{
+			Base:       bd.Base,
+			Matadors:   bd.Matadors,
+			Multiplier: bd.Multiplier,
+			Hand:       bd.Hand,
+			Schneider:  bd.Schneider,
+			Schwarz:    bd.Schwarz,
+			Doubled:    bd.Doubled,
+			Overbid:    bd.Overbid,
+			Value:      bd.Value,
+			Null:       bd.Null,
+		}
+	}
 	resObj.GameEndFlag = s.GetGameEndFlag()
 	resObj.LeadPlayerIdx = s.GetLeadPlayerIdx()
 

--- a/internal/adapter/presenter/SkatWebPresenter.go
+++ b/internal/adapter/presenter/SkatWebPresenter.go
@@ -69,6 +69,7 @@ func (p *SkatWebPresenter) buildBaseOutput(s interfaces.SkatGame) *controller.Sk
 			Schwarz:    bd.Schwarz,
 			Doubled:    bd.Doubled,
 			Overbid:    bd.Overbid,
+			Bid:        bd.Bid,
 			Value:      bd.Value,
 			Null:       bd.Null,
 		}

--- a/internal/adapter/presenter/SkatWebPresenter_test.go
+++ b/internal/adapter/presenter/SkatWebPresenter_test.go
@@ -179,3 +179,22 @@ func TestSkatWebPresenter_OutputCarriesTheScoreBreakdown(t *testing.T) {
 	assert.True(t, out.ScoreBreakdown.Hand)
 	assert.Equal(t, out.GameValue, out.ScoreBreakdown.Value)
 }
+
+// オーバービッドの式は 入札×2。入札を落とすとクライアントが「0 × 2 = 80」と
+// 書くので、フラグだけでなく数字も渡っていること (#5561 のレビュー指摘)。
+func TestSkatWebPresenter_ScoreBreakdownCarriesTheBidOnAnOverbid(t *testing.T) {
+	m := setupSkatWebMock()
+	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetScoreBreakdown")
+	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetGameValue")
+	m.On("GetGameValue").Return(80)
+	m.On("GetScoreBreakdown").Return(&domain.SkatScoreBreakdown{
+		Base: 11, Matadors: 2, Multiplier: 3, Overbid: true, Bid: 40, Value: 80,
+	})
+
+	var out controller.SkatWebOutput
+	require.NoError(t, json.Unmarshal([]byte(new(presenter.SkatWebPresenter).Output(m, nil)), &out))
+	require.NotNil(t, out.ScoreBreakdown)
+	assert.True(t, out.ScoreBreakdown.Overbid)
+	assert.Equal(t, 40, out.ScoreBreakdown.Bid)
+	assert.Equal(t, out.ScoreBreakdown.Bid*2, out.ScoreBreakdown.Value)
+}

--- a/internal/adapter/presenter/SkatWebPresenter_test.go
+++ b/internal/adapter/presenter/SkatWebPresenter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
@@ -34,6 +35,7 @@ func setupSkatWebMock() *interfaces.MockSkatGame {
 	m.On("GetDefendersCardPoints").Return(0)
 	m.On("GetWinnerSide").Return(domain.SkatWinnerUndecided)
 	m.On("GetGameValue").Return(0)
+	m.On("GetScoreBreakdown").Return((*domain.SkatScoreBreakdown)(nil)).Maybe()
 	m.On("GetGameEndFlag").Return(false)
 	m.On("GetLeadPlayerIdx").Return(-1)
 	m.On("GetCurrentTrick").Return(([]*domain.TrickCard)(nil))
@@ -96,6 +98,9 @@ func TestSkatWebPresenter_OutputRoundEndExposesSkat(t *testing.T) {
 	m.On("GetDefendersCardPoints").Return(50)
 	m.On("GetWinnerSide").Return(domain.SkatWinnerDeclarer)
 	m.On("GetGameValue").Return(22)
+	m.On("GetScoreBreakdown").Return(&domain.SkatScoreBreakdown{
+		Base: 11, Matadors: 1, Multiplier: 2, Value: 22,
+	})
 	m.On("GetGameEndFlag").Return(false)
 	m.On("GetLeadPlayerIdx").Return(0)
 	m.On("GetCurrentTrick").Return(([]*domain.TrickCard)(nil))
@@ -152,4 +157,25 @@ func TestSkatWebPresenterOutputCarriesTheHint(t *testing.T) {
 
 	result := new(presenter.SkatWebPresenter).Output(skg, nil)
 	assert.Contains(t, result, `"hint"`, "Output must carry the hint -- the frontend reads state.hint")
+}
+
+// #5561: 内訳が Web に載っていること。**合計は GetGameValue と同じ数字**でなければ、
+// 画面の内訳と合計が別の話になる。
+func TestSkatWebPresenter_OutputCarriesTheScoreBreakdown(t *testing.T) {
+	m := setupSkatWebMock()
+	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetScoreBreakdown")
+	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetGameValue")
+	m.On("GetGameValue").Return(44)
+	m.On("GetScoreBreakdown").Return(&domain.SkatScoreBreakdown{
+		Base: 11, Matadors: 2, Multiplier: 4, Hand: true, Value: 44,
+	})
+
+	var out controller.SkatWebOutput
+	require.NoError(t, json.Unmarshal([]byte(new(presenter.SkatWebPresenter).Output(m, nil)), &out))
+	require.NotNil(t, out.ScoreBreakdown)
+	assert.Equal(t, 11, out.ScoreBreakdown.Base)
+	assert.Equal(t, 2, out.ScoreBreakdown.Matadors)
+	assert.Equal(t, 4, out.ScoreBreakdown.Multiplier)
+	assert.True(t, out.ScoreBreakdown.Hand)
+	assert.Equal(t, out.GameValue, out.ScoreBreakdown.Value)
 }

--- a/internal/domain/Skat.go
+++ b/internal/domain/Skat.go
@@ -114,13 +114,14 @@ type skatRoundState struct {
 	round1Winner     int // survivor of auction round 1 (-1 = unknown)
 	declarerIdx      int // -1 if undecided / passed-out
 	passedAtCall     [SkatPlayerCnt]bool
-	pickedSkat       bool         // declarer picked up the skat
-	gameType         SkatGameType // chosen game type
-	trumpSuit        int          // chosen trump suit (suit games only)
-	skat             []*Card      // 2 face-down cards; possibly post-discard
-	originalSkat     []*Card      // pre-pickup skat snapshot for log
-	declarerHand     []*Card      // declarer hand snapshot at start of play (used for matadors at scoring time)
-	gameValue        int          // game value (positive when declarer wins)
+	pickedSkat       bool                // declarer picked up the skat
+	gameType         SkatGameType        // chosen game type
+	trumpSuit        int                 // chosen trump suit (suit games only)
+	skat             []*Card             // 2 face-down cards; possibly post-discard
+	originalSkat     []*Card             // pre-pickup skat snapshot for log
+	declarerHand     []*Card             // declarer hand snapshot at start of play (used for matadors at scoring time)
+	gameValue        int                 // game value (positive when declarer wins)
+	breakdown        *SkatScoreBreakdown // 得点の内訳 (#5561)
 	declarerCardPts  int
 	defendersCardPts int
 	winnerSide       int // SkatWinner*
@@ -220,6 +221,7 @@ func (s *Skat) startRound() {
 	s.round.declarerCardPts = 0
 	s.round.defendersCardPts = 0
 	s.round.gameValue = 0
+	s.round.breakdown = nil
 	s.round.winnerSide = SkatWinnerUndecided
 	s.round.trickNumber = 0
 	s.round.currentTrick = nil
@@ -767,6 +769,7 @@ func (s *Skat) computeRoundResult() (int, bool) {
 		declarerLostNoTricks := s.players[s.round.declarerIdx].GetTrickCount() == 0
 		// Simplified Null base value.
 		base := 23
+		s.round.breakdown = &SkatScoreBreakdown{Base: base, Multiplier: 1, Value: base, Null: true}
 		if !declarerLostNoTricks {
 			return base, false
 		}
@@ -774,32 +777,72 @@ func (s *Skat) computeRoundResult() (int, bool) {
 	}
 
 	base := s.gameBaseValue()
+	matadors := s.matadorsCount(s.round.declarerHand)
 	multiplier := s.gameMultiplier()
 	declPts := s.round.declarerCardPts
 
 	won := declPts >= 61
+	bd := &SkatScoreBreakdown{Base: base, Matadors: matadors, Hand: !s.round.pickedSkat}
 	var value int
 	// Schneider/Schwarz bonuses (simplified): +1 if 90+ pts (Schneider), +1 if all 10 tricks (Schwarz).
 	if won {
 		if declPts >= 90 {
 			multiplier++
+			bd.Schneider = true
 		}
 		if s.players[s.round.declarerIdx].GetTrickCount() == SkatTricksPerRound {
 			multiplier++
+			bd.Schwarz = true
 		}
 		value = base * multiplier
 	} else {
 		// Loser pays double the game value.
 		value = base * multiplier * 2
+		bd.Doubled = true
 	}
+	bd.Multiplier = multiplier
+	bd.Value = value
+	s.round.breakdown = bd
 
 	// If the declarer overbid (final value < bid), they lose by twice the lowest
 	// multiple of base that meets the bid (simplified to bid * 2).
 	if won && value < s.round.currentBid {
-		return s.round.currentBid * 2, false
+		bd.Overbid = true
+		bd.Value = s.round.currentBid * 2
+		return bd.Value, false
 	}
 
 	return value, won
+}
+
+// SkatScoreBreakdown はラウンド得点がどう積み上がったかの内訳。
+//
+// **なぜ 33 点で、別のラウンドは 66 点なのか。**マタドール (切り札の連続所持/
+// 不所持) はスカートで最も分かりにくい規則なのに、どちらの UI も最終値しか
+// 出していなかった (#5561)。ここに残しておけば、表示側が計算をやり直さずに済む。
+type SkatScoreBreakdown struct {
+	// Base は基礎点 (スート 9〜12 / グランド 24 / ヌル 23)。
+	Base int
+	// Matadors はマタドール数。乗数の出発点。
+	Matadors int
+	// Multiplier は最終的な乗数 (マタドール+1、ハンド・シュナイダー・シュヴァルツで加算)。
+	Multiplier int
+	// Hand / Schneider / Schwarz はそれぞれ乗数に +1 したか。
+	Hand      bool
+	Schneider bool
+	Schwarz   bool
+	// Doubled は敗北による 2 倍。Overbid はオーバービッドで bid*2 に置き換わったこと。
+	Doubled bool
+	Overbid bool
+	// Value は最終得点。GetGameValue() と必ず一致する。
+	Value int
+	// Null はヌル契約 (乗数の概念が無い)。
+	Null bool
+}
+
+// GetScoreBreakdown は直近ラウンドの得点内訳を返す。ラウンドが終わっていなければ nil。
+func (s *Skat) GetScoreBreakdown() *SkatScoreBreakdown {
+	return s.round.breakdown
 }
 
 // gameBaseValue returns the base value for the game type.

--- a/internal/domain/Skat.go
+++ b/internal/domain/Skat.go
@@ -808,6 +808,7 @@ func (s *Skat) computeRoundResult() (int, bool) {
 	// multiple of base that meets the bid (simplified to bid * 2).
 	if won && value < s.round.currentBid {
 		bd.Overbid = true
+		bd.Bid = s.round.currentBid
 		bd.Value = s.round.currentBid * 2
 		return bd.Value, false
 	}
@@ -832,8 +833,14 @@ type SkatScoreBreakdown struct {
 	Schneider bool
 	Schwarz   bool
 	// Doubled は敗北による 2 倍。Overbid はオーバービッドで bid*2 に置き換わったこと。
+	//
+	// **どちらも Base*Multiplier では最終得点にならない。**敗北は 2 倍、
+	// オーバービッドは基礎点と無関係な bid*2 に置き換わる。表示側はこの 2 つを
+	// 見て式そのものを変える必要がある (#5561 のレビュー指摘)。
 	Doubled bool
 	Overbid bool
+	// Bid はそのラウンドの最終入札。Overbid のときだけ意味を持つ (Value = Bid*2)。
+	Bid int
 	// Value は最終得点。GetGameValue() と必ず一致する。
 	Value int
 	// Null はヌル契約 (乗数の概念が無い)。

--- a/internal/domain/Skat_test.go
+++ b/internal/domain/Skat_test.go
@@ -618,3 +618,95 @@ func TestSkatScoreBreakdownIsNilBeforeARound(t *testing.T) {
 	g := newSkatForTest(t, DefaultSkatConfig())
 	assert.Nil(t, g.GetScoreBreakdown())
 }
+
+// #5561: 内訳の各ボーナスは、点数を決めている枝と同じ枝で立つ。片方だけ動くと
+// 「44点」と「基礎点11×乗数4」が食い違うので、枝ごとに両方を見る。
+func TestSkatScoreBreakdownFollowsTheBranchThatSetTheValue(t *testing.T) {
+	setup := func(declPts, bid int, pickedSkat bool, tricks int) *Skat {
+		g := newSkatForTest(t, DefaultSkatConfig())
+		resetForControlledPhase(g)
+		declarer := g.GetPlayer(0)
+		declarer.AddCard(NewCard(CardDesignClover, skatValueJack, false))
+		declarer.ResetTricks()
+		for range tricks {
+			declarer.AddTrick([]*Card{NewCard(CardDesignSpade, skatValueAce, false)})
+		}
+		g.round.declarerIdx = 0
+		g.round.gameType = SkatGameSuit
+		g.round.trumpSuit = CardDesignSpade
+		g.round.pickedSkat = pickedSkat
+		g.round.currentBid = bid
+		g.round.declarerCardPts = declPts
+		g.round.defendersCardPts = 120 - declPts
+		return g
+	}
+
+	t.Run("schneider at 90 points", func(t *testing.T) {
+		g := setup(95, 18, true, 5)
+		val, won := g.computeRoundResult()
+		bd := g.GetScoreBreakdown()
+		require.True(t, won)
+		assert.True(t, bd.Schneider)
+		assert.False(t, bd.Schwarz, "five tricks is not schwarz")
+		assert.Equal(t, val, bd.Value)
+		assert.Equal(t, bd.Base*bd.Multiplier, bd.Value)
+	})
+
+	t.Run("schwarz on every trick", func(t *testing.T) {
+		g := setup(120, 18, true, SkatTricksPerRound)
+		val, won := g.computeRoundResult()
+		bd := g.GetScoreBreakdown()
+		require.True(t, won)
+		assert.True(t, bd.Schwarz)
+		assert.Equal(t, val, bd.Value)
+	})
+
+	t.Run("hand when the skat was left alone", func(t *testing.T) {
+		g := setup(75, 18, false, 6)
+		g.computeRoundResult()
+		assert.True(t, g.GetScoreBreakdown().Hand)
+		assert.False(t, setup(75, 18, true, 6).mustCompute().Hand)
+	})
+
+	t.Run("a loss is doubled", func(t *testing.T) {
+		g := setup(40, 18, true, 3)
+		val, won := g.computeRoundResult()
+		bd := g.GetScoreBreakdown()
+		require.False(t, won)
+		assert.True(t, bd.Doubled)
+		assert.Equal(t, val, bd.Value)
+		// 敗北は2倍。内訳の基礎点×乗数だけを読むと半分に見えるので、
+		// Doubled が立っていることが数字の説明になっている。
+		assert.Equal(t, bd.Base*bd.Multiplier*2, bd.Value)
+	})
+
+	// **オーバービッドは値そのものを置き換える。**内訳が置き換え前の
+	// 基礎点×乗数を報告すると、画面の合計と食い違う。
+	t.Run("an overbid replaces the value", func(t *testing.T) {
+		// 入札が最終値 (132) を上回る局面。宣言者は「取れる」と言った分を払う。
+		g := setup(75, 240, true, 6)
+		val, _ := g.computeRoundResult()
+		bd := g.GetScoreBreakdown()
+		assert.True(t, bd.Overbid)
+		assert.Equal(t, val, bd.Value)
+		assert.NotEqual(t, bd.Base*bd.Multiplier, bd.Value)
+	})
+
+	// ヌル契約には乗数が無い。内訳は Null を立てて、表示側に黙らせる。
+	t.Run("null carries no multiplier", func(t *testing.T) {
+		g := newSkatForTest(t, DefaultSkatConfig())
+		g.round.declarerIdx = 0
+		g.round.gameType = SkatGameNull
+		g.GetPlayer(0).ResetTricks()
+		val, _ := g.computeRoundResult()
+		bd := g.GetScoreBreakdown()
+		assert.True(t, bd.Null)
+		assert.Equal(t, val, bd.Value)
+	})
+}
+
+// mustCompute は内訳だけが欲しい呼び出しを短く書くためのヘルパー。
+func (s *Skat) mustCompute() *SkatScoreBreakdown {
+	s.computeRoundResult()
+	return s.GetScoreBreakdown()
+}

--- a/internal/domain/Skat_test.go
+++ b/internal/domain/Skat_test.go
@@ -240,6 +240,17 @@ func TestSkatHumanFlowSuitGameWin(t *testing.T) {
 	if g.GetGameValue() <= 0 {
 		t.Fatalf("game value = %d, want > 0", g.GetGameValue())
 	}
+
+	// #5561: 「なぜ 33 点で、別のラウンドは 66 点なのか」をどちらの UI も
+	// 説明していなかった。内訳を残しておけば表示側が計算をやり直さずに済む。
+	bd := g.GetScoreBreakdown()
+	require.NotNil(t, bd)
+	// **合計は必ず GetGameValue() と一致する。**食い違うと画面の内訳と合計が別の話になる。
+	assert.Equal(t, g.GetGameValue(), bd.Value)
+	assert.Positive(t, bd.Base)
+	// 乗数はマタドール数 + 1 から始まる (ハンド/シュナイダー/シュヴァルツで増える)。
+	assert.GreaterOrEqual(t, bd.Multiplier, bd.Matadors+1)
+	assert.Equal(t, bd.Base*bd.Multiplier, bd.Value, "勝ちラウンドは 基礎点 x 乗数")
 }
 
 func TestSkatNextRoundAdvancesDealer(t *testing.T) {
@@ -600,4 +611,10 @@ func TestSkat_BidEstimates(t *testing.T) {
 
 	// 空の手札でも壊れない。ジャックを 1 枚も持たないので without 4 以上。
 	assert.Positive(t, SkatBestBidEstimate(nil).Value)
+}
+
+// ラウンドが終わるまでは内訳が無い。
+func TestSkatScoreBreakdownIsNilBeforeARound(t *testing.T) {
+	g := newSkatForTest(t, DefaultSkatConfig())
+	assert.Nil(t, g.GetScoreBreakdown())
 }

--- a/internal/domain/Skat_test.go
+++ b/internal/domain/Skat_test.go
@@ -710,3 +710,47 @@ func (s *Skat) mustCompute() *SkatScoreBreakdown {
 	s.computeRoundResult()
 	return s.GetScoreBreakdown()
 }
+
+// オーバービッドは基礎点と無関係な入札×2 に置き換わるので、表示側が式を書くには
+// 入札そのものが要る。落とすと「入札 0 × 2 = 80」と出る (#5561 のレビュー指摘)。
+func TestSkatScoreBreakdownCarriesTheBidOnAnOverbid(t *testing.T) {
+	g := newSkatForTest(t, DefaultSkatConfig())
+	resetForControlledPhase(g)
+	declarer := g.GetPlayer(0)
+	declarer.AddCard(NewCard(CardDesignClover, skatValueJack, false))
+	declarer.ResetTricks()
+	for range 6 {
+		declarer.AddTrick([]*Card{NewCard(CardDesignSpade, skatValueAce, false)})
+	}
+	g.round.declarerIdx = 0
+	g.round.gameType = SkatGameSuit
+	g.round.trumpSuit = CardDesignSpade
+	g.round.pickedSkat = true
+	g.round.currentBid = 240
+	g.round.declarerCardPts = 75
+	g.round.defendersCardPts = 45
+
+	val, _ := g.computeRoundResult()
+	bd := g.GetScoreBreakdown()
+	require.True(t, bd.Overbid)
+	assert.Equal(t, 240, bd.Bid)
+	assert.Equal(t, bd.Bid*2, bd.Value)
+	assert.Equal(t, val, bd.Value)
+}
+
+// 勝ったラウンドは入札を持ち込まない。0 のままなら、表示側が誤って
+// オーバービッドの文を書いても数字が合わないので気づける。
+func TestSkatScoreBreakdownLeavesTheBidUnsetWhenThereIsNoOverbid(t *testing.T) {
+	g := newSkatForTest(t, DefaultSkatConfig())
+	resetForControlledPhase(g)
+	g.GetPlayer(0).AddCard(NewCard(CardDesignClover, skatValueJack, false))
+	g.round.declarerIdx = 0
+	g.round.gameType = SkatGameSuit
+	g.round.trumpSuit = CardDesignSpade
+	g.round.pickedSkat = true
+	g.round.currentBid = 18
+	g.round.declarerCardPts = 75
+
+	g.computeRoundResult()
+	assert.Zero(t, g.GetScoreBreakdown().Bid)
+}

--- a/internal/domain/interfaces/skat.go
+++ b/internal/domain/interfaces/skat.go
@@ -101,6 +101,8 @@ type SkatGame interface {
 	GetWinnerSide() int
 	// GetGameValue returns the round's game value.
 	GetGameValue() int
+	// GetScoreBreakdown 直近ラウンドの得点内訳 (#5561)。ラウンド前は nil
+	GetScoreBreakdown() *domain.SkatScoreBreakdown
 	// GetLeadPlayerIdx returns the lead player's index.
 	GetLeadPlayerIdx() int
 	// PickedSkat reports whether the declarer picked up the skat.

--- a/internal/domain/interfaces/skat_mock.go
+++ b/internal/domain/interfaces/skat_mock.go
@@ -102,8 +102,17 @@ func (m *MockSkatGame) GetDeclarerCardPoints() int  { return m.Called().Int(0) }
 func (m *MockSkatGame) GetDefendersCardPoints() int { return m.Called().Int(0) }
 func (m *MockSkatGame) GetWinnerSide() int          { return m.Called().Int(0) }
 func (m *MockSkatGame) GetGameValue() int           { return m.Called().Int(0) }
-func (m *MockSkatGame) GetLeadPlayerIdx() int       { return m.Called().Int(0) }
-func (m *MockSkatGame) PickedSkat() bool            { return m.Called().Bool(0) }
+
+// GetScoreBreakdown 直近ラウンドの得点内訳
+func (m *MockSkatGame) GetScoreBreakdown() *domain.SkatScoreBreakdown {
+	args := m.Called()
+	if v, ok := args.Get(0).(*domain.SkatScoreBreakdown); ok {
+		return v
+	}
+	return nil
+}
+func (m *MockSkatGame) GetLeadPlayerIdx() int { return m.Called().Int(0) }
+func (m *MockSkatGame) PickedSkat() bool      { return m.Called().Bool(0) }
 
 func (m *MockSkatGame) GetPlayerCnt() int { return m.Called().Int(0) }
 func (m *MockSkatGame) GetPlayer(i int) *domain.SkatPlayer {

--- a/internal/i18n/locales/en/skat.json
+++ b/internal/i18n/locales/en/skat.json
@@ -51,5 +51,11 @@
   "hintReasonGameChoice": "best game choice",
   "hintReasonBestPlay": "best play",
   "helpExamplePlay": "  p 0                  play hand card 0",
-  "helpHint": "  h                    show a hint"
+  "helpHint": "  h                    show a hint",
+  "scoreBreakdownLine": "  breakdown: base {{base}} x multiplier {{multiplier}} (matadors {{matadors}}){{bonuses}}",
+  "bonusHand": "hand",
+  "bonusSchneider": "schneider",
+  "bonusSchwarz": "schwarz",
+  "bonusDoubled": "doubled on a loss",
+  "bonusOverbid": "overbid"
 }

--- a/internal/i18n/locales/en/skat.json
+++ b/internal/i18n/locales/en/skat.json
@@ -52,10 +52,10 @@
   "hintReasonBestPlay": "best play",
   "helpExamplePlay": "  p 0                  play hand card 0",
   "helpHint": "  h                    show a hint",
-  "scoreBreakdownLine": "  breakdown: base {{base}} x multiplier {{multiplier}} (matadors {{matadors}}){{bonuses}}",
+  "scoreBreakdownLine": "Breakdown: base {{base}} x multiplier {{multiplier}} (matadors {{matadors}}) = {{value}}{{bonuses}}",
   "bonusHand": "hand",
   "bonusSchneider": "schneider",
   "bonusSchwarz": "schwarz",
-  "bonusDoubled": "doubled on a loss",
-  "bonusOverbid": "overbid"
+  "scoreBreakdownLineDoubled": "Breakdown: base {{base}} x multiplier {{multiplier}} x 2 (doubled on a loss, matadors {{matadors}}) = {{value}}{{bonuses}}",
+  "scoreBreakdownLineOverbid": "Breakdown: overbid - bid {{bid}} x 2 = {{value}} (base {{base}} x multiplier {{multiplier}} did not reach the bid)"
 }

--- a/internal/i18n/locales/ja/skat.json
+++ b/internal/i18n/locales/ja/skat.json
@@ -51,5 +51,11 @@
   "hintReasonGameChoice": "最適なゲーム選択",
   "hintReasonBestPlay": "最善手",
   "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す",
-  "helpHint": "  h                    助言を表示"
+  "helpHint": "  h                    助言を表示",
+  "scoreBreakdownLine": "  内訳: 基礎点 {{base}} × 乗数 {{multiplier}} (マタドール {{matadors}}){{bonuses}}",
+  "bonusHand": "ハンド",
+  "bonusSchneider": "シュナイダー",
+  "bonusSchwarz": "シュヴァルツ",
+  "bonusDoubled": "敗北で2倍",
+  "bonusOverbid": "オーバービッド"
 }

--- a/internal/i18n/locales/ja/skat.json
+++ b/internal/i18n/locales/ja/skat.json
@@ -52,10 +52,10 @@
   "hintReasonBestPlay": "最善手",
   "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す",
   "helpHint": "  h                    助言を表示",
-  "scoreBreakdownLine": "  内訳: 基礎点 {{base}} × 乗数 {{multiplier}} (マタドール {{matadors}}){{bonuses}}",
+  "scoreBreakdownLine": "内訳: 基礎点 {{base}} × 乗数 {{multiplier}}（マタドール {{matadors}}）= {{value}}{{bonuses}}",
   "bonusHand": "ハンド",
   "bonusSchneider": "シュナイダー",
   "bonusSchwarz": "シュヴァルツ",
-  "bonusDoubled": "敗北で2倍",
-  "bonusOverbid": "オーバービッド"
+  "scoreBreakdownLineDoubled": "内訳: 基礎点 {{base}} × 乗数 {{multiplier}} × 2（敗北のため2倍・マタドール {{matadors}}）= {{value}}{{bonuses}}",
+  "scoreBreakdownLineOverbid": "内訳: オーバービッド — 入札 {{bid}} × 2 = {{value}}（基礎点 {{base}} × 乗数 {{multiplier}} では入札に届かなかった）"
 }


### PR DESCRIPTION
Closes #5561

## 何が問題だったか

ラウンド終了時に出るのは最終点だけで、**なぜその数字なのかを知る手段が無かった**。
スカートで最も分かりにくいのはマタドール（クラブのジャックから途切れずに続く切り札を
持っている／欠いている枚数）で、これが乗数を決める。その乗数も基礎点も
どちらの UI にも出ていなかったので、点数は構造的に説明不能だった。

## 変更

- `SkatScoreBreakdown` + `GetScoreBreakdown()` — 基礎点 / マタドール / 乗数 /
  ハンド・シュナイダー・シュヴァルツ・2倍・オーバービッドの各ボーナス / 最終値。
- **表示用に計算し直していない。** 既に得点を計算している `computeRoundResult` の中で
  同じ値から埋めている。`bd.Value` は `GetGameValue()` と同じ数字で、
  オーバービッド時の「入札 x 2」への置き換えも含む（テストで等値を固定）。
- **ヌル契約は乗数の概念が無い**ので `Null=true` を立て、CUI / Web とも内訳を出さない。
  出せば `23 x 1` という嘘になる。
- CUI は `skat.scoreBreakdownLine`、Web は `SkatPage` のスコア表の下に表示。
  文言は ja/en 両方に追加。`api/openapi.yaml` に `scoreBreakdown` を追加（CRLF 維持、
  `git diff --numstat` は 27/0）。

## テスト

- `TestSkatHumanFlowSuitGameWin` に `bd.Value == GetGameValue()` と
  `bd.Base*bd.Multiplier == bd.Value` を追加
- `TestSkatScoreBreakdownIsNilBeforeARound` — ラウンド前は nil
- `TestSkatCuiPresenter_Output_ScoreBreakdown` — 通常契約で出る / ヌルで出ない / nil で落ちない
- `TestSkatWebPresenter_OutputCarriesTheScoreBreakdown`
- `SkatPage.test.tsx` — 内訳が出る（付いていないボーナスは書かない）/ ヌルで出ない / プレイ中は出ない

変異テスト2件で検出を確認: 「Value がオーバービッドの置き換えを無視」→ 1件検出、
「CUI がヌルでも内訳を出す」→ 1件検出。

`golangci-lint` 0 issues / `bun run check` / `bun run typecheck` / SkatPage 42 passed。