### PR TITLE
fix(congress): say the rules in the player's language

### DIFF
--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -2203,7 +2203,20 @@
     "bisley.errNothingToUndo": "There is nothing to undo",
     "bisley.errBadColumn": "Invalid column index",
     "bisley.errColumnEmpty": "That column is empty",
-    "bisley.errNotPlaying": "The game is not in play"
+    "bisley.errNotPlaying": "The game is not in play",
+    "congress.errStockEmptyNoRedeal": "The stock is empty and this game has no redeal",
+    "congress.errPileEmpty": "Pile {{pile}} is empty",
+    "congress.errNoFoundationForCard": "No foundation accepts that card",
+    "congress.errSamePile": "The source and the destination are the same pile",
+    "congress.errEmptyPileNeedsStockOrWaste": "An empty pile cannot be filled from the tableau (only from the stock or the waste)",
+    "congress.errCannotPlaceOnPile": "That card cannot go on that pile (build down in the same suit)",
+    "congress.errWasteEmpty": "The waste is empty",
+    "congress.errStockEmpty": "The stock is empty",
+    "congress.errStockFillsGapsOnly": "The stock may only fill an empty pile",
+    "congress.errNothingToAutoComplete": "No card can be auto-completed",
+    "congress.errNothingToUndo": "There is nothing to undo",
+    "congress.errNotPlaying": "The game is not in the playing phase",
+    "congress.errInvalidPile": "Invalid pile number: {{pile}}"
   },
   "manual": {
     "ariaLabel": "Game Manual",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -2203,7 +2203,20 @@
     "bisley.errNothingToUndo": "取り消せる手がありません",
     "bisley.errBadColumn": "列番号が不正です",
     "bisley.errColumnEmpty": "その列は空です",
-    "bisley.errNotPlaying": "プレイ中ではありません"
+    "bisley.errNotPlaying": "プレイ中ではありません",
+    "congress.errStockEmptyNoRedeal": "山札は空です（このゲームにめくり直しはありません）",
+    "congress.errPileEmpty": "タブロー山{{pile}}は空です",
+    "congress.errNoFoundationForCard": "その札を置ける基礎札がありません",
+    "congress.errSamePile": "移動元と移動先が同じ山です",
+    "congress.errEmptyPileNeedsStockOrWaste": "空き山はタブローからは埋められません（山札か捨て札からのみ）",
+    "congress.errCannotPlaceOnPile": "その山にはその札を置けません（同じスートで1つ下の札の上にのみ置けます）",
+    "congress.errWasteEmpty": "捨て札は空です",
+    "congress.errStockEmpty": "山札は空です",
+    "congress.errStockFillsGapsOnly": "山札から直接置けるのは空き山だけです",
+    "congress.errNothingToAutoComplete": "自動で基礎札に送れる札がありません",
+    "congress.errNothingToUndo": "取り消せる手がありません",
+    "congress.errNotPlaying": "プレイ中ではありません",
+    "congress.errInvalidPile": "無効なタブロー山の番号です: {{pile}}"
   },
   "manual": {
     "ariaLabel": "ゲームマニュアル",

--- a/internal/adapter/presenter/CongressCuiPresenter_test.go
+++ b/internal/adapter/presenter/CongressCuiPresenter_test.go
@@ -178,3 +178,63 @@ func TestCongressCuiPresenter_ActionLogOutput(t *testing.T) {
 		assert.Contains(t, new(CongressCuiPresenter).ActionLogOutput(g), "move")
 	})
 }
