### PR TITLE
feat(braid): announce the one-time direction choice

### DIFF
--- a/frontend/src/components/LiveAnnouncement.test.tsx
+++ b/frontend/src/components/LiveAnnouncement.test.tsx
@@ -31,11 +31,19 @@ describe('LiveAnnouncement', () => {
     expect(after).toHaveTextContent('choose a direction');
   });
 
+  // role と aria-live は対。role="alert" は暗黙に assertive なので、
+  // 片方だけ切り替えると宣言が食い違う (GameMessageBox と同じ形にした)。
   it('is polite by default and assertive on request', () => {
-    const { rerender } = render(<LiveAnnouncement message="hi" />);
-    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
-    rerender(<LiveAnnouncement message="hi" assertive />);
-    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'assertive');
+    render(<LiveAnnouncement message="hi" />);
+    const polite = screen.getByRole('status');
+    expect(polite).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('switches role and aria-live together when assertive', () => {
+    render(<LiveAnnouncement message="hi" assertive />);
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
   });
 
   it('clears when the message goes away', async () => {

--- a/frontend/src/components/LiveAnnouncement.test.tsx
+++ b/frontend/src/components/LiveAnnouncement.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { LiveAnnouncement } from './LiveAnnouncement';
+
+describe('LiveAnnouncement', () => {
+  // **これが本題で、DOM を見ただけでは証明できない。**RTL の render は effect を
+  // 流してしまうので、最初のコミットの中身を見るには effect の走らない
+  // 静的レンダリングを使う。領域だけが出て、本文は入っていないこと ——
+  // これが崩れると、領域と本文が同時に現れて読み上げられなくなる。
+  it('paints the region before it paints the message', () => {
+    const html = renderToStaticMarkup(<LiveAnnouncement message="choose a direction" />);
+    expect(html).toContain('role="status"');
+    expect(html).not.toContain('choose a direction');
+  });
+
+  // 言うことが無いうちから領域が居ること。
+  it('renders the region even with nothing to say', () => {
+    render(<LiveAnnouncement message="" />);
+    expect(screen.getByRole('status')).toHaveTextContent('');
+  });
+
+  // 本文が付くとき、領域は**同じ DOM ノードのまま**であること。作り直すと
+  // 「既存の領域が変化した」ではなく「領域が現れた」になり、読み上げられない。
+  it('reuses the same node when the message arrives', () => {
+    const { rerender } = render(<LiveAnnouncement message="" />);
+    const before = screen.getByRole('status');
+    rerender(<LiveAnnouncement message="choose a direction" />);
+    const after = screen.getByRole('status');
+    expect(after).toBe(before);
+    expect(after).toHaveTextContent('choose a direction');
+  });
+
+  it('is polite by default and assertive on request', () => {
+    const { rerender } = render(<LiveAnnouncement message="hi" />);
+    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
+    rerender(<LiveAnnouncement message="hi" assertive />);
+    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'assertive');
+  });
+
+  it('clears when the message goes away', async () => {
+    const { rerender } = render(<LiveAnnouncement message="choose a direction" />);
+    rerender(<LiveAnnouncement message="" />);
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent(''));
+  });
+
+  // 読み上げ専用。見た目には出ない。
+  it('stays visually hidden', () => {
+    render(<LiveAnnouncement message="hi" />);
+    expect(screen.getByRole('status')).toHaveClass('sr-only');
+  });
+});

--- a/frontend/src/components/LiveAnnouncement.tsx
+++ b/frontend/src/components/LiveAnnouncement.tsx
@@ -34,7 +34,15 @@ export function LiveAnnouncement({ message, assertive = false }: LiveAnnouncemen
   }, [message]);
 
   return (
-    <div role="status" aria-live={assertive ? 'assertive' : 'polite'} aria-atomic="true" className="sr-only">
+    // role と aria-live を対で切り替える (GameMessageBox と同じ形)。
+    // role="alert" は暗黙に assertive なので、両方合わせておくと支援技術の
+    // 実装差に影響されにくい。
+    <div
+      role={assertive ? 'alert' : 'status'}
+      aria-live={assertive ? 'assertive' : 'polite'}
+      aria-atomic="true"
+      className="sr-only"
+    >
       {announced}
     </div>
   );

