### PR TITLE
feat(mushi): print the wild card's exception in the CUI too

### DIFF
--- a/internal/adapter/presenter/MushiCuiPresenter.go
+++ b/internal/adapter/presenter/MushiCuiPresenter.go
@@ -58,6 +58,10 @@ func (p *MushiCuiPresenter) Output(m interfaces.MushiGame, lastErr error) string
 
 		fieldCards := m.GetField()
 		sb.WriteString(i18n.Tf("mushi.fieldLine", "cards", mushiCardListStr(fieldCards, true)) + "\n")
+		// **ワイルドの唯一の例外がこのゲームの間違いの大半を決める。**Web は
+		// 場札の真下に出しっぱなしにしているのに、CUI はワイルドを選んで
+		// 弾かれるまで教えていなかった (#5569)。同じ場所に、同じ意味で出す。
+		sb.WriteString(color.Yellow(i18n.T("mushi.wildRule")) + "\n")
 
 		for i, player := range m.GetPlayers() {
 			captured := m.GetCaptured(i)

--- a/internal/adapter/presenter/MushiCuiPresenter_test.go
+++ b/internal/adapter/presenter/MushiCuiPresenter_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func TestMushiCuiPresenter_ShowsBothCapturesButOnlyTheHumanHand(t *testing.T) {
@@ -227,4 +228,50 @@ func TestMushiCuiPresenter_EveryReasonTheHintCanReturnIsMapped(t *testing.T) {
 		assert.NotEmpty(t, mushiHintReasonKeys[reason], "reason %q has no i18n key", reason)
 	}
 	assert.Len(t, mushiHintReasonKeys, 6, "a new reason needs an entry here too")
+}
+
+// #5569: ワイルドの唯一の例外 (柳だけは取れない) は Web には出しっぱなしなのに、
+// CUI はワイルドを選んで弾かれるまで教えていなかった。
+func TestMushiCuiPresenter_AlwaysShowsTheWildRule(t *testing.T) {
+	m := domain.NewDefaultMushi()
+	m.Reset()
+	assert.Contains(t, new(MushiCuiPresenter).Output(m, nil), i18n.T("mushi.wildRule"))
+
+	// **弾かれた直後こそ要る。**エラー行と一緒に出ること。
+	assert.Contains(t, new(MushiCuiPresenter).Output(m, assert.AnError), i18n.T("mushi.wildRule"))
+
+	// **フェーズが変わっても残ること。**選択中こそ一番要る規則なので、
+	// 手番の途中で消えては意味がない。
+	m2 := domain.NewDefaultMushi()
+	m2.Reset()
+	for range 400 {
+		if m2.GetPhase() == domain.MushiPhaseSelect || m2.GetPhase() == domain.MushiPhaseWildSelect {
+			break
+		}
+		if m2.GetGameEndFlag() {
+			break
+		}
+		idx := m2.GetCurrentPlayerIdx()
+		if !m2.GetPlayer(idx).GetIsHuman() {
+			m2.MushiCpuDecide(idx)
+		}
+		if err := m2.PlayCard(idx, 0); err != nil {
+			break
+		}
+	}
+	assert.Contains(t, new(MushiCuiPresenter).Output(m2, nil), i18n.T("mushi.wildRule"))
+}
+
+// 場札のすぐ下に出ること。Web と同じ位置なので、片方を見て覚えた人が
+// もう片方で探し直さずに済む。
+func TestMushiCuiPresenter_PutsTheWildRuleUnderTheField(t *testing.T) {
+	m := domain.NewDefaultMushi()
+	m.Reset()
+
+	out := new(MushiCuiPresenter).Output(m, nil)
+	fieldAt := strings.Index(out, strings.SplitN(i18n.T("mushi.fieldLine"), "{{", 2)[0])
+	ruleAt := strings.Index(out, i18n.T("mushi.wildRule"))
+	require.NotEqual(t, -1, ruleAt)
+	require.NotEqual(t, -1, fieldAt)
+	assert.Greater(t, ruleAt, fieldAt, "the rule belongs under the field, as on the Web page")
 }

--- a/internal/i18n/locales/en/mushi.json
+++ b/internal/i18n/locales/en/mushi.json
@@ -29,5 +29,6 @@
   "hintReasonPlay": "this card captures the most points",
   "cardLabel": "m{{month}}-{{index}}({{category}})",
   "helpExamplePlay": "  p 0                      play hand card 0",
-  "helpHint": "  h                        show a hint"
+  "helpHint": "  h                        show a hint",
+  "wildRule": "The ★ lightning card is wild — it takes any field card EXCEPT a willow"
 }

