### PR TITLE
feat(laughandliedown): show the last-in bonus on the web too

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -29382,6 +29382,11 @@ components:
         lastInIdx:
           type: integer
           description: "Last seat still holding cards; -1 while undecided"
+        lastInBonus:
+          type: integer
+          description: >-
+            What the seat at `lastInIdx` receives. Sent so the figure is not
+            written into a translation string on one surface only.
         pot:
           type: integer
           description: |

--- a/frontend/src/i18n/locales/en/laughandliedown.json
+++ b/frontend/src/i18n/locales/en/laughandliedown.json
@@ -13,7 +13,7 @@
   "opponentHandAriaLabel": "{{name}} holds {{n}} face-down card(s)",
   "yourHand": "Your hand",
   "score": "net {{n}}",
-  "lastIn": "was last in",
+  "lastIn": "was last in: +{{amount}}",
   "landscapeBanner": "Turn your device sideways for a better view",
   "phase.play": "In progress",
   "phase.end": "Finished",

--- a/frontend/src/i18n/locales/ja/laughandliedown.json
+++ b/frontend/src/i18n/locales/ja/laughandliedown.json
@@ -13,7 +13,7 @@
   "opponentHandAriaLabel": "{{name}} の手札 {{n}} 枚（裏向き）",
   "yourHand": "あなたの手札",
   "score": "収支 {{n}}",
-  "lastIn": "最後まで手札を持っていました",
+  "lastIn": "最後まで手札を持っていたので +{{amount}}",
   "landscapeBanner": "横向きにするとカードが見やすくなります",
   "phase.play": "進行中",
   "phase.end": "終了",

--- a/frontend/src/pages/LaughAndLieDownPage.test.tsx
+++ b/frontend/src/pages/LaughAndLieDownPage.test.tsx
@@ -4,6 +4,7 @@ import { laughandliedownApi } from '../api/gameApi';
 import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, LaughAndLieDownPlayer, LaughAndLieDownResponse } from '../types/card';
+import { LaughAndLieDownPhase } from '../types/phases';
 import { LaughAndLieDownPage } from './LaughAndLieDownPage';
 
 vi.mock('../api/gameApi', () => ({
@@ -53,6 +54,7 @@ function makeState(overrides?: Partial<LaughAndLieDownResponse>): LaughAndLieDow
     threeTakeIndices: [],
     dealerIdx: 0,
     lastInIdx: -1,
+    lastInBonus: 5,
     pot: 11,
     gameEndFlag: false,
     message: '',
@@ -180,5 +182,50 @@ describe('LaughAndLieDownPage', () => {
       renderWithProviders(<LaughAndLieDownPage />);
       await waitFor(() => expect(screen.getAllByText(text).length).toBeGreaterThan(0));
     }
+  });
+
+  // #5576: 訳文 (`lastIn`) もサーバのデータ (`lastInIdx`) も既にあったのに、
+  // 画面が一度も読んでいなかった。最終点差の理由の一つが出ないまま終わっていた。
+  describe('last-in bonus', () => {
+    it('names the opponent who was last in, with the amount', async () => {
+      mockExec.mockResolvedValue(makeState({ phase: LaughAndLieDownPhase.GAME_END, lastInIdx: 1, lastInBonus: 5 }));
+      renderWithProviders(<LaughAndLieDownPage />);
+      const row = await screen.findByTestId('lld-lastin-1');
+      expect(row).toHaveTextContent('5');
+      // 他の席には出ない。全員に出すと誰が受け取ったか分からない。
+      expect(screen.queryByTestId('lld-lastin-0')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('lld-lastin-2')).not.toBeInTheDocument();
+    });
+
+    it('names the human seat when it was last in', async () => {
+      mockExec.mockResolvedValue(makeState({ phase: LaughAndLieDownPhase.GAME_END, lastInIdx: 0, lastInBonus: 5 }));
+      renderWithProviders(<LaughAndLieDownPage />);
+      expect(await screen.findByTestId('lld-lastin-0')).toBeInTheDocument();
+    });
+
+    // -1 は「該当なし」。出すと、誰も受け取っていないボーナスを説明することになる。
+    it('says nothing when nobody was last in', async () => {
+      mockExec.mockResolvedValue(makeState({ phase: LaughAndLieDownPhase.GAME_END, lastInIdx: -1 }));
+      renderWithProviders(<LaughAndLieDownPage />);
+      await waitFor(() => expect(mockExec).toHaveBeenCalled());
+      expect(document.querySelector('[data-testid^="lld-lastin-"]')).toBeNull();
+    });
+
+    // 決着前は出さない。まだ確定していない。
+    it('says nothing before the game ends', async () => {
+      mockExec.mockResolvedValue(makeState({ phase: LaughAndLieDownPhase.PLAY, lastInIdx: 1, lastInBonus: 5 }));
+      renderWithProviders(<LaughAndLieDownPage />);
+      await waitFor(() => expect(mockExec).toHaveBeenCalled());
+      expect(document.querySelector('[data-testid^="lld-lastin-"]')).toBeNull();
+    });
+
+    // **額はサーバから。**訳文に数字を書くと、額を変えたとき片方だけ嘘になる。
+    it('renders whatever amount the server sends', async () => {
+      mockExec.mockResolvedValue(makeState({ phase: LaughAndLieDownPhase.GAME_END, lastInIdx: 1, lastInBonus: 9 }));
+      renderWithProviders(<LaughAndLieDownPage />);
+      const row = await screen.findByTestId('lld-lastin-1');
+      expect(row).toHaveTextContent('9');
+      expect(row).not.toHaveTextContent('5');
+    });
   });
 });

