### PR TITLE
feat(nertz): show how far each foundation has left to go

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -19122,6 +19122,11 @@ paths:
                           type: integer
                         size:
                           type: integer
+                  foundationMax:
+                    type: integer
+                    description: >-
+                      Cards that complete one foundation (A..K = 13). Sent so
+                      the figure is not written into the page as well.
                   hint:
                     nullable: true
                     type: object

--- a/frontend/src/i18n/locales/en/nertz.json
+++ b/frontend/src/i18n/locales/en/nertz.json
@@ -12,7 +12,7 @@
     "waste": "Waste",
     "stock": "Stock",
     "foundation": "Foundation",
-    "foundationN": "Foundation {{n}}",
+    "foundationN": "Foundation {{n}} ({{size}}/{{max}} cards)",
     "remaining": "left",
     "size": ""
   },

--- a/frontend/src/i18n/locales/ja/nertz.json
+++ b/frontend/src/i18n/locales/ja/nertz.json
@@ -12,7 +12,7 @@
     "waste": "ウェイスト",
     "stock": "ストック",
     "foundation": "ファウンデーション",
-    "foundationN": "ファウンデーション{{n}}",
+    "foundationN": "ファウンデーション{{n}}（{{size}}/{{max}}枚）",
     "remaining": "残り",
     "size": "枚"
   },

--- a/frontend/src/pages/NertzPage.test.tsx
+++ b/frontend/src/pages/NertzPage.test.tsx
@@ -23,6 +23,7 @@ const baseConfig = {
 };
 
 const playingState: NertzResponse = {
+  foundationMax: 13,
   phase: NertzPhase.PLAYING,
   roundNumber: 1,
   winnerIdx: -1,
@@ -559,5 +560,43 @@ describe('NertzPage', () => {
 
     await waitFor(() => expect(screen.getByText(/ナッツ から ファウンデーション2 へ移動/)).toBeInTheDocument());
     expect(screen.queryByText('移動先のファウンデーションかタブローを選んでください')).not.toBeInTheDocument();
+  });
+
+  // #5578: あと何枚で完成するかは組札の読みどころなのに、現在枚数しか出ておらず
+  // 暗算させていた。CUI は前から "n/13" で出している。
+  describe('foundation capacity', () => {
+    it('shows the size against the maximum', async () => {
+      mockExec.mockResolvedValue({
+        ...playingState,
+        foundations: [{ top: { design: 'SPADE', value: 5 }, suit: 1, size: 5 }],
+      });
+      renderWithProviders(<NertzPage />);
+      const cell = await screen.findByTestId('nertz-foundation-0');
+      expect(cell).toHaveTextContent('(5/13)');
+    });
+
+    // **上限はサーバから。**画面に 13 を焼き込むと、定数を変えたとき嘘になる。
+    it('renders whatever maximum the server sends', async () => {
+      mockExec.mockResolvedValue({
+        ...playingState,
+        foundationMax: 10,
+        foundations: [{ top: { design: 'SPADE', value: 5 }, suit: 1, size: 5 }],
+      });
+      renderWithProviders(<NertzPage />);
+      const cell = await screen.findByTestId('nertz-foundation-0');
+      expect(cell).toHaveTextContent('(5/10)');
+      expect(cell).not.toHaveTextContent('/13');
+    });
+
+    // 読み上げにも枚数が乗ること。見えている数字だけでは支援技術に届かない。
+    it('carries the count in the accessible name', async () => {
+      mockExec.mockResolvedValue({
+        ...playingState,
+        foundations: [{ top: { design: 'SPADE', value: 5 }, suit: 1, size: 5 }],
+      });
+      renderWithProviders(<NertzPage />);
+      const cell = await screen.findByTestId('nertz-foundation-0');
+      expect(cell.getAttribute('aria-label')).toContain('5/13');
+    });
   });
 });

