### PR TITLE
feat(settemezzo): say where the other hands stand

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -29023,6 +29023,11 @@ components:
         targetHalves:
           type: integer
           description: The target (7.5) in halves, so 15. Sent so the figure is not written down twice.
+        cpuStandHalves:
+          type: integer
+          description: >-
+            The total in halves at which the CPU seats and the banker stand
+            (11, i.e. 5.5). Sent so the figure is not written down twice.
         canHit:
           type: boolean
         canStand:

--- a/frontend/src/hooks/useSetteEMezzoGame.test.ts
+++ b/frontend/src/hooks/useSetteEMezzoGame.test.ts
@@ -32,6 +32,7 @@ const baseState: SetteEMezzoResponse = {
   lastResult: '',
   phase: 1,
   targetHalves: 15,
+  cpuStandHalves: 11,
   canHit: false,
   canStand: false,
   canSetMatta: false,

--- a/frontend/src/i18n/locales/en/settemezzo.json
+++ b/frontend/src/i18n/locales/en/settemezzo.json
@@ -48,5 +48,6 @@
     "settemezzoHitLow": "Still far from seven and a half — draw another card",
     "settemezzoStandClose": "Close to seven and a half; drawing busts you more often than not",
     "settemezzoSetMatta": "You can choose the matta value — set it to reach exactly seven and a half"
-  }
+  },
+  "cpuStand": "They stand at {{total}}"
 }

--- a/frontend/src/i18n/locales/ja/settemezzo.json
+++ b/frontend/src/i18n/locales/ja/settemezzo.json
@@ -48,5 +48,6 @@
     "settemezzoHitLow": "7.5 まで距離があります。もう 1 枚引きましょう",
     "settemezzoStandClose": "7.5 に近く、引くと外す目のほうが多くなります",
     "settemezzoSetMatta": "マッタの値を決められます。7.5 ちょうどに合わせましょう"
-  }
+  },
+  "cpuStand": "相手は {{total}} 点で止まる"
 }

--- a/frontend/src/pages/SetteEMezzoPage.test.tsx
+++ b/frontend/src/pages/SetteEMezzoPage.test.tsx
@@ -46,6 +46,7 @@ function makeState(overrides?: Partial<SetteEMezzoResponse>): SetteEMezzoRespons
     lastResult: '',
     phase: 2,
     targetHalves: 15,
+    cpuStandHalves: 11,
     canHit: true,
     canStand: true,
     canSetMatta: false,
@@ -294,5 +295,27 @@ describe('SetteEMezzoPage keyboard shortcuts', () => {
 
     fireEvent.click(toggle);
     expect(await screen.findByTestId('hint-tooltip')).toBeInTheDocument();
+  });
+});
+
+// #5566: 相手がいつ引くのをやめるかが分からないまま、賭け続けるか降りるかを
+// 決めさせていた。
+describe('SetteEMezzoPage stand threshold', () => {
+  it('shows the threshold in points, not in halves', async () => {
+    mockExec.mockResolvedValue(makeState({}));
+    renderWithProviders(<SetteEMezzoPage />);
+    const line = await screen.findByTestId('settemezzo-cpu-stand');
+    expect(line).toHaveTextContent('5.5');
+    // **半点の内部表現をそのまま出さない。**11 と読めては意味が逆になる。
+    expect(line).not.toHaveTextContent('11');
+  });
+
+  // サーバが別の閾値を返せばそのまま出ること (定数を再実装していない証拠)。
+  it('renders whatever the server sends', async () => {
+    mockExec.mockResolvedValue(makeState({ cpuStandHalves: 13 }));
+    renderWithProviders(<SetteEMezzoPage />);
+    const line = await screen.findByTestId('settemezzo-cpu-stand');
+    expect(line).toHaveTextContent('6.5');
+    expect(line).not.toHaveTextContent('5.5');
   });
 });

