### PR TITLE
feat(tonk): warn about the undercut risk in the CUI too

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -39218,6 +39218,11 @@ components:
         isUndercut:
           type: boolean
           description: Whether the opponent undercut the knocker
+        undercutRiskMax:
+          type: integer
+          description: >-
+            Opponent hand size at or below which knocking risks an undercut.
+            Sent so the warning fires on the same board state in both UIs.
         config:
           type: object
           properties:

--- a/frontend/src/hooks/useTonkGame.test.ts
+++ b/frontend/src/hooks/useTonkGame.test.ts
@@ -38,6 +38,7 @@ const defaultState: TonkResponse = {
   opponentMelds: [],
   opponentDeadwood: [],
   isTonk: false,
+  undercutRiskMax: 2,
   isUndercut: false,
   bestDeadwood: -1,
   knockThreshold: 5,

--- a/frontend/src/pages/TonkPage.test.tsx
+++ b/frontend/src/pages/TonkPage.test.tsx
@@ -42,6 +42,7 @@ function makeState(overrides: Partial<TonkResponse> = {}): TonkResponse {
     opponentMelds: [],
     opponentDeadwood: [],
     isTonk: false,
+    undercutRiskMax: 2,
     isUndercut: false,
     bestDeadwood: -1,
     knockThreshold: 5,
@@ -259,5 +260,33 @@ describe('TonkPage', () => {
 
     await waitFor(() => expect(mockExec).toHaveBeenCalled());
     expect(screen.queryByTestId('tonk-deadwood')).not.toBeInTheDocument();
+  });
+
+  // #5582: 閾値はサーバから来ること。画面に 2 を書くと、変えたとき CUI と
+  // 警告の出る局面がずれる。
+  describe('undercut warning threshold', () => {
+    it('warns at the threshold the server sends', async () => {
+      mockExec.mockResolvedValue({
+        ...makeState(),
+        undercutRiskMax: 3,
+        players: [makeState().players[0], { ...makeState().players[1], cardCount: 3 }],
+      });
+      renderWithProviders(<TonkPage />);
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /ノック/ })).toHaveAttribute('data-undercut-risk', 'true'),
+      );
+    });
+
+    // 同じ 3 枚でも、閾値が 2 なら警告しない。画面が 2 を持っていない証拠。
+    it('stays quiet above that threshold', async () => {
+      mockExec.mockResolvedValue({
+        ...makeState(),
+        undercutRiskMax: 2,
+        players: [makeState().players[0], { ...makeState().players[1], cardCount: 3 }],
+      });
+      renderWithProviders(<TonkPage />);
+      await waitFor(() => expect(screen.getByRole('button', { name: /ノック/ })).toBeInTheDocument());
+      expect(screen.getByRole('button', { name: /ノック/ })).not.toHaveAttribute('data-undercut-risk');
+    });
   });
 });