--- a/internal/i18n/locales/ja/mushi.json
+++ b/internal/i18n/locales/ja/mushi.json
@@ -29,5 +29,6 @@
   "hintReasonPlay": "この札が最も多くの点を取れます",
   "cardLabel": "{{month}}月{{index}}({{category}})",
   "helpExamplePlay": "  p 0                      手札の 0 番のカードを出す",
-  "helpHint": "  h                        助言を表示"
+  "helpHint": "  h                        助言を表示",
+  "wildRule": "★ の雷札はワイルド。柳以外なら何でも取れます（柳だけは取れません）"
 }

--- a/internal/infrastructure/games/mushi_wild_rule_test.go
+++ b/internal/infrastructure/games/mushi_wild_rule_test.go
@@ -1,0 +1,51 @@
+package games_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMushiWildRuleReadsTheSameInBothCatalogues keeps the wild card's one
+// exception saying the same thing on both surfaces.
+//
+// The rule -- the lightning card takes anything except a willow -- decides most
+// of the mistakes in this game, and it lived only on the Web page until #5569
+// put it in the CUI too. The two catalogues are separate files (`internal/i18n`
+// for the CUI, `frontend/src/i18n` for the Web), so the sentence now exists
+// twice with nothing tying the copies together: reword one and the other keeps
+// teaching the old rule, silently and only to half the players.
+func TestMushiWildRuleReadsTheSameInBothCatalogues(t *testing.T) {
+	root := filepath.Join("..", "..", "..")
+
+	read := func(path string) map[string]any {
+		t.Helper()
+		raw, err := os.ReadFile(filepath.Join(root, path))
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		return m
+	}
+
+	for _, lang := range []string{"ja", "en"} {
+		cui := read("internal/i18n/locales/" + lang + "/mushi.json")
+		web := read("frontend/src/i18n/locales/" + lang + "/mushi.json")
+
+		cuiRule, ok := cui["wildRule"].(string)
+		if !ok || cuiRule == "" {
+			t.Fatalf("%s: internal/i18n has no mushi.wildRule", lang)
+		}
+		webRule, ok := web["wildRule"].(string)
+		if !ok || webRule == "" {
+			t.Fatalf("%s: frontend/src/i18n has no wildRule", lang)
+		}
+		if cuiRule != webRule {
+			t.Errorf("%s: the wild rule differs between the two catalogues\n CUI: %s\n Web: %s", lang, cuiRule, webRule)
+		}
+	}
+}


### PR DESCRIPTION
Closes #5569

## 何が問題だったか

★ の雷札は「柳以外なら何でも取れる」。**この 1 つの例外がこのゲームの間違いの大半を決める**
ので Web は場札の真下に出しっぱなしにしているのに、CUI は一言も出していなかった。
Go 側ロケールに `wildRule` に相当するキー自体が無く、Web 専用の説明になっていた。
端末のプレイヤーは柳を選んで弾かれて初めて気づく。

## 変更

- `internal/i18n/locales/{ja,en}/mushi.json` に `wildRule`（Web と同じ文）
- `MushiCuiPresenter.Output` が場札行の直下に常時出力（**Web と同じ位置** — 片方で覚えた人が
  もう片方で探し直さずに済む）

## 同じ文が 2 つのカタログに並ぶので、突き合わせる

CUI は `internal/i18n`、Web は `frontend/src/i18n` で**別カタログ**。同じ文が 2 箇所に
できたので、片方を直しても気づけない。`internal/infrastructure/games` に
（`baccarat_payout_test.go` と同じ形で）両方の JSON を読んで**文字列一致**を見るテストを追加した。

**さっそく効いた。**英語を手で書いたら Web が em ダッシュ `—` のところをハイフン 2 つで
書いていて、そのまま出荷するところだった。

## テスト

- 常時出ること / **エラー行と一緒にも出ること**（弾かれた直後こそ要る）/ 選択フェーズでも残ること
- 場札行の**下**にあること（位置まで見る）
- ja/en 両方でカタログ間の文字列が一致すること

変異テスト2件: CUI の出力行を消す → 5件検出 / ja の文から「柳だけは取れません」を落とす → 4件検出。

`golangci-lint` 0 issues / 関連パッケージ green。