+
+// #5562: 空き山の規則違反は英語の生文で返っていたので、日本語ロケールでも
+// 英語のまま出ていた。**コードを名乗るようにしただけでは足りない** — 訳が
+// 無ければキー文字列がそのまま画面に出る。
+func TestCongressCuiPresenter_ErrorsAreTranslated(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+	defer i18n.SetLang("ja")
+
+	codes := []string{
+		"congress.errStockEmptyNoRedeal",
+		"congress.errPileEmpty",
+		"congress.errNoFoundationForCard",
+		"congress.errSamePile",
+		"congress.errEmptyPileNeedsStockOrWaste",
+		"congress.errCannotPlaceOnPile",
+		"congress.errWasteEmpty",
+		"congress.errStockEmpty",
+		"congress.errStockFillsGapsOnly",
+		"congress.errNothingToAutoComplete",
+		"congress.errNothingToUndo",
+		"congress.errNotPlaying",
+		"congress.errInvalidPile",
+	}
+
+	for _, lang := range []string{"ja", "en"} {
+		i18n.SetLang(lang)
+		for _, code := range codes {
+			g := new(interfaces.MockCongressGame)
+			setupCongressCuiMockDefaults(g)
+			err := domain.NewDomainErrorCode(domain.ErrInvalidPlay, code, map[string]string{"pile": "3"})
+			out := new(CongressCuiPresenter).Output(g, err)
+
+			// **キーが画面に出ないこと。**訳の抜けはこれでしか見えない。
+			assert.NotContains(t, out, code, "%s untranslated in %s", code, lang)
+			// 訳文そのものが出ていること (キーが出ないだけなら空でも通る)。
+			assert.Contains(t, out, i18n.Tf(code, "pile", "3"))
+		}
+	}
+
+	// **日本語と英語で違う文が出ること。**両方に同じ英文を入れても上は通る。
+	i18n.SetLang("ja")
+	ja := i18n.T("congress.errEmptyPileNeedsStockOrWaste")
+	i18n.SetLang("en")
+	assert.NotEqual(t, ja, i18n.T("congress.errEmptyPileNeedsStockOrWaste"))
+}
+
+// コードを持たないエラー (逆シリアライズの防御など) は今までどおり素の文言で
+// 出ること。全部を翻訳経路に流すと、キーでない文字列を引いて空行になる。
+func TestCongressCuiPresenter_UncodedErrorsStillPrintTheirPhrase(t *testing.T) {
+	origNoColor := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(origNoColor)
+
+	g := new(interfaces.MockCongressGame)
+	setupCongressCuiMockDefaults(g)
+	out := new(CongressCuiPresenter).Output(g, errors.New("congress: snapshot array exceeds maximum allowed size"))
+	assert.Contains(t, out, "snapshot array exceeds maximum allowed size")
+}

--- a/internal/adapter/presenter/CongressWebPresenter.go
+++ b/internal/adapter/presenter/CongressWebPresenter.go
@@ -60,7 +60,15 @@ func (p *CongressWebPresenter) Output(c interfaces.CongressGame, lastErr error) 
 	}
 
 	if lastErr != nil {
-		resObj.Message = lastErr.Error()
+		// コードを持つエラーはクライアントの i18n に組み立てさせる。ここで
+		// Error() をそのまま入れると、キーを名乗るエラーはキー文字列が画面に
+		// 出る (#5562)。
+		if code, params := domain.ErrorMessageCode(lastErr); code != "" {
+			resObj.MessageCode = code
+			resObj.MessageParams = params
+		} else {
+			resObj.Message = lastErr.Error()
+		}
 	} else {
 		switch c.GetPhase() {
 		case domain.CongressPhasePlaying:

--- a/internal/adapter/presenter/CongressWebPresenter_test.go
+++ b/internal/adapter/presenter/CongressWebPresenter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -168,4 +169,39 @@ func TestCongressWebPresenter_ActionLogOutput(t *testing.T) {
 
 		assert.Contains(t, new(CongressWebPresenter).ActionLogOutput(g), "move")
 	})
+}
+
+// Web も同じエラーを受け取る。コードを Message に入れるとキー文字列が画面に
+// 出るので、MessageCode に振り分けること (#5562)。
+func TestCongressWebPresenter_ErrorCodesGoToMessageCode(t *testing.T) {
+	g := new(interfaces.MockCongressGame)
+	setupCongressOutputMock(g)
+	err := domain.NewDomainErrorCode(domain.ErrInvalidPlay, "congress.errEmptyPileNeedsStockOrWaste", nil)
+
+	var res controller.CongressWebOutput
+	require.NoError(t, json.Unmarshal([]byte(new(CongressWebPresenter).Output(g, err)), &res))
+	assert.Equal(t, "congress.errEmptyPileNeedsStockOrWaste", res.MessageCode)
+	assert.Empty(t, res.Message)
+}
+
+// パラメータ付きのコードは値も渡すこと。落とすと "{{pile}}" が画面に出る。
+func TestCongressWebPresenter_ErrorParamsSurvive(t *testing.T) {
+	g := new(interfaces.MockCongressGame)
+	setupCongressOutputMock(g)
+	err := domain.NewDomainErrorCode(domain.ErrInvalidPlay, "congress.errPileEmpty", map[string]string{"pile": "5"})
+
+	var res controller.CongressWebOutput
+	require.NoError(t, json.Unmarshal([]byte(new(CongressWebPresenter).Output(g, err)), &res))
+	assert.Equal(t, map[string]string{"pile": "5"}, res.MessageParams)
+}
+
+// コードを持たないエラーは今までどおり Message に入ること。
+func TestCongressWebPresenter_UncodedErrorsStayInMessage(t *testing.T) {
+	g := new(interfaces.MockCongressGame)
+	setupCongressOutputMock(g)
+
+	var res controller.CongressWebOutput
+	require.NoError(t, json.Unmarshal([]byte(new(CongressWebPresenter).Output(g, errors.New("boom"))), &res))
+	assert.Equal(t, "boom", res.Message)
+	assert.Empty(t, res.MessageCode)
 }