--- a/frontend/src/pages/SetteEMezzoPage.tsx
+++ b/frontend/src/pages/SetteEMezzoPage.tsx
@@ -173,6 +173,13 @@ function SetteEMezzoPageContent() {
           <span className="text-sm text-ds-text-muted">
             {t('target')}: {halvesToLabel(state.targetHalves)}
           </span>
+          {/* **相手がいつ引くのをやめるかは、賭け続けるかの判断材料。**
+              ブラックジャックの「17 でスタンド」に当たる数字なのに、どの画面にも
+              出ていなかった (#5566)。半点はサーバから来るので、5.5 という文字列を
+              訳文にも画面にも焼き込まない。 */}
+          <span className="text-sm text-ds-text-muted" data-testid="settemezzo-cpu-stand">
+            {t('cpuStand', { total: halvesToLabel(state.cpuStandHalves) })}
+          </span>
           <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
         </>
       }

--- a/frontend/src/types/games/settemezzo.ts
+++ b/frontend/src/types/games/settemezzo.ts
@@ -54,5 +54,7 @@ export interface SetteEMezzoResponse extends BaseGameResponse {
   targetHalves: number;
   canHit: boolean;
   canStand: boolean;
+  /** Total (in halves) at which the CPU seats and the banker stand. */
+  cpuStandHalves: number;
   canSetMatta: boolean;
 }

--- a/frontend/src/utils/cli/formatters/settemezzoFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/settemezzoFormatter.test.ts
@@ -35,6 +35,7 @@ function makeState(overrides?: Partial<SetteEMezzoResponse>): SetteEMezzoRespons
     lastResult: '',
     phase: 2,
     targetHalves: 15,
+    cpuStandHalves: 11,
     canHit: true,
     canStand: true,
     canSetMatta: false,

--- a/internal/adapter/controller/SetteEMezzoWebController.go
+++ b/internal/adapter/controller/SetteEMezzoWebController.go
@@ -52,10 +52,13 @@ type SetteEMezzoWebOutput struct {
 	LastResult    string                      `json:"lastResult"`
 	Phase         int                         `json:"phase"`
 	// TargetHalves は 7.5 を半点単位で表したもの（15）。
-	TargetHalves int  `json:"targetHalves"`
-	CanHit       bool `json:"canHit"`
-	CanStand     bool `json:"canStand"`
-	CanSetMatta  bool `json:"canSetMatta"`
+	TargetHalves int `json:"targetHalves"`
+	// CpuStandHalves は CPU 席と親が止まる合計（11 = 5.5 点、#5566）。
+	// 数字を訳文に焼き込むと、閾値を変えたとき案内だけが嘘になる。
+	CpuStandHalves int  `json:"cpuStandHalves"`
+	CanHit         bool `json:"canHit"`
+	CanStand       bool `json:"canStand"`
+	CanSetMatta    bool `json:"canSetMatta"`
 	WebOutputBase
 }
 

--- a/internal/adapter/presenter/SetteEMezzoCuiPresenter.go
+++ b/internal/adapter/presenter/SetteEMezzoCuiPresenter.go
@@ -123,7 +123,13 @@ func (sp *SetteEMezzoCuiPresenter) actionHints(s interfaces.SetteEMezzoGame) str
 	if len(opts) == 0 {
 		return ""
 	}
-	return i18n.Tf("settemezzo.actionsLine", "options", strings.Join(opts, " / ")) + "\n"
+	// **相手がいつ引くのをやめるかは、賭け続けるかの判断材料。**その数字は
+	// どの画面にも出ていなかった (#5566)。点は FormatHalves に通す ── 半点単位の
+	// 内部表現をそのまま出すと 11 と読めてしまう。
+	return i18n.Tf("settemezzo.actionsLine", "options", strings.Join(opts, " / ")) + "\n" +
+		color.Yellow(i18n.Tf("settemezzo.cpuStandLine",
+			"total", s.FormatHalves(domain.SetteEMezzoCpuStandHalves),
+			"target", s.FormatHalves(domain.SetteEMezzoTargetHalves))) + "\n"
 }
 
 // ActionLogOutput 棋譜をテキスト出力

--- a/internal/adapter/presenter/SetteEMezzoCuiPresenter_test.go
+++ b/internal/adapter/presenter/SetteEMezzoCuiPresenter_test.go
@@ -183,3 +183,38 @@ func TestSetteEMezzoCuiPresenter_ActionLogOutput(t *testing.T) {
 		assert.Contains(t, new(SetteEMezzoCuiPresenter).ActionLogOutput(g), "test detail")
 	})
 }