--- a/frontend/src/components/LiveAnnouncement.tsx
+++ b/frontend/src/components/LiveAnnouncement.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+
+/** Props for {@link LiveAnnouncement}. */
+export interface LiveAnnouncementProps {
+  /** What to announce. Empty means nothing is pending. */
+  message: string;
+  /**
+   * Interrupt whatever the screen reader is saying. Reserve it for a prompt the
+   * player cannot act correctly without — an irreversible one-time choice, not
+   * a status update.
+   */
+  assertive?: boolean;
+}
+
+/**
+ * Screen-reader-only live region that announces `message` when it appears.
+ *
+ * **The region is mounted before it has anything to say.** A live region that
+ * enters the DOM already holding its text is usually not announced at all:
+ * assistive tech watches an existing region for changes, and a region and its
+ * content arriving in the same commit is not a change. Holding the text back
+ * by one commit is what makes the announcement happen, and it is the whole
+ * reason this is a component rather than an `aria-live` attribute on the
+ * visible element.
+ *
+ * The visible element stays as it is; this is an additional channel, so the
+ * announcement never depends on how the visible copy is styled or positioned.
+ */
+export function LiveAnnouncement({ message, assertive = false }: LiveAnnouncementProps) {
+  const [announced, setAnnounced] = useState('');
+
+  useEffect(() => {
+    setAnnounced(message);
+  }, [message]);
+
+  return (
+    <div role="status" aria-live={assertive ? 'assertive' : 'polite'} aria-atomic="true" className="sr-only">
+      {announced}
+    </div>
+  );
+}

--- a/frontend/src/pages/BraidPage.test.tsx
+++ b/frontend/src/pages/BraidPage.test.tsx
@@ -416,3 +416,34 @@ describe('BraidPage keyboard shortcuts', () => {
     expect(mockExec).not.toHaveBeenCalled();
   });
 });
+
+// #5564: 方向は一度きりで取り消せないのに、その分岐点がページに現れたことが
+// 読み上げられていなかった。CUI は黄色で強調し、チュートリアルは太字で警告して
+// いるので、支援技術の利用者だけが自分で探さないと気づけない状態だった。
+describe('BraidPage direction announcement', () => {
+  const liveRegion = () => document.querySelector('[role="status"][aria-live="assertive"]');
+
+  it('announces the direction prompt while it is unset', async () => {
+    mockExec.mockResolvedValue(awaitingDirectionState);
+    renderWithProviders(<BraidPage />);
+    await waitFor(() => expect(screen.getByTestId('direction-up')).toBeInTheDocument());
+    // 見えている案内と同じ文言が、読み上げ用にも出ていること。
+    await waitFor(() => expect(liveRegion()).toHaveTextContent(/組札/));
+  });
+
+  // **選んだ後は黙ること。**空にしないと、以後の操作のたびに読み上げが残る。
+  it('says nothing once the direction is fixed', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<BraidPage />);
+    await waitFor(() => expect(screen.getByText(/向き: 昇順/)).toBeInTheDocument());
+    expect(liveRegion()).toHaveTextContent('');
+  });
+
+  // 見た目は変えない (受け入れ条件3)。案内の <p> はそのまま。
+  it('leaves the visible banner in place', async () => {
+    mockExec.mockResolvedValue(awaitingDirectionState);
+    renderWithProviders(<BraidPage />);
+    const banner = await screen.findByTestId('direction-up');
+    expect(banner.closest('[data-tutorial="br-direction"]')).not.toBeNull();
+  });
+});