--- a/internal/domain/Congress.go
+++ b/internal/domain/Congress.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 )
 
 // CongressPhase コングレスのゲームフェーズ
@@ -150,7 +151,7 @@ func (c *Congress) Draw() error {
 		return err
 	}
 	if len(c.stock) == 0 {
-		return errors.New("stock is empty and there is no redeal")
+		return NewDomainErrorCode(ErrDeckExhausted, "congress.errStockEmptyNoRedeal", nil)
 	}
 	c.takeSnapshot()
 	card := c.stock[0]
@@ -170,11 +171,11 @@ func (c *Congress) MoveTableauToFoundation(pile int) error {
 	}
 	card := c.tableauTop(pile)
 	if card == nil {
-		return fmt.Errorf("pile %d is empty", pile)
+		return NewDomainErrorCode(ErrInvalidPlay, "congress.errPileEmpty", map[string]string{"pile": strconv.Itoa(pile)})
 	}
 	fIdx := c.findFoundation(card)
 	if fIdx < 0 {
-		return errors.New("card cannot be placed on a foundation")
+		return NewDomainErrorCode(ErrInvalidPlay, "congress.errNoFoundationForCard", nil)
 	}
 	c.takeSnapshot()
 	c.tableau[pile] = c.tableau[pile][:len(c.tableau[pile])-1]
@@ -198,17 +199,17 @@ func (c *Congress) MoveTableauToTableau(fromPile, toPile int) error {
 		return err
 	}
 	if fromPile == toPile {
-		return errors.New("source and destination are the same pile")
+		return NewDomainErrorCode(ErrInvalidPlay, "congress.errSamePile", nil)
 	}
 	card := c.tableauTop(fromPile)
 	if card == nil {
-		return fmt.Errorf("pile %d is empty", fromPile)
+		return NewDomainErrorCode(ErrInvalidPlay, "congress.errPileEmpty", map[string]string{"pile": strconv.Itoa(fromPile)})
 	}
 	if len(c.tableau[toPile]) == 0 {
-		return errors.New("an empty pile can only be filled from the stock or the waste")
+		return NewDomainErrorCode(ErrInvalidPlay, "congress.errEmptyPileNeedsStockOrWaste", nil)
 	}
 	if !c.canPlaceOnTableau(card, toPile) {
-		return errors.New("card cannot be placed on that pile")
+		return NewDomainErrorCode(ErrInvalidPlay, "congress.errCannotPlaceOnPile", nil)
 	}
 	c.takeSnapshot()
 	c.tableau[fromPile] = c.tableau[fromPile][:len(c.tableau[fromPile])-1]