+
+// #5566: 相手がいつ引くのをやめるかは、賭け続けるかの判断材料。5.5 点という
+// 数字はどの画面にも出ていなかった。
+func TestSetteEMezzoCuiPresenter_ShowsTheCpuStandThreshold(t *testing.T) {
+	g := new(interfaces.MockSetteEMezzoGame)
+	setupSemCuiMockDefaults(g)
+	// **半点をそのまま出さない。**閾値は 11 だが、画面に出るのは 5.5 点。
+	// ドメインの FormatHalves を通していることを、引数ごとの戻り値で確かめる
+	// (既定の総括登録を外してから、引数ごとに積む)。
+	g.ExpectedCalls = filterCalls(g.ExpectedCalls, "FormatHalves")
+	g.On("FormatHalves", domain.SetteEMezzoCpuStandHalves).Return("5.5").Maybe()
+	g.On("FormatHalves", domain.SetteEMezzoTargetHalves).Return("7.5").Maybe()
+	g.On("FormatHalves", mock.Anything).Return("4.5").Maybe()
+
+	out := new(SetteEMezzoCuiPresenter).Output(g, nil)
+	assert.Contains(t, out, i18n.Tf("settemezzo.cpuStandLine", "total", "5.5", "target", "7.5"))
+	assert.NotContains(t, out, i18n.Tf("settemezzo.cpuStandLine", "total", "11", "target", "15"))
+}
+
+// 打てる手が無い局面では出さない。手番でもないのに停止ラインだけ残ると、
+// 誰の話をしているのか分からない。
+func TestSetteEMezzoCuiPresenter_HidesTheThresholdWithNoLegalAction(t *testing.T) {
+	g := new(interfaces.MockSetteEMezzoGame)
+	setupSemCuiMockDefaults(g)
+	g.ExpectedCalls = filterCalls(g.ExpectedCalls, "FormatHalves")
+	g.On("FormatHalves", domain.SetteEMezzoCpuStandHalves).Return("5.5").Maybe()
+	g.On("FormatHalves", domain.SetteEMezzoTargetHalves).Return("7.5").Maybe()
+	g.On("FormatHalves", mock.Anything).Return("4.5").Maybe()
+	for _, name := range []string{"CanHit", "CanStand", "CanSetMatta"} {
+		g.ExpectedCalls = filterCalls(g.ExpectedCalls, name)
+		g.On(name).Return(false)
+	}
+	assert.NotContains(t, new(SetteEMezzoCuiPresenter).Output(g, nil),
+		i18n.Tf("settemezzo.cpuStandLine", "total", "5.5", "target", "7.5"))
+}

--- a/internal/adapter/presenter/SetteEMezzoWebPresenter.go
+++ b/internal/adapter/presenter/SetteEMezzoWebPresenter.go
@@ -67,6 +67,7 @@ func (sp *SetteEMezzoWebPresenter) Output(s interfaces.SetteEMezzoGame, lastErr 
 	resObj.TargetHalves = domain.SetteEMezzoTargetHalves
 	resObj.CanHit = s.CanHit()
 	resObj.CanStand = s.CanStand()
+	resObj.CpuStandHalves = domain.SetteEMezzoCpuStandHalves
 	resObj.CanSetMatta = s.CanSetMatta()
 
 	if lastErr != nil {

--- a/internal/adapter/presenter/SetteEMezzoWebPresenter_test.go
+++ b/internal/adapter/presenter/SetteEMezzoWebPresenter_test.go
@@ -237,3 +237,16 @@ func TestSetteEMezzoWebPresenter_ActionLogOutput(t *testing.T) {
 		assert.Contains(t, new(SetteEMezzoWebPresenter).ActionLogOutput(g), "deal")
 	})
 }
+
+// #5566: 停止ラインの数字はドメインの定数から来ること。訳文にも TS にも
+// 焼き込まないので、ここが落ちるとクライアントは「0 点で止まる」と書く。
+func TestSetteEMezzoWebPresenter_CarriesTheCpuStandThreshold(t *testing.T) {
+	g := new(interfaces.MockSetteEMezzoGame)
+	setupSemWebMockDefaults(g)
+
+	result := parseSemOutput(t, new(SetteEMezzoWebPresenter).Output(g, nil))
+	assert.Equal(t, domain.SetteEMezzoCpuStandHalves, result.CpuStandHalves)
+	assert.NotZero(t, result.CpuStandHalves)
+	// 目標点とは別の数字であること。同じなら CPU は一度も引かない。
+	assert.NotEqual(t, result.TargetHalves, result.CpuStandHalves)
+}