--- a/frontend/src/pages/TonkPage.tsx
+++ b/frontend/src/pages/TonkPage.tsx
@@ -186,7 +186,8 @@ function TonkPageContent() {
   const minOpponentCards = state.players
     .filter((p) => !p.isHuman)
     .reduce((m, p) => Math.min(m, p.cardCount), Number.POSITIVE_INFINITY);
-  const undercutRisk = Number.isFinite(minOpponentCards) && minOpponentCards <= 2;
+  // 閾値はサーバから。画面に 2 を書くと、変えたとき CUI と警告の出る局面がずれる (#5582)。
+  const undercutRisk = Number.isFinite(minOpponentCards) && minOpponentCards <= state.undercutRiskMax;
   const knockBtnClass = undercutRisk ? `${btnPrimary} ring-2 ring-ds-warning motion-safe:animate-pulse` : btnPrimary;
 
   return (

--- a/frontend/src/types/games/tonk.ts
+++ b/frontend/src/types/games/tonk.ts
@@ -40,6 +40,11 @@ export interface TonkResponse extends BaseGameResponse {
   opponentMelds: TonkMeld[];
   opponentDeadwood: Card[];
   isTonk: boolean;
+  /**
+   * Opponent hand size at or below which knocking risks an undercut. Sent so
+   * the warning fires on the same board state in both UIs.
+   */
+  undercutRiskMax: number;
   isUndercut: boolean;
   /**
    * 1枚捨てて到達できる最小デッドウッド。人間のディスカードフェーズ以外は -1。

--- a/internal/adapter/controller/TonkWebController.go
+++ b/internal/adapter/controller/TonkWebController.go
@@ -52,7 +52,10 @@ type TonkWebOutput struct {
 	OpponentMelds    []*TonkWebOutputMeld   `json:"opponentMelds"`
 	OpponentDeadwood []*WebOutputCard       `json:"opponentDeadwood"`
 	IsTonk           bool                   `json:"isTonk"`
-	IsUndercut       bool                   `json:"isUndercut"`
+	// UndercutRiskMax は「アンダーカットされうる」と警告する相手の残り枚数 (#5582)。
+	// 閾値を画面に焼き込むと、変えたとき Web と CUI で警告の出る局面がずれる。
+	UndercutRiskMax int  `json:"undercutRiskMax"`
+	IsUndercut      bool `json:"isUndercut"`
 	// BestDeadwood は1枚捨てて到達できる最小デッドウッド。CUI は毎ターン
 	// これを閾値と比べて「ノック可能/不可」を出しているのに、Web は同じ判断を
 	// プレイヤーの手計算に任せていた。人間のディスカードフェーズ以外は -1。
@@ -101,7 +104,9 @@ func newTonkDefaultOutput(msg string) *TonkWebOutput {
 		KnockerDeadwood:  make([]*WebOutputCard, 0),
 		OpponentMelds:    make([]*TonkWebOutputMeld, 0),
 		OpponentDeadwood: make([]*WebOutputCard, 0),
-		WebOutputBase:    WebOutputBase{Message: msg},
+		// 閾値は盤面が無くても規則なので、既定の応答にも乗せる。
+		UndercutRiskMax: domain.TonkUndercutRiskMax,
+		WebOutputBase:   WebOutputBase{Message: msg},
 	}
 }
 

--- a/internal/adapter/controller/TonkWebController_test.go
+++ b/internal/adapter/controller/TonkWebController_test.go
@@ -24,7 +24,9 @@ func mustTonkOutputJSON(msg string) string {
 		KnockerDeadwood:  []*controller.WebOutputCard{},
 		OpponentMelds:    []*controller.TonkWebOutputMeld{},
 		OpponentDeadwood: []*controller.WebOutputCard{},
-		WebOutputBase:    controller.WebOutputBase{Message: msg},
+		// 閾値は盤面が無くても規則なので、既定の応答にも乗る (#5582)。
+		UndercutRiskMax: domain.TonkUndercutRiskMax,
+		WebOutputBase:   controller.WebOutputBase{Message: msg},
 	}
 	b, err := json.Marshal(out)
 	if err != nil {

--- a/internal/adapter/presenter/TonkCuiPresenter.go
+++ b/internal/adapter/presenter/TonkCuiPresenter.go
@@ -13,6 +13,23 @@ import (
 // tonkBestDeadwood returns the lowest deadwood value the player can reach by
 // discarding one card — the value that gates knocking (<= TonkKnockThreshold).
 
+// tonkMinOpponentCards は相手のうち最も手札が少ない枚数を返す。相手がいなければ false。
+//
+// 人間を除くのは、自分の枚数はアンダーカットのリスクと関係ないから。
+func tonkMinOpponentCards(g interfaces.TonkGame) (int, bool) {
+	minCards, found := 0, false
+	for i := range domain.TonkPlayerCnt {
+		p := g.GetPlayer(i)
+		if p == nil || p.GetIsHuman() {
+			continue
+		}
+		if !found || p.GetCardsSize() < minCards {
+			minCards, found = p.GetCardsSize(), true
+		}
+	}
+	return minCards, found
+}
+
 // tonkPlayerStr returns the display string for a single Tonk player.
 func tonkPlayerStr(player *domain.TonkPlayer, i int) string {
 	var b strings.Builder
@@ -120,6 +137,11 @@ func (p *TonkCuiPresenter) Output(g interfaces.TonkGame, lastErr error) string {
 			}
 			b.WriteString(i18n.T("tonk.promptDiscardHelp") + "\n")
 			b.WriteString(i18n.T("tonk.promptKnockHelp") + "\n")
+			// **相手の残りが少ないほどノックは裏目。**Web はボタンに警告リングと
+			// ⚠️ を出しているのに、CUI は各行の枚数を見比べさせるだけだった (#5582)。
+			if n, ok := tonkMinOpponentCards(g); ok && n <= domain.TonkUndercutRiskMax {
+				b.WriteString(color.Yellow(i18n.Tf("tonk.knockUndercutWarning", "count", strconv.Itoa(n))) + "\n")
+			}
 		case domain.TonkPhaseRoundEnd:
 			if g.GetIsTonk() {
 				b.WriteString(i18n.T("tonk.promptDealtTonk") + "\n")

--- a/internal/adapter/presenter/TonkCuiPresenter.go
+++ b/internal/adapter/presenter/TonkCuiPresenter.go
@@ -139,8 +139,12 @@ func (p *TonkCuiPresenter) Output(g interfaces.TonkGame, lastErr error) string {
 			b.WriteString(i18n.T("tonk.promptKnockHelp") + "\n")
 			// **相手の残りが少ないほどノックは裏目。**Web はボタンに警告リングと
 			// ⚠️ を出しているのに、CUI は各行の枚数を見比べさせるだけだった (#5582)。
-			if n, ok := tonkMinOpponentCards(g); ok && n <= domain.TonkUndercutRiskMax {
-				b.WriteString(color.Yellow(i18n.Tf("tonk.knockUndercutWarning", "count", strconv.Itoa(n))) + "\n")
+			// 人間の手番だけに出す。上のデッドウッド表示と同じ条件 ── ノックを
+			// 決めるのは人間なので、CPU の捨て札中に警告しても行動できない。
+			if cur := g.GetPlayer(currentIdx); cur.GetIsHuman() {
+				if n, ok := tonkMinOpponentCards(g); ok && n <= domain.TonkUndercutRiskMax {
+					b.WriteString(color.Yellow(i18n.Tf("tonk.knockUndercutWarning", "count", strconv.Itoa(n))) + "\n")
+				}
 			}
 		case domain.TonkPhaseRoundEnd:
 			if g.GetIsTonk() {

--- a/internal/adapter/presenter/TonkCuiPresenter_test.go
+++ b/internal/adapter/presenter/TonkCuiPresenter_test.go
@@ -285,3 +285,18 @@ func TestTonkCuiPresenter_DoesNotWarnOutsideTheDiscardPhase(t *testing.T) {
 	out := new(presenter.TonkCuiPresenter).Output(m, nil)
 	assert.NotContains(t, out, i18n.Tf("tonk.knockUndercutWarning", "count", "1"))
 }
+
+// レビュー (#5941) の指摘: ノックを決めるのは人間なので、CPU の捨て札中に
+// 「相手の手札が少ない」と警告しても行動できない。上のデッドウッド表示と同じ条件。
+func TestTonkCuiPresenter_WarnsOnlyOnTheHumanTurn(t *testing.T) {
+	i18n.SetLang("ja")
+	m, players := setupTonkCuiMockWithPlayers()
+	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetCurrentPlayerIdx")
+	m.On("GetPhase").Return(domain.TonkPhaseDiscard)
+	m.On("GetCurrentPlayerIdx").Return(1) // CPU の捨て札中
+	players[1].AddCard(domain.NewCard(domain.CardDesignSpade, 3, true))
+
+	out := new(presenter.TonkCuiPresenter).Output(m, nil)
+	assert.NotContains(t, out, i18n.Tf("tonk.knockUndercutWarning", "count", "1"))
+}

--- a/internal/adapter/presenter/TonkCuiPresenter_test.go
+++ b/internal/adapter/presenter/TonkCuiPresenter_test.go
@@ -4,6 +4,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupTonkCuiMock() *interfaces.MockTonkGame {
@@ -248,4 +250,38 @@ func TestTonkCuiPresenter_ActionLogOutput(t *testing.T) {
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜はありません")
 	})
+}
+
+// #5582: 相手の残りが少ないほどノックは裏目 (#1939)。Web はボタンに警告リングと
+// ⚠️ を出しているのに、CUI は各行の枚数を見比べさせるだけだった。
+func TestTonkCuiPresenter_WarnsAboutTheUndercutRisk(t *testing.T) {
+	i18n.SetLang("ja")
+	build := func(oppCards int) string {
+		m, players := setupTonkCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.On("GetPhase").Return(domain.TonkPhaseDiscard)
+		for range oppCards {
+			players[1].AddCard(domain.NewCard(domain.CardDesignSpade, 3, true))
+		}
+		return new(presenter.TonkCuiPresenter).Output(m, nil)
+	}
+
+	// 境界値。閾値ちょうどでは出し、1 枚上では出さない (受け入れ条件3)。
+	assert.Contains(t, build(domain.TonkUndercutRiskMax),
+		i18n.Tf("tonk.knockUndercutWarning", "count", strconv.Itoa(domain.TonkUndercutRiskMax)))
+	assert.NotContains(t, build(domain.TonkUndercutRiskMax+1),
+		i18n.Tf("tonk.knockUndercutWarning", "count", strconv.Itoa(domain.TonkUndercutRiskMax+1)))
+
+	// **1 枚でも出ること。**「ちょうど 2 枚」だけを見る実装では通らない。
+	assert.Contains(t, build(1), i18n.Tf("tonk.knockUndercutWarning", "count", "1"))
+}
+
+// ドロー中は出さない。ノックできない局面で「ノックは危ない」と言っても仕方がない。
+func TestTonkCuiPresenter_DoesNotWarnOutsideTheDiscardPhase(t *testing.T) {
+	i18n.SetLang("ja")
+	m, players := setupTonkCuiMockWithPlayers()
+	players[1].AddCard(domain.NewCard(domain.CardDesignSpade, 3, true))
+
+	out := new(presenter.TonkCuiPresenter).Output(m, nil)
+	assert.NotContains(t, out, i18n.Tf("tonk.knockUndercutWarning", "count", "1"))
 }

--- a/internal/adapter/presenter/TonkWebPresenter.go
+++ b/internal/adapter/presenter/TonkWebPresenter.go
@@ -13,6 +13,7 @@ type TonkWebPresenter struct{}
 func (p *TonkWebPresenter) Output(g interfaces.TonkGame, lastErr error) string {
 	resObj := new(controller.TonkWebOutput)
 	resObj.Phase = int(g.GetPhase())
+	resObj.UndercutRiskMax = domain.TonkUndercutRiskMax
 
 	// **CUI は毎ターン「ノック可能/不可」を出しているのに、Web は手計算だった。**
 	// 判断の基準ごと送るので、フロントは閾値の数値を写さずに済む。

--- a/internal/adapter/presenter/TonkWebPresenter_test.go
+++ b/internal/adapter/presenter/TonkWebPresenter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
@@ -273,4 +274,16 @@ func TestTonkWebPresenter_ActionLogOutput(t *testing.T) {
 		result := p.ActionLogOutput(m)
 		assert.NotEmpty(t, result)
 	})
+}
+
+// #5582: 閾値はドメインから渡すこと。画面に 2 を書くと、変えたとき Web と CUI で
+// 警告の出る局面がずれる。
+func TestTonkWebPresenter_ShipsTheUndercutThreshold(t *testing.T) {
+	g := domain.NewDefaultTonk()
+	g.Reset()
+
+	var out controller.TonkWebOutput
+	require.NoError(t, json.Unmarshal([]byte(new(presenter.TonkWebPresenter).Output(g, nil)), &out))
+	assert.Equal(t, domain.TonkUndercutRiskMax, out.UndercutRiskMax)
+	assert.NotZero(t, out.UndercutRiskMax)
 }

--- a/internal/domain/Tonk.go
+++ b/internal/domain/Tonk.go
@@ -24,6 +24,13 @@ const TonkOnDealHigh = 50
 // TonkBonus 配牌時Tonk成立時のボーナス点
 const TonkBonus = 50
 
+// TonkUndercutRiskMax は「アンダーカットされうる」と警告する相手の残り枚数。
+//
+// **ノックは相手の残りが少ないほど裏目になる。**相手が先に上がれば、こちらの
+// デッドウッドが低くても負ける (#1939)。Web はこの閾値でノックボタンに警告を
+// 出しているが、閾値が画面側に書かれていて CUI は何も出していなかった (#5582)。
+const TonkUndercutRiskMax = 2
+
 // TonkUndercutPenalty アンダーカット時のペナルティ点
 const TonkUndercutPenalty = 5
 

--- a/internal/i18n/locales/en/tonk.json
+++ b/internal/i18n/locales/en/tonk.json
@@ -29,5 +29,6 @@
   "promptRoundEnd": "Round complete",
   "promptRoundEndHelp": "nr / nextround: advance to next round",
   "helpExampleDraw": "  ds                   start the turn by drawing from the stock",
-  "helpExampleDiscard": "  d 0                  discard hand card 0"
+  "helpExampleDiscard": "  d 0                  discard hand card 0",
+  "knockUndercutWarning": "The opponent is down to {{count}} card(s) — undercut risk is high"
 }

--- a/internal/i18n/locales/ja/tonk.json
+++ b/internal/i18n/locales/ja/tonk.json
@@ -29,5 +29,6 @@
   "promptRoundEnd": "ラウンド終了",
   "promptRoundEndHelp": "nr / nextround・・・次のラウンドへ",
   "helpExampleDraw": "  ds                   手番の最初に山札から 1 枚引く",
-  "helpExampleDiscard": "  d 0                  手札の 0 番を捨てる"
+  "helpExampleDiscard": "  d 0                  手札の 0 番を捨てる",
+  "knockUndercutWarning": "相手の手札が残り{{count}}枚です。アンダーカットのリスクがあります"
 }


### PR DESCRIPTION
Closes #5582

## 何が問題だったか

相手の残り手札が少ないほど、ノックは裏目になる（相手が先に上がればデッドウッドが低くても負ける、#1939）。
Web はノックボタンに警告リングと ⚠️ と `knockUndercutWarning` を出しているのに、
CUI は各プレイヤー行の枚数を出すだけで、**プレイヤーが自分で見比べて初めて気づく**状態だった。

## 閾値が画面に書かれていた

`undercutRisk` の `<= 2` は `TonkPage.tsx` の中の literal。CUI 側で同じ数字を書くと
**2 箇所になる**ので、`domain.TonkUndercutRiskMax` を新設し:

- CUI は定数を直接読む
- Web は `undercutRiskMax` としてレスポンスから読む（画面から literal を削除）

これで、閾値を変えたときに**警告の出る局面が 2 つの画面でずれない**。
`api/openapi.yaml` も更新（CRLF 維持 5/0）。

文言は「少ない」ではなく**残り枚数を出す** — 1 枚と 2 枚ではリスクが違うし、数字は既に分かっている。

## テスト

- CUI: **境界値**（閾値ちょうどで出す / 1 つ上では出さない、受け入れ条件3）/ **1 枚でも出る**
  （「ちょうど 2 枚」を見る実装では通らない）/ ドロー中は出さない（ノックできない局面で
  「ノックは危ない」と言っても仕方がない）
- Web presenter: 閾値が乗る / ゼロでない
- ページ: **サーバが 3 を返せば 3 枚で警告し、2 を返せば同じ 3 枚で警告しない**
  （画面が 2 を持っていない証拠）

変異テスト2件: `<=` を `==` にする → 4件検出 / 人間の手札も相手として数える → 4件検出。

`golangci-lint` 0 issues / `go test ./internal/...` 全 green / `bun run check` / `bun run typecheck`。