@@ -224,11 +225,11 @@ func (c *Congress) MoveWasteToFoundation() error {
 	}
 	card := c.wasteTop()
 	if card == nil {
-		return errors.New("waste is empty")
+		return NewDomainErrorCode(ErrInvalidPlay, "congress.errWasteEmpty", nil)
 	}
 	fIdx := c.findFoundation(card)
 	if fIdx < 0 {
-		return errors.New("card cannot be placed on a foundation")
+		return NewDomainErrorCode(ErrInvalidPlay, "congress.errNoFoundationForCard", nil)
 	}
 	c.takeSnapshot()
 	c.popWaste()
@@ -247,10 +248,10 @@ func (c *Congress) MoveWasteToTableau(pile int) error {
 	}
 	card := c.wasteTop()
 	if card == nil {
-		return errors.New("waste is empty")
+		return NewDomainErrorCode(ErrInvalidPlay, "congress.errWasteEmpty", nil)
 	}
 	if !c.canPlaceOnTableau(card, pile) {
-		return errors.New("card cannot be placed on that pile")
+		return NewDomainErrorCode(ErrInvalidPlay, "congress.errCannotPlaceOnPile", nil)
 	}
 	c.takeSnapshot()
 	c.popWaste()
@@ -271,10 +272,10 @@ func (c *Congress) MoveStockToTableau(pile int) error {
 		return err
 	}
 	if len(c.stock) == 0 {
-		return errors.New("stock is empty")
+		return NewDomainErrorCode(ErrDeckExhausted, "congress.errStockEmpty", nil)
 	}
 	if len(c.tableau[pile]) != 0 {
-		return errors.New("the stock may only fill an empty pile")
+		return NewDomainErrorCode(ErrInvalidPlay, "congress.errStockFillsGapsOnly", nil)
 	}
 	c.takeSnapshot()
 	card := c.stock[0]