--- a/frontend/src/pages/NertzPage.tsx
+++ b/frontend/src/pages/NertzPage.tsx
@@ -520,7 +520,13 @@ function NertzPageContent() {
                       size={f.size}
                       onClick={() => handleFoundationClick(idx)}
                       disabled={!isHumanTurn || !selection}
-                      ariaLabel={t('labels.foundationN', { n: idx, defaultValue: `Foundation ${idx}` })}
+                      max={state.foundationMax}
+                      ariaLabel={t('labels.foundationN', {
+                        n: idx,
+                        size: f.size,
+                        max: state.foundationMax,
+                        defaultValue: `Foundation ${idx}`,
+                      })}
                       collided={collidedFoundationIdx === idx}
                       placedBy={flash?.placedBy ?? null}
                       placedFlashKey={flash?.key ?? 0}
@@ -693,6 +699,8 @@ interface FoundationCellProps {
   placedBy?: 'human' | 'cpu' | null;
   /** Re-applies the placed flash even when `placedBy` stays the same (e.g., two human placements in a row). */
   placedFlashKey?: number;
+  /** Cards that complete this foundation. Comes from the server so the figure lives in one place. */
+  max: number;
   /** The current selection can legally be placed here → persistent success ring. */
   validTarget?: boolean;
   /** A source is currently selected → invalid destinations are dimmed. */
@@ -703,6 +711,7 @@ function FoundationCell({
   idx,
   top,
   size,
+  max,
   onClick,
   disabled,
   ariaLabel,
@@ -755,7 +764,11 @@ function FoundationCell({
             style={{ width: w, height: Math.round(w * 1.4) }}
           />
         )}
-        <span className="block">({size})</span>
+        {/* **あと何枚で完成するか**は組札の読みどころなのに、現在枚数しか
+            出ておらず暗算させていた (#5578)。CUI は前から "n/13" で出している。 */}
+        <span className="block">
+          ({size}/{max})
+        </span>
       </button>
       {flashOverlayClass && (
         // Remount the overlay (via key) on each new placement so the

--- a/frontend/src/types/games/nertz.ts
+++ b/frontend/src/types/games/nertz.ts
@@ -72,5 +72,7 @@ export interface NertzResponse extends BaseGameResponse {
   cpuTickMoves: number;
   players: NertzPlayerData[];
   foundations: NertzFoundationData[];
+  /** Cards that complete one foundation (A..K = 13). Sent so the figure is not written down twice. */
+  foundationMax: number;
   hint?: NertzHint;
 }

--- a/frontend/src/utils/cli/formatters/nertzFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/nertzFormatter.test.ts
@@ -38,6 +38,7 @@ function makeState(overrides?: Partial<NertzResponse>): NertzResponse {
       },
     ],
     foundations: [],
+    foundationMax: 13,
     message: '',
     ...overrides,
   };

--- a/internal/adapter/controller/NertzWebController.go
+++ b/internal/adapter/controller/NertzWebController.go
@@ -84,7 +84,11 @@ type NertzWebOutput struct {
 	CpuTickMoves  int                   `json:"cpuTickMoves"`
 	Players       []*NertzWebPlayer     `json:"players"`
 	Foundations   []*NertzWebFoundation `json:"foundations"`
-	Hint          *NertzWebHint         `json:"hint,omitempty"`
+	// FoundationMax は組札が完成する枚数 (A..K = 13)。CUI は枚数を "n/13" で
+	// 出しているのに Web は現在枚数だけで、あと何枚かを暗算させていた (#5578)。
+	// 数字を画面に焼き込まず、ドメインの定数を渡す。
+	FoundationMax int           `json:"foundationMax"`
+	Hint          *NertzWebHint `json:"hint,omitempty"`
 	WebOutputBase
 }
 
@@ -107,6 +111,7 @@ func newNertzDefaultOutput(msg string) *NertzWebOutput {
 		CpuDifficulty: int(domain.NertzCpuDifficultyNormal),
 		Players:       make([]*NertzWebPlayer, 0),
 		Foundations:   make([]*NertzWebFoundation, 0),
+		FoundationMax: domain.NertzFoundationMax,
 		WebOutputBase: WebOutputBase{Message: msg},
 	}
 }

--- a/internal/adapter/controller/NertzWebController_test.go
+++ b/internal/adapter/controller/NertzWebController_test.go
@@ -24,6 +24,8 @@ func mustNertzOutputJSON(msg string) string {
 		CpuDifficulty: int(domain.NertzCpuDifficultyNormal),
 		Players:       make([]*controller.NertzWebPlayer, 0),
 		Foundations:   make([]*controller.NertzWebFoundation, 0),
+		// 上限は盤面が無くても規則なので、既定の応答にも乗る (#5578)。
+		FoundationMax: domain.NertzFoundationMax,
 		WebOutputBase: controller.WebOutputBase{Message: msg},
 	}
 	b, err := json.Marshal(out)

--- a/internal/adapter/presenter/NertzWebPresenter.go
+++ b/internal/adapter/presenter/NertzWebPresenter.go
@@ -98,6 +98,7 @@ func (p *NertzWebPresenter) buildBase(g interfaces.NertzGame) *controller.NertzW
 		CpuTickMoves:  cfg.ResolvedCpuTickMoves(),
 		Players:       make([]*controller.NertzWebPlayer, 0),
 		Foundations:   make([]*controller.NertzWebFoundation, 0),
+		FoundationMax: domain.NertzFoundationMax,
 	}
 
 	for _, pl := range g.GetPlayers() {

--- a/internal/adapter/presenter/NertzWebPresenter_test.go
+++ b/internal/adapter/presenter/NertzWebPresenter_test.go
@@ -241,3 +241,16 @@ func TestNertzWebPresenter_ActionLogOutput(t *testing.T) {
 		assert.NotEmpty(t, new(NertzWebPresenter).ActionLogOutput(g))
 	})
 }
+
+// #5578: 組札の上限はドメインの定数から渡すこと。画面に 13 を焼き込むと、
+// 定数を変えたとき Web だけが嘘になる (CUI は前から定数を使っている)。
+func TestNertzWebPresenter_ShipsTheFoundationMax(t *testing.T) {
+	g := domain.NewDefaultNertz()
+	g.Reset()
+
+	var out controller.NertzWebOutput
+	require.NoError(t, json.Unmarshal([]byte(new(NertzWebPresenter).Output(g, nil)), &out))
+	assert.Equal(t, domain.NertzFoundationMax, out.FoundationMax)
+	// ゼロ値と区別が付かない検査にしない。
+	assert.NotZero(t, out.FoundationMax)
+}


### PR DESCRIPTION
Closes #5578

## 何が問題だったか

CUI は組札を `{{card}} ({{count}}/{{max}})` の形で出している（`domain.NertzFoundationMax` 使用）のに、
Web の `FoundationCell` は `({size})` と**現在枚数だけ**。あと何枚で完成するかは
ニルツ／パウンスの読みどころなのに、暗記させていた。

## 上限は画面に焼き込まない

`foundationMax` をレスポンスに追加し（`domain.NertzFoundationMax` から）、
セル表示と `aria-label` の両方に差し込む。13 を TSX に書くと、定数を変えたとき
CUI だけ追随して Web が嘘になる。`api/openapi.yaml` も更新（CRLF 維持 5/0）。

`aria-label` にも枚数を入れた（受け入れ条件3）。見えている数字だけでは支援技術に届かない。

## テスト

- `(5/13)` の形で出る
- **サーバが 10 を返せば `(5/10)` と出る**（画面に 13 を持っていない証拠）
- **読み上げ名にも `5/13` が乗る**
- Go 側: `foundationMax` がドメイン定数どおりに乗る / ゼロでない

変異テスト2件: presenter が上限を落とす → 4件検出 /
ページが 13 を直書きする → 1件検出。

`golangci-lint` 0 issues / `bun run check` / `bun run typecheck` / 30 tests green。