--- a/internal/domain/SetteEMezzo.go
+++ b/internal/domain/SetteEMezzo.go
@@ -284,7 +284,6 @@ func (s *SetteEMezzo) playCpuSeat(h *SetteEMezzoHand) {
 		if total >= SetteEMezzoTargetHalves {
 			break
 		}
-		// 11 半点 = 5.5 点。ここを超えたら止める。
 		if total >= SetteEMezzoCpuStandHalves {
 			h.stood = true
 			break

--- a/internal/domain/SetteEMezzo.go
+++ b/internal/domain/SetteEMezzo.go
@@ -43,6 +43,14 @@ const (
 // 依存する形になるため、全体を 2 倍した整数で扱う。
 const SetteEMezzoTargetHalves = 15
 
+// SetteEMezzoCpuStandHalves CPU 席と CPU 親がここに達したら止める (5.5 点)。
+//
+// **相手の停止ラインは賭け続けるかの判断材料。**ブラックジャックの「17 で
+// スタンド」に当たる数字なのに、どの画面にも出ていなかった (#5566)。案内は
+// この定数を FormatHalves に通して書く。文言に 5.5 を焼き込むと、閾値を
+// 変えたとき案内だけが嘘になる。
+const SetteEMezzoCpuStandHalves = 11
+
 // SetteEMezzoMattaDesign マッタ（コインの K）に対応するスート。
 // フレンチスートではコイン＝ダイヤに対応させる。
 const SetteEMezzoMattaDesign = CardDesignDiamond
@@ -277,7 +285,7 @@ func (s *SetteEMezzo) playCpuSeat(h *SetteEMezzoHand) {
 			break
 		}
 		// 11 半点 = 5.5 点。ここを超えたら止める。
-		if total >= 11 {
+		if total >= SetteEMezzoCpuStandHalves {
 			h.stood = true
 			break
 		}

--- a/internal/domain/SetteEMezzo_test.go
+++ b/internal/domain/SetteEMezzo_test.go
@@ -5,6 +5,9 @@ package domain
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // setteEMezzoDealAttempts caps the reshuffles a test may take while looking for
@@ -908,4 +911,62 @@ func TestSetteEMezzo_BankerStandSettles(t *testing.T) {
 	if !s.GetBankerHand().IsStood() {
 		t.Error("the banker's hand should be marked as stood")
 	}
+}
+
+// #5566: 停止ライン (11 半点 = 5.5 点) は直書きされているだけで、どの画面にも
+// 出ていなかった。定数にしたので、実際に打たせて定数どおりに止まることを見る。
+func TestSetteEMezzoCpuStandsAtTheNamedThreshold(t *testing.T) {
+	// 定数そのものは規則の一部。黙って変わると案内も一緒に変わる。
+	assert.Equal(t, 11, SetteEMezzoCpuStandHalves)
+	assert.Less(t, SetteEMezzoCpuStandHalves, SetteEMezzoTargetHalves,
+		"standing at or above the target would mean the CPU never draws")
+
+	// **止まった手だけを見る。**バーストとデッキ切れは閾値と無関係。
+	for range 300 {
+		s := NewDefaultSetteEMezzo()
+		s.Reset()
+		if err := s.PlaceBet(10); err != nil {
+			continue
+		}
+		for range 10 {
+			if s.GetPhase() != SetteEMezzoPhasePlayerTurn {
+				break
+			}
+			if s.CanStand() {
+				_ = s.Stand()
+				continue
+			}
+			if s.Hit() != nil {
+				break
+			}
+		}
+		if s.GetPhase() != SetteEMezzoPhaseEnd {
+			continue
+		}
+		for i, seat := range s.GetSeats() {
+			if !seat.IsCPU() || i == s.banker {
+				continue
+			}
+			h := seat.hand
+			total := s.handHalves(h)
+			if !h.stood || total > SetteEMezzoTargetHalves {
+				continue
+			}
+			assert.GreaterOrEqual(t, total, SetteEMezzoCpuStandHalves,
+				"a CPU seat stood below the threshold")
+		}
+	}
+}
+
+// ちょうど閾値で止まり、1 つ下では引くこと。境界そのものを固定する。
+func TestSetteEMezzoCpuStandsExactlyAtTheThreshold(t *testing.T) {
+	atThreshold := NewDefaultSetteEMezzo()
+	atThreshold.Reset()
+	h := &SetteEMezzoHand{cards: []*Card{
+		NewCard(CardDesignSpade, 5, true),  // 5 -> 10 halves
+		NewCard(CardDesignHeart, 11, true), // face -> 1 half
+	}}
+	require.Equal(t, SetteEMezzoCpuStandHalves, atThreshold.handHalves(h))
+	atThreshold.playCpuSeat(h)
+	assert.Len(t, h.cards, 2, "a hand already at the threshold does not draw")
 }

--- a/internal/i18n/locales/en/settemezzo.json
+++ b/internal/i18n/locales/en/settemezzo.json
@@ -24,5 +24,6 @@
   "optStand": "s = stand",
   "optMatta": "matta = set the matta",
   "bankPasses": "{{name}} lands exactly 7.5 and takes the bank",
-  "helpExampleBet": "  b 100                    bet 100 chips"
+  "helpExampleBet": "  b 100                    bet 100 chips",
+  "cpuStandLine": "The CPU seats and the banker stand at {{total}} or more (over {{target}} busts)."
 }

--- a/internal/i18n/locales/ja/settemezzo.json
+++ b/internal/i18n/locales/ja/settemezzo.json
@@ -24,5 +24,6 @@
   "optStand": "s=止める",
   "optMatta": "matta=マッタの値",
   "bankPasses": "{{name}} がちょうど7.5を出して親を取りました",
-  "helpExampleBet": "  b 100                   100 チップを賭ける"
+  "helpExampleBet": "  b 100                   100 チップを賭ける",
+  "cpuStandLine": "CPU 席と親は {{total}} 点以上で止まります（{{target}} 点を超えるとバースト）。"
 }


### PR DESCRIPTION
Closes #5566

## 何が問題だったか

CPU 席と親は **5.5 点で止まる**（ブラックジャックの「17 でスタンド」に当たる、
このゲーム独自の閾値）。ところがその数字はドメインに素の `11` として書かれているだけで、
CUI にも Web にもロケールにも出ていなかった。プレイヤーは相手がいつ引くのをやめるか
分からないまま、賭け続けるか降りるかを決めていた。

issue の前提はコードと一致していた（`playCpuSeat` は席と親の両方が通る）。

## 変更

- `SetteEMezzoCpuStandHalves = 11` を新設し、直書きの 11 を置き換え。
- CUI: `actionHints` に停止ラインの行。打てる手が無い局面では出さない。
- Web: `cpuStandHalves` をレスポンスに載せ、ヘッダに表示。`api/openapi.yaml` にも追加
  （CRLF 維持、numstat 5/0）。
- **どちらも `FormatHalves` を通す。**内部表現は半点なので、素で出すと `11` と読める ——
  目標の 7.5 より 2 点*上*に見えてしまい、助言の意味が逆になる。
  5.5 という文字列は訳文にも TS にも書かない。

## テスト

- ドメイン: 定数の値と `< SetteEMezzoTargetHalves`（同じなら CPU は一度も引かない）/
  300 局を最後まで打たせて**止まった手**が閾値未満でないこと / ちょうど閾値の手は引かない
- CUI: `FormatHalves` を**引数ごとにモック**して 5.5 が出ること、**11/15 の行が出ないこと**/
  打てる手が無ければ出さない
- Web presenter: `cpuStandHalves` が乗る / ゼロでない / **目標点とは別の数字**
- ページ: 5.5 が出て 11 が出ない / **サーバが 13 を返せば 6.5 と出る**（定数を再実装していない証拠）

変異テスト2件: 閾値を 2 半点ずらす → 1件検出 / CUI が半点を素で出す → 4件検出。

`golangci-lint` 0 issues / `bun run check` / `bun run typecheck` green。