@@ -375,7 +376,7 @@ func (c *Congress) tableauHint() *CongressHint {
 // AutoComplete 基礎札へ送れる札がなくなるまで自動で送る
 func (c *Congress) AutoComplete() error {
 	if c.phase != CongressPhasePlaying {
-		return errors.New("game is not in playing phase")
+		return NewDomainErrorCode(ErrWrongPhase, "congress.errNotPlaying", nil)
 	}
 	moved := false
 	for {
@@ -395,7 +396,7 @@ func (c *Congress) AutoComplete() error {
 		moved = true
 	}
 	if !moved {
-		return errors.New("no card can be auto-completed")
+		return NewDomainErrorCode(ErrInvalidPlay, "congress.errNothingToAutoComplete", nil)
 	}
 	return nil
 }
@@ -403,7 +404,7 @@ func (c *Congress) AutoComplete() error {
 // Undo 直前の 1 手を取り消す
 func (c *Congress) Undo() error {
 	if len(c.history) == 0 {
-		return errors.New("nothing to undo")
+		return NewDomainErrorCode(ErrInvalidPlay, "congress.errNothingToUndo", nil)
 	}
 	snap := c.history[len(c.history)-1]
 	c.history = c.history[:len(c.history)-1]
@@ -462,7 +463,7 @@ func (c *Congress) IsStalemate() bool { return c.isStalemate }
 // requirePlaying プレイ中でなければエラーを返す
 func (c *Congress) requirePlaying() error {
 	if c.phase != CongressPhasePlaying {
-		return errors.New("game is not in playing phase")
+		return NewDomainErrorCode(ErrWrongPhase, "congress.errNotPlaying", nil)
 	}
 	return nil
 }
@@ -470,7 +471,7 @@ func (c *Congress) requirePlaying() error {
 // validCongressPile タブロー山のインデックスを検証する
 func validCongressPile(pile int) error {
 	if pile < 0 || pile >= CongressTableauCnt {
-		return fmt.Errorf("invalid pile: %d", pile)
+		return NewDomainErrorCode(ErrInvalidPlay, "congress.errInvalidPile", map[string]string{"pile": strconv.Itoa(pile)})
 	}
 	return nil
 }

--- a/internal/domain/Congress_test.go
+++ b/internal/domain/Congress_test.go
@@ -4,6 +4,7 @@ package domain
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -747,4 +748,120 @@ func TestCongress_FullGameDrive(t *testing.T) {
 			}
 		}
 	}
+}
+
+// #5562: 空き山の規則違反は英語の生文で返っていたので、日本語ロケールの CUI が
+// 英語のまま表示していた。**プレイヤーが踏める手はすべて**コードを名乗ること
+// (issue は 1 件だけ挙げているが、同じ経路の他の拒否も同じように英語で出る)。
+func TestCongress_PlayerFacingErrorsCarryAMessageCode(t *testing.T) {
+	setup := func(fn func(c *Congress)) *Congress {
+		c := newTestCongress()
+		clearCongressBoard(c)
+		fillCongressPiles(c)
+		fn(c)
+		return c
+	}
+
+	cases := []struct {
+		name string
+		code string
+		act  func() error
+	}{
+		{"stock exhausted", "congress.errStockEmptyNoRedeal", func() error {
+			return setup(func(c *Congress) { c.stock = nil }).Draw()
+		}},
+		{"tableau pile empty", "congress.errPileEmpty", func() error {
+			c := setup(func(c *Congress) { c.tableau[0] = nil })
+			return c.MoveTableauToFoundation(0)
+		}},
+		{"no foundation for that card", "congress.errNoFoundationForCard", func() error {
+			c := setup(func(c *Congress) { c.tableau[0] = []*Card{NewCard(CardDesignSpade, 9, true)} })
+			return c.MoveTableauToFoundation(0)
+		}},
+		{"same pile", "congress.errSamePile", func() error {
+			return setup(func(c *Congress) {}).MoveTableauToTableau(1, 1)
+		}},
+		{"source pile empty", "congress.errPileEmpty", func() error {
+			c := setup(func(c *Congress) { c.tableau[0] = nil })
+			return c.MoveTableauToTableau(0, 1)
+		}},
+		{"empty pile from the tableau", "congress.errEmptyPileNeedsStockOrWaste", func() error {
+			c := setup(func(c *Congress) { c.tableau[1] = nil })
+			return c.MoveTableauToTableau(0, 1)
+		}},
+		{"not stackable", "congress.errCannotPlaceOnPile", func() error {
+			c := setup(func(c *Congress) {
+				c.tableau[0] = []*Card{NewCard(CardDesignSpade, 2, true)}
+				c.tableau[1] = []*Card{NewCard(CardDesignHeart, 7, true)}
+			})
+			return c.MoveTableauToTableau(0, 1)
+		}},
+		{"waste empty for the foundation", "congress.errWasteEmpty", func() error {
+			return setup(func(c *Congress) { c.waste = nil }).MoveWasteToFoundation()
+		}},
+		{"waste card has no foundation", "congress.errNoFoundationForCard", func() error {
+			c := setup(func(c *Congress) { c.waste = []*Card{NewCard(CardDesignSpade, 9, true)} })
+			return c.MoveWasteToFoundation()
+		}},
+		{"waste empty for the tableau", "congress.errWasteEmpty", func() error {
+			return setup(func(c *Congress) { c.waste = nil }).MoveWasteToTableau(0)
+		}},
+		{"waste card not stackable", "congress.errCannotPlaceOnPile", func() error {
+			c := setup(func(c *Congress) {
+				c.waste = []*Card{NewCard(CardDesignSpade, 2, true)}
+				c.tableau[0] = []*Card{NewCard(CardDesignHeart, 7, true)}
+			})
+			return c.MoveWasteToTableau(0)
+		}},
+		{"stock empty", "congress.errStockEmpty", func() error {
+			c := setup(func(c *Congress) {
+				c.stock = nil
+				c.tableau[0] = nil
+			})
+			return c.MoveStockToTableau(0)
+		}},
+		{"stock may only fill a gap", "congress.errStockFillsGapsOnly", func() error {
+			c := setup(func(c *Congress) { c.stock = []*Card{NewCard(CardDesignHeart, 3, true)} })
+			return c.MoveStockToTableau(0)
+		}},
+		{"nothing to auto-complete", "congress.errNothingToAutoComplete", func() error {
+			return setup(func(c *Congress) {}).AutoComplete()
+		}},
+		{"nothing to undo", "congress.errNothingToUndo", func() error {
+			c := setup(func(c *Congress) {})
+			c.history = nil
+			return c.Undo()
+		}},
+		{"not playing", "congress.errNotPlaying", func() error {
+			c := setup(func(c *Congress) { c.phase = CongressPhaseGameOver })
+			return c.Draw()
+		}},
+		{"invalid pile", "congress.errInvalidPile", func() error {
+			return setup(func(c *Congress) {}).MoveTableauToFoundation(99)
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.act()
+			require.Error(t, err)
+			code, _ := ErrorMessageCode(err)
+			assert.Equal(t, tc.code, code)
+			// センチネルは errors.Is で見分けられること。コードだけ足して
+			// 種別を失うと、呼び出し側の分岐が黙って死ぬ。
+			assert.True(t, errors.Is(err, ErrInvalidPlay) || errors.Is(err, ErrWrongPhase) ||
+				errors.Is(err, ErrDeckExhausted), "unexpected sentinel: %v", err)
+		})
+	}
+}
+
+// AutoComplete がプレイ中以外で拒む経路も同じコードを名乗ること
+// (requirePlaying を通らない独自チェックなので、上の表とは別に見る)。
+func TestCongress_AutoCompleteOutsidePlayingCarriesACode(t *testing.T) {
+	c := newTestCongress()
+	c.phase = CongressPhaseGameOver
+	err := c.AutoComplete()
+	require.Error(t, err)
+	code, _ := ErrorMessageCode(err)
+	assert.Equal(t, "congress.errNotPlaying", code)
 }

--- a/internal/i18n/locales/en/congress.json
+++ b/internal/i18n/locales/en/congress.json
@@ -32,5 +32,18 @@
   "hintLine": "Hint: {{from}} → {{to}}",
   "undoToEscape": "Undo {{count}} move(s) to escape the dead end (undo {{count}}, or repeat u)",
   "helpExampleHint": "  h                        ask for a move",
-  "helpExampleAuto": "  ac                       send everything that can go to a foundation"
+  "helpExampleAuto": "  ac                       send everything that can go to a foundation",
+  "errStockEmptyNoRedeal": "The stock is empty and this game has no redeal",
+  "errPileEmpty": "Pile {{pile}} is empty",
+  "errNoFoundationForCard": "No foundation accepts that card",
+  "errSamePile": "The source and the destination are the same pile",
+  "errEmptyPileNeedsStockOrWaste": "An empty pile cannot be filled from the tableau (only from the stock or the waste)",
+  "errCannotPlaceOnPile": "That card cannot go on that pile (build down in the same suit)",
+  "errWasteEmpty": "The waste is empty",
+  "errStockEmpty": "The stock is empty",
+  "errStockFillsGapsOnly": "The stock may only fill an empty pile",
+  "errNothingToAutoComplete": "No card can be auto-completed",
+  "errNothingToUndo": "There is nothing to undo",
+  "errNotPlaying": "The game is not in the playing phase",
+  "errInvalidPile": "Invalid pile number: {{pile}}"
 }

--- a/internal/i18n/locales/ja/congress.json
+++ b/internal/i18n/locales/ja/congress.json
@@ -32,5 +32,18 @@
   "hintLine": "ヒント: {{from}} → {{to}}",
   "undoToEscape": "脱出には {{count}} 手戻す必要があります（undo {{count}} または u を繰り返す）",
   "helpExampleHint": "  h                        次の一手を教えてもらう",
-  "helpExampleAuto": "  ac                       組札へ送れる札を自動で送る"
+  "helpExampleAuto": "  ac                       組札へ送れる札を自動で送る",
+  "errStockEmptyNoRedeal": "山札は空です（このゲームにめくり直しはありません）",
+  "errPileEmpty": "タブロー山{{pile}}は空です",
+  "errNoFoundationForCard": "その札を置ける基礎札がありません",
+  "errSamePile": "移動元と移動先が同じ山です",
+  "errEmptyPileNeedsStockOrWaste": "空き山はタブローからは埋められません（山札か捨て札からのみ）",
+  "errCannotPlaceOnPile": "その山にはその札を置けません（同じスートで1つ下の札の上にのみ置けます）",
+  "errWasteEmpty": "捨て札は空です",
+  "errStockEmpty": "山札は空です",
+  "errStockFillsGapsOnly": "山札から直接置けるのは空き山だけです",
+  "errNothingToAutoComplete": "自動で基礎札に送れる札がありません",
+  "errNothingToUndo": "取り消せる手がありません",
+  "errNotPlaying": "プレイ中ではありません",
+  "errInvalidPile": "無効なタブロー山の番号です: {{pile}}"
 }