--- a/frontend/src/pages/BraidPage.test.tsx
+++ b/frontend/src/pages/BraidPage.test.tsx
@@ -421,7 +421,7 @@ describe('BraidPage keyboard shortcuts', () => {
 // 読み上げられていなかった。CUI は黄色で強調し、チュートリアルは太字で警告して
 // いるので、支援技術の利用者だけが自分で探さないと気づけない状態だった。
 describe('BraidPage direction announcement', () => {
-  const liveRegion = () => document.querySelector('[role="status"][aria-live="assertive"]');
+  const liveRegion = () => document.querySelector('[role="alert"][aria-live="assertive"]');
 
   it('announces the direction prompt while it is unset', async () => {
     mockExec.mockResolvedValue(awaitingDirectionState);

--- a/frontend/src/pages/BraidPage.tsx
+++ b/frontend/src/pages/BraidPage.tsx
@@ -13,6 +13,7 @@ import { GamePageShell } from '../components/GamePageShell';
 import { GameResetButton } from '../components/GameResetButton';
 import { FrontendHintTooltip } from '../components/hint/FrontendHintTooltip';
 import { LandscapeBanner } from '../components/LandscapeBanner';
+import { LiveAnnouncement } from '../components/LiveAnnouncement';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { StalemateEscapeButton } from '../components/StalemateEscapeButton';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
@@ -315,6 +316,15 @@ function BraidPageContent() {
       ) : (
         <>
           <div className="flex-1 overflow-y-auto pt-3 px-2 sm:px-4 lg:px-8">
+            {/* **一度きりで取り消せない選択**なのに、画面に現れたことが
+                読み上げられていなかった (#5564)。見えている案内はそのまま、
+                読み上げ用の領域を別に持つ。assertive なのは、方向を決めるまで
+                他の手が一切通らないから。 */}
+            <LiveAnnouncement
+              assertive
+              message={state.awaitingDirection && isPlaying ? t('chooseDirectionBanner', { rank: state.baseRank }) : ''}
+            />
+
             {state.awaitingDirection && isPlaying && (
               <div className="text-center mb-2" data-tutorial="br-direction">
                 <p className="text-ds-warning text-sm mb-1">{t('chooseDirectionBanner', { rank: state.baseRank })}</p>


### PR DESCRIPTION
Closes #5564

## 何が問題だったか

ブレイドは**開始直後に取り消せない選択**がある（組札を昇順に積むか降順に積むか）。
CUI は `color.Yellow` で強調し、Web のチュートリアルは「一度決めると変えられません」と
太字で警告しているのに、Web の案内は普通の `<p>` で、支援技術の利用者だけが
「ゲーム唯一の分岐点が今画面に出ている」ことを自分で探しに行かないと気づけなかった。

## その `<p>` に `aria-live` を付けても直らない

issue の提案どおり既存の `<p>` に `role="status" aria-live="assertive"` を足しても、
**このケースでは読み上げられない**。live region は「既にある領域が変化した」ときに
読み上げられるもので、領域と本文が同じコミットで現れるのは変化ではない。
このページは `state` が来るまで `GameSkeleton` なので、案内は必ず領域ごと後から現れる。

そこで `LiveAnnouncement` を追加した: **空の領域を先に置き、本文は 1 コミット遅れて入れる。**
見えている `<p>` は一切変えていない（受け入れ条件3）。

## テスト

- `LiveAnnouncement`: **最初の描画に領域はあり本文は無い**ことを、effect の走らない
  `renderToStaticMarkup` で見る（RTL の `render` は effect を流すので DOM からは証明できない）。
  本文が付くとき領域が**同じ DOM ノードのまま**であること / polite ↔ assertive /
  消えること / `sr-only` であること
- `BraidPage`: 未選択の間は読み上げに文言が出る / 決まった後は**黙る** /
  見えているバナーはそのまま

変異テスト2件で検出確認: 領域を空にしない（決定後も読み上げが残る）→ 1件検出 /
遅延をやめて同じコミットで本文を入れる → 1件検出（**最初この変異が検出されず**、
DOM を見るだけのテストでは証明になっていないと分かったので上の静的レンダリングに直した）。

`bun run check` / `bun run typecheck` / 45 tests green。