### PR TITLE
fix(test): stop the help-example guard reporting refusals that were marked

### DIFF
--- a/internal/infrastructure/ui/help_example_exec_test.go
+++ b/internal/infrastructure/ui/help_example_exec_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
@@ -123,6 +124,27 @@ var exampleRefusalRe = regexp.MustCompile(`(?i)invalid|required|must |cannot|not
 // cannot be found by looking at the whole output's length.
 var exampleErrorLineRe = regexp.MustCompile("\x1b\\[31m(.*?)\x1b\\[0m")
 
+// dropMarkedErrorLines removes the lines a presenter already marked as
+// rejections, leaving the ones nothing marked.
+//
+// Without this the guard reports every properly marked refusal it happens to
+// trigger, which is deal-dependent: bisley's `ac` example only gets turned down
+// when the deal leaves nothing to send to a foundation, so this failed about
+// one run in seven and looked like a flake.
+func dropMarkedErrorLines(out string) string {
+	if !strings.Contains(out, i18n.ErrorLinePrefix) {
+		return out
+	}
+	kept := make([]string, 0, 32)
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, i18n.ErrorLinePrefix) {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "\n")
+}
+
 // exampleRefusalLine reports the line on which the game turned the command
 // down, if it did.
 //
@@ -196,6 +218,13 @@ func TestCuiHelpExamplesAreNotQuietlyRefused(t *testing.T) {
 			if _, isErr := i18n.StripErrorPrefix(out); isErr {
 				continue // TestCuiHelpExamplesExecute owns the marked ones
 			}
+			// **A board game marks the line, not the reply.** cuiErrorBlock
+			// renders a refusal as ErrorLinePrefix + a red line inside the
+			// board, so StripErrorPrefix above -- which only looks at the front
+			// of the whole reply -- never sees it. Scanning what is left after
+			// the marked lines are removed keeps the two shapes apart: a
+			// properly marked refusal drops out, an unmarked one stays.
+			out = dropMarkedErrorLines(out)
 			if line, ok := exampleRefusalLine(out); ok {
 				bad = append(bad, entry.Name+": `"+cmd+"` -> "+line)
 			}
@@ -208,5 +237,39 @@ func TestCuiHelpExamplesAreNotQuietlyRefused(t *testing.T) {
 	if len(bad) > 0 {
 		t.Errorf("examples the game turns down without marking it (%d of %d):\n  %s",
 			len(bad), checked, strings.Join(bad, "\n  "))
+	}
+}
+
+// TestDropMarkedErrorLinesKeepsTheUnmarkedOnes is the negative control for the
+// filter above: it must remove what a presenter marked and keep what nothing
+// marked, or the guard it feeds stops catching the thing it exists for.
+func TestDropMarkedErrorLinesKeepsTheUnmarkedOnes(t *testing.T) {
+	board := "Round: 1  Trick: 0\n"
+	marked := i18n.MarkErrorLine(color.Red("No card can be sent to a foundation"))
+	unmarked := color.Red("Multiplier (1, 2 or 3) is required.")
+
+	// A marked refusal drops out, so the guard says nothing about it.
+	if _, ok := exampleRefusalLine(dropMarkedErrorLines(board + marked + "\n")); ok {
+		t.Error("a marked refusal must not be reported")
+	}
+
+	// An unmarked one survives and is still reported.
+	line, ok := exampleRefusalLine(dropMarkedErrorLines(board + unmarked + "\n"))
+	if !ok {
+		t.Fatal("an unmarked refusal must still be reported")
+	}
+	if !strings.Contains(line, "required") {
+		t.Errorf("reported the wrong line: %q", line)
+	}
+
+	// Both at once: the unmarked one is what comes back.
+	line, ok = exampleRefusalLine(dropMarkedErrorLines(board + marked + "\n" + unmarked + "\n"))
+	if !ok || !strings.Contains(line, "required") {
+		t.Errorf("an unmarked refusal beside a marked one must still be reported, got %q (%v)", line, ok)
+	}
+
+	// Nothing marked, nothing to drop -- the input is returned untouched.
+	if got := dropMarkedErrorLines(board); got != board {
+		t.Errorf("an ordinary board must pass through unchanged, got %q", got)
 	}
 }


### PR DESCRIPTION
## 症状

`TestCuiHelpExamplesAreNotQuietlyRefused` が **クリーンな develop で 20 回中 3 回**落ちる。

```
examples the game turns down without marking it (1 of 404):
  bisley: `ac` -> No card can be sent to a foundation
```

PR #5928 の CI で見つけたが、その PR は mushi しか触っていない。develop で実測して再現した
（フレークとして再実行で済ませず、[flake-ledger](../.claude/skills/flake-ledger/SKILL.md) の
手順どおり 2 回目の観測まで取った）。

## 原因: ガードが「印」を 1 種類しか知らなかった

拒否の印は 2 種類ある:

- `i18n.MarkError` — **返答全体**の先頭に付く（短い返答だけを返すゲーム）
- `i18n.MarkErrorLine` — **1 行**に付く（盤面を描き直すゲーム。`cuiErrorBlock` がこれ）

ガードは `StripErrorPrefix`（前者だけ）を見て「印が無い」と判断し、盤の中に赤く出ている
**正しく印の付いた**拒否を報告していた。ビズリーの `ac` は「基礎札に送れる札が無い」配りの
ときだけ拒否されるので、**配り依存**で 7 回に 1 回ほど落ちる形になっていた。

## 修正

印の付いた行を落としてから走査する。2 つの形が混ざらない。

**ガードを盲目にして直したのではないこと**を、隣の単体テストで担保している:
印の付いた拒否と付いていない拒否を並べて、**付いていない方は今も報告される**ことを見る
（`TestDropMarkedErrorLinesKeepsTheUnmarkedOnes`）。変異テストで「全行を落とす」形にすると
4 件検出する。

## 実測

- 修正前: クリーンな develop で **3/20 失敗**
- 修正後: **12/12 成功**、`internal/infrastructure/ui` 全体も green、`golangci-lint` 0 issues