### PR DESCRIPTION
Closes #5562

## 何が問題だったか

コングレスの**プレイヤーが踏める拒否は全部 `errors.New` の英語の生文**で、
CUI (`cuiErrorBlock`) はそれをそのまま印字していた。日本語ロケールで空き山に
タブローから置こうとすると `an empty pile can only be filled from the stock or the waste`
と出る。

**issue が挙げているのは 1 件だが、同じ経路に 13 件ある** —
`waste is empty` / `nothing to undo` / `the stock may only fill an empty pile` …。
1 件だけ直すと CUI が中途半端に日英混在になるので、まとめて `NewDomainErrorCode` に
寄せた。逆シリアライズの防御 4 件は生文のまま残す（壊れたセーブデータへの返答であって、
手に対する返答ではない）。

## 変更

- `internal/domain/Congress.go`: 13 箇所を `NewDomainErrorCode(sentinel, "congress.errX", params)` へ。
  センチネル (`ErrInvalidPlay` / `ErrWrongPhase` / `ErrDeckExhausted`) は保つので
  `errors.Is` で見分ける呼び出し側は壊れない。
- ja/en の CUI ロケールに 13 キー。`{{pile}}` を持つ 2 件はパラメータ付き。
- **`CongressWebPresenter` は `lastErr.Error()` を `Message` にそのまま入れていた。**
  コード付きエラーではキー文字列が画面に出るので、Bisley と同じく `MessageCode` +
  `MessageParams` に振り分ける。frontend の `common.json` の `messageCode` 配下にも 13 キー。

## テスト

- `TestCongress_PlayerFacingErrorsCarryAMessageCode` — 17 経路それぞれで
  期待するコードと**センチネルが保たれていること**を見る
- `TestCongressCuiPresenter_ErrorsAreTranslated` — ja/en 両方で
  (a) キー文字列が出力に現れない (b) 訳文そのものが出る
  (c) **ja と en が違う文である**（両方に英文を入れても (a)(b) は通ってしまう）
- `TestCongressCuiPresenter_UncodedErrorsStillPrintTheirPhrase` — 変換していない
  エラーは今までどおり
- Web 側 3 本 — コードの振り分け / params の生存 / 生文の据え置き

変異テスト3件でいずれも検出を確認:
Web presenter がコードを無視 → 2件検出 / ja の訳を1件消す → 4件検出 /
issue が挙げたエラーだけ生文に戻す → 1件検出。

`go test ./internal/{domain,adapter/presenter,usecase}` green / `golangci-lint` 0 issues /
`bun run check` exit 0。