--- a/frontend/src/pages/LaughAndLieDownPage.tsx
+++ b/frontend/src/pages/LaughAndLieDownPage.tsx
@@ -146,6 +146,11 @@ function LaughAndLieDownPageContent() {
                     {t('won', { n: o.wonCount })}
                     {o.laidDown && ` · ${t('laidDown')}`}
                     {ended && ` · ${t('score', { n: o.score })}`}
+                    {ended && state.lastInIdx === o.id && (
+                      <span data-testid={`lld-lastin-${o.id.toString()}`}>
+                        {` · ${t('lastIn', { amount: state.lastInBonus })}`}
+                      </span>
+                    )}
                   </div>
                   <div
                     className="flex gap-1 justify-center flex-wrap"
@@ -181,6 +186,11 @@ function LaughAndLieDownPageContent() {
                 {' · '}
                 {t('won', { n: human?.wonCount ?? 0 })}
                 {ended && ` · ${t('score', { n: human?.score ?? 0 })}`}
+                {/* **既に訳文もサーバのデータもあったのに、画面が一度も読んでいなかった**
+                    (#5576)。最終点差の理由の一つがどこにも出ないまま終わっていた。 */}
+                {ended && state.lastInIdx === 0 && (
+                  <span data-testid="lld-lastin-0">{` · ${t('lastIn', { amount: state.lastInBonus })}`}</span>
+                )}
               </div>
               <div className="flex gap-2 justify-center flex-wrap items-start">
                 {(human?.cards ?? []).map((card, i) => {

--- a/frontend/src/types/games/laughandliedown.ts
+++ b/frontend/src/types/games/laughandliedown.ts
@@ -56,6 +56,8 @@ export interface LaughAndLieDownResponse extends BaseGameResponse {
   dealerIdx: number;
   /** Last seat still holding cards; -1 while undecided. */
   lastInIdx: number;
+  /** What the player at `lastInIdx` receives. Sent so the figure is not written down twice. */
+  lastInBonus: number;
   /**
    * Total staked. Equals the last-in award plus the over/short total, which is
    * what verifies the settlement table.

--- a/frontend/src/utils/cli/formatters/laughandliedownFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/laughandliedownFormatter.test.ts
@@ -36,6 +36,7 @@ function makeState(overrides?: Partial<LaughAndLieDownResponse>): LaughAndLieDow
     threeTakeIndices: [],
     dealerIdx: 0,
     lastInIdx: -1,
+    lastInBonus: 5,
     pot: 11,
     gameEndFlag: false,
     message: '',

--- a/frontend/src/utils/hints/laughandliedownHint.test.ts
+++ b/frontend/src/utils/hints/laughandliedownHint.test.ts
@@ -11,6 +11,7 @@ const base = {
   threeTakeIndices: [],
   dealerIdx: 0,
   lastInIdx: -1,
+  lastInBonus: 5,
   pot: 11,
   gameEndFlag: false,
   message: '',

--- a/internal/adapter/controller/LaughAndLieDownWebController.go
+++ b/internal/adapter/controller/LaughAndLieDownWebController.go
@@ -62,6 +62,9 @@ type LaughAndLieDownWebOutput struct {
 	DealerIdx        int   `json:"dealerIdx"`
 	// LastInIdx は最後まで手札が残っていた人 (-1: 未決着/該当なし)。
 	LastInIdx int `json:"lastInIdx"`
+	// LastInBonus は上の人が受け取る額 (#5576)。CUI は精算行で額まで出しているので、
+	// Web も同じ粒度で出せるよう渡す。訳文に数字を書くと、額を変えたとき片方だけ嘘になる。
+	LastInBonus int `json:"lastInBonus"`
 	// Pot はポットの総額。精算の内訳がこれに一致することが規則の裏取りになる。
 	Pot         int                           `json:"pot"`
 	GameEndFlag bool                          `json:"gameEndFlag"`
@@ -120,6 +123,7 @@ func newLaughAndLieDownDefaultOutput(msg string) *LaughAndLieDownWebOutput {
 		ValidIndices:     make([]int, 0),
 		ThreeTakeIndices: make([]int, 0),
 		LastInIdx:        -1,
+		LastInBonus:      domain.LaughAndLieDownLastInBonus,
 		Pot:              domain.LaughAndLieDownPot,
 		WebOutputBase:    WebOutputBase{Message: msg},
 	}

--- a/internal/adapter/presenter/LaughAndLieDownPresenter_test.go
+++ b/internal/adapter/presenter/LaughAndLieDownPresenter_test.go
@@ -254,3 +254,13 @@ func TestLaughAndLieDownCuiPresenter_HintReasonKeysAreAllMapped(t *testing.T) {
 func TestLaughAndLieDownCuiPresenter_ActionLog(t *testing.T) {
 	assert.NotEmpty(t, new(LaughAndLieDownCuiPresenter).ActionLogOutput(lldTestGame(t)))
 }
+
+// #5576: ラストインのボーナス額は CUI の精算行には出ているが Web には無く、
+// 画面は `lastInIdx` すら読んでいなかった。額は**ドメインの定数から**渡すこと ──
+// 訳文に数字を書くと、額を変えたとき片方だけ嘘になる。
+func TestLaughAndLieDownWebPresenter_ShipsTheLastInBonus(t *testing.T) {
+	out := lldDecode(t, new(LaughAndLieDownWebPresenter).Output(lldTestGame(t), nil))
+	assert.Equal(t, float64(domain.LaughAndLieDownLastInBonus), out["lastInBonus"])
+	// ゼロ値と区別が付かない検査にしない。
+	assert.NotZero(t, out["lastInBonus"])
+}

--- a/internal/adapter/presenter/LaughAndLieDownWebPresenter.go
+++ b/internal/adapter/presenter/LaughAndLieDownWebPresenter.go
@@ -37,6 +37,7 @@ func (p *LaughAndLieDownWebPresenter) buildBase(c interfaces.LaughAndLieDownGame
 	resObj.Layout = laughAndLieDownCardsOutput(c.GetLayout())
 	resObj.DealerIdx = c.GetDealerIdx()
 	resObj.LastInIdx = c.GetLastInIdx()
+	resObj.LastInBonus = domain.LaughAndLieDownLastInBonus
 	resObj.Pot = domain.LaughAndLieDownPot
 	resObj.GameEndFlag = c.GetGameEndFlag()
 


### PR DESCRIPTION
Closes #5576

## 何が問題だったか

**訳文もサーバのデータも既にあったのに、画面が一度も読んでいなかった。**

- `frontend/src/i18n/locales/ja/laughandliedown.json` に `lastIn`（用意済み）
- レスポンスに `lastInIdx`（送信済み）
- `LaughAndLieDownPage.tsx` はどちらも参照していない

CUI の `endBlock` は「X が最後まで手札を持っていたので N を受け取ります」と額まで出しているのに、
Web は最終スコアだけで終わり、点差の理由の一つが画面に出ないままだった。

## 額もサーバから渡す

受け入れ条件3が「CUI の `endBlock` と同じ情報粒度」なので、額まで出す必要がある。
`lastInBonus` をレスポンスに追加して**ドメインの定数から**渡す ── 訳文に 5 と書くと、
額を変えたとき片方だけ嘘になる。`api/openapi.yaml` も更新（CRLF 維持 5/0）。

## テスト

- 相手席が該当なら**その席にだけ**出る（他の席には出ない）/ 人間の席でも出る
- **`lastInIdx: -1` では何も出ない**（誰も受け取っていないボーナスを説明しない）
- 決着前は出さない
- **サーバが 9 を返せば 9 と出る**（訳文に数字を持っていない証拠）
- Go 側: `lastInBonus` がドメイン定数どおりに乗る / ゼロでない

変異テスト2件: 席の一致条件を外して全員に出す → 2件検出 /
presenter が額を落とす → **フロントのテストは通る**（API をモックするため）ので
Go 側に検査を足して 4件検出。

`golangci-lint` 0 issues / `bun run check` / `bun run typecheck` / 15 tests green。