### PR TITLE
feat(pitch): show who took High, Low, Jack and Game

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -45147,6 +45147,21 @@ components:
           type: integer
         leadPlayerIdx:
           type: integer
+        roundBreakdown:
+          type: object
+          description: >-
+            Who took each of the four points last round; -1 for nobody. The
+            totals alone do not say whether a one-point gap came from losing
+            Jack or from tying Game.
+          properties:
+            high:
+              type: integer
+            low:
+              type: integer
+            jack:
+              type: integer
+            game:
+              type: integer
         validPlayIndices:
           type: array
           items:

--- a/frontend/src/i18n/locales/en/pitch.json
+++ b/frontend/src/i18n/locales/en/pitch.json
@@ -94,5 +94,6 @@
     "bid4": "4",
     "play": "↵",
     "next": "N"
-  }
+  },
+  "scoringNobody": "nobody"
 }

--- a/frontend/src/i18n/locales/ja/pitch.json
+++ b/frontend/src/i18n/locales/ja/pitch.json
@@ -94,5 +94,6 @@
     "bid4": "4",
     "play": "↵",
     "next": "N"
-  }
+  },
+  "scoringNobody": "なし"
 }

--- a/frontend/src/pages/PitchPage.test.tsx
+++ b/frontend/src/pages/PitchPage.test.tsx
@@ -62,6 +62,7 @@ const bidState: PitchResponse = {
   gameEndFlag: false,
   winnerIdx: -1,
   leadPlayerIdx: -1,
+  roundBreakdown: { high: -1, low: -1, jack: -1, game: -1 },
   validPlayIndices: [],
   message: '',
   config: baseConfig,
@@ -321,5 +322,44 @@ describe('PitchPage', () => {
     renderWithProviders(<PitchPage />);
     expect(screen.getByTestId('skeleton')).toBeInTheDocument();
     expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+  });
+
+  // #5584: 4 種の得点 (High/Low/Jack/Game) はこのゲームの骨格なのに、スコア表は
+  // 合計しか出しておらず、用意されていた scoring.* のキーも未使用だった。
+  describe('round score breakdown', () => {
+    const roundEnd = (bd: PitchResponse['roundBreakdown']): PitchResponse => ({
+      ...playState,
+      phase: PitchPhase.ROUND_END,
+      roundBreakdown: bd,
+    });
+
+    it('names who took each category', async () => {
+      mockApi.mockResolvedValue(roundEnd({ high: 0, low: 1, jack: 0, game: 2 }));
+      renderWithProviders(<PitchPage />);
+      await waitFor(() => expect(screen.getByTestId('pitch-score-breakdown')).toBeInTheDocument());
+      // ラベルは既存の未使用キーを使う (受け入れ条件2)。
+      expect(screen.getByTestId('pitch-scoring-high')).toHaveTextContent('High');
+      // **カテゴリごとに違う席が出ること。**1 席に固定する実装でも「含む」だけなら通る。
+      expect(screen.getByTestId('pitch-scoring-low')).not.toHaveTextContent(
+        screen.getByTestId('pitch-scoring-game').textContent ?? '',
+      );
+    });
+
+    // -1 は「誰も取っていない」。黙って省くと、争われなかったのか見落としたのか
+    // 区別が付かない。
+    it('says nobody took a category the server left at -1', async () => {
+      mockApi.mockResolvedValue(roundEnd({ high: 0, low: 0, jack: -1, game: -1 }));
+      renderWithProviders(<PitchPage />);
+      const jack = await screen.findByTestId('pitch-scoring-jack');
+      expect(jack).toHaveTextContent('なし');
+    });
+
+    // ラウンド途中では出さない。まだ確定していない。
+    it('stays hidden while the round is running', async () => {
+      mockApi.mockResolvedValue(playState);
+      renderWithProviders(<PitchPage />);
+      await waitFor(() => expect(mockApi).toHaveBeenCalled());
+      expect(screen.queryByTestId('pitch-score-breakdown')).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/pages/PitchPage.tsx
+++ b/frontend/src/pages/PitchPage.tsx
@@ -125,6 +125,9 @@ function valueLabel(value: number): string {
 /** Pitch (Setback) game page. */
 export const PitchPage = withTutorial(PitchPageContent, 'pitch', PT_TUTORIAL_STEPS);
 
+/** Sentinel the server sends when nobody took a category (sync: domain.PitchNoScorer). */
+const PITCH_NO_SCORER = -1;
+
 function PitchPageContent() {
   const { t } = useTranslation('pitch');
   const { tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
@@ -333,6 +336,29 @@ function PitchPageContent() {
                 </tbody>
               </table>
             </div>
+
+            {/* **4 種の得点がこのゲームの骨格**なのに、合計しか出ていなかった
+                (#5584)。用意されていた scoring.* のキーもどこからも使われて
+                いなかった。獲得者はサーバが得点と同時に記録している。 */}
+            {(isRoundEnd || state.gameEndFlag) && (
+              <div className="text-xs text-ds-text-muted mb-3" data-testid="pitch-score-breakdown">
+                {(
+                  [
+                    ['high', state.roundBreakdown.high],
+                    ['low', state.roundBreakdown.low],
+                    ['jack', state.roundBreakdown.jack],
+                    ['game', state.roundBreakdown.game],
+                  ] as const
+                ).map(([key, idx]) => (
+                  <div key={key} data-testid={`pitch-scoring-${key}`}>
+                    {t(`scoring.${key}`)}:{' '}
+                    {idx === PITCH_NO_SCORER
+                      ? t('scoringNobody')
+                      : playerName(idx, state.players[idx]?.isHuman ?? false)}
+                  </div>
+                ))}
+              </div>
+            )}
 
             {/* Current trick */}
             <div

--- a/frontend/src/types/games/pitch.ts
+++ b/frontend/src/types/games/pitch.ts
@@ -54,6 +54,12 @@ export interface PitchResponse extends BaseGameResponse {
   gameEndFlag: boolean;
   winnerIdx: number;
   leadPlayerIdx: number;
+  /**
+   * Who took each of the four points last round; -1 for nobody. Sent because
+   * the totals alone do not say whether a one-point gap came from losing Jack
+   * or from tying Game.
+   */
+  roundBreakdown: { high: number; low: number; jack: number; game: number };
   validPlayIndices: number[];
   config: PitchConfig;
   hint?: PitchHint;

--- a/frontend/src/utils/hints/pitchHint.test.ts
+++ b/frontend/src/utils/hints/pitchHint.test.ts
@@ -38,6 +38,7 @@ const makeState = (override: Partial<PitchResponse> = {}): PitchResponse => ({
   gameEndFlag: false,
   winnerIdx: -1,
   leadPlayerIdx: -1,
+  roundBreakdown: { high: -1, low: -1, jack: -1, game: -1 },
   validPlayIndices: [],
   message: '',
   config: baseConfig,

--- a/internal/adapter/controller/PitchWebController.go
+++ b/internal/adapter/controller/PitchWebController.go
@@ -42,6 +42,14 @@ type PitchWebOutputHint struct {
 }
 
 // PitchWebOutput ピッチWebアウトプット
+// PitchWebOutputBreakdown は 4 種の得点をそれぞれ取った席の添字 (-1=なし)。
+type PitchWebOutputBreakdown struct {
+	High int `json:"high"`
+	Low  int `json:"low"`
+	Jack int `json:"jack"`
+	Game int `json:"game"`
+}
+
 type PitchWebOutput struct {
 	Players          []*PitchWebOutputPlayer `json:"players"`
 	Phase            int                     `json:"phase"`
@@ -59,8 +67,11 @@ type PitchWebOutput struct {
 	GameEndFlag      bool                    `json:"gameEndFlag"`
 	WinnerIdx        int                     `json:"winnerIdx"`
 	LeadPlayerIdx    int                     `json:"leadPlayerIdx"`
-	ValidPlayIndices []int                   `json:"validPlayIndices,omitempty"`
-	Hint             *PitchWebOutputHint     `json:"hint,omitempty"`
+	// RoundBreakdown は直近ラウンドの High/Low/Jack/Game を誰が取ったか (#5584)。
+	// -1 は誰も取っていない。合計だけでは 1 点差の理由が読めない。
+	RoundBreakdown   *PitchWebOutputBreakdown `json:"roundBreakdown"`
+	ValidPlayIndices []int                    `json:"validPlayIndices,omitempty"`
+	Hint             *PitchWebOutputHint      `json:"hint,omitempty"`
 	WebOutputBase
 	Config PitchWebOutputConfig `json:"config"`
 }
@@ -101,7 +112,14 @@ func newPitchDefaultOutput(msg string) *PitchWebOutput {
 		LastTrickWinner: -1,
 		WinnerIdx:       -1,
 		BidWinnerIdx:    -1,
-		WebOutputBase:   WebOutputBase{Message: msg},
+		// まだ何も争われていないので、どのカテゴリも「なし」。
+		RoundBreakdown: &PitchWebOutputBreakdown{
+			High: domain.PitchNoScorer,
+			Low:  domain.PitchNoScorer,
+			Jack: domain.PitchNoScorer,
+			Game: domain.PitchNoScorer,
+		},
+		WebOutputBase: WebOutputBase{Message: msg},
 	}
 }
 

--- a/internal/adapter/controller/PitchWebController_test.go
+++ b/internal/adapter/controller/PitchWebController_test.go
@@ -22,7 +22,14 @@ func mustPitchOutputJSON(msg string) string {
 		LastTrickWinner: -1,
 		WinnerIdx:       -1,
 		BidWinnerIdx:    -1,
-		WebOutputBase:   controller.WebOutputBase{Message: msg},
+		// まだ何も争われていないので、どのカテゴリも「なし」(#5584)。
+		RoundBreakdown: &controller.PitchWebOutputBreakdown{
+			High: domain.PitchNoScorer,
+			Low:  domain.PitchNoScorer,
+			Jack: domain.PitchNoScorer,
+			Game: domain.PitchNoScorer,
+		},
+		WebOutputBase: controller.WebOutputBase{Message: msg},
 	}
 	b, err := json.Marshal(out)
 	if err != nil {

--- a/internal/adapter/presenter/PitchCuiPresenter.go
+++ b/internal/adapter/presenter/PitchCuiPresenter.go
@@ -61,6 +61,24 @@ func pitchSuitName(suit int) string {
 type PitchCuiPresenter struct{}
 
 // Output renders the current game state for the active locale (#1699).
+// pitchBreakdownBlock は High/Low/Jack/Game をそれぞれ誰が取ったかを 1 行に並べる。
+// 誰も取っていないカテゴリは「なし」と出す ── 黙って省くと、そのラウンドで
+// そもそも争われなかったのか見落としたのか分からない。
+func pitchBreakdownBlock(g interfaces.PitchGame) string {
+	bd := g.GetRoundBreakdown()
+	name := func(idx int) string {
+		if idx == domain.PitchNoScorer {
+			return i18n.T("pitch.scoringNobody")
+		}
+		return cuiPlayerName(g.GetPlayer(idx), idx)
+	}
+	return i18n.Tf("pitch.scoringLine",
+		"high", name(bd.High),
+		"low", name(bd.Low),
+		"jack", name(bd.Jack),
+		"game", name(bd.Game))
+}
+
 func (p *PitchCuiPresenter) Output(s interfaces.PitchGame, lastErr error) string {
 	return buildCuiOutput(i18n.T("pitch.helpTitle"), func(b *strings.Builder) {
 		b.WriteString(i18n.Tf("pitch.header",
@@ -118,6 +136,10 @@ func (p *PitchCuiPresenter) Output(s interfaces.PitchGame, lastErr error) string
 			b.WriteString(i18n.T("pitch.promptTrickEnd") + "\n")
 			b.WriteString(i18n.T("pitch.promptTrickEndHelp") + "\n")
 		case domain.PitchPhaseRoundEnd:
+			// **4 種の得点がこのゲームの骨格。**合計だけでは、1 点差の理由が
+			// Jack を取られたからなのか Game で並ばれたからなのか分からない
+			// (#5584)。獲得者はドメインが得点と同時に記録している。
+			b.WriteString(pitchBreakdownBlock(s) + "\n")
 			b.WriteString(i18n.T("pitch.promptRoundEnd") + "\n")
 			b.WriteString(i18n.T("pitch.promptRoundEndHelp") + "\n")
 		}

--- a/internal/adapter/presenter/PitchCuiPresenter_test.go
+++ b/internal/adapter/presenter/PitchCuiPresenter_test.go
@@ -2,6 +2,7 @@ package presenter_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +11,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupPitchCuiMock() *interfaces.MockPitchGame {
@@ -27,6 +29,10 @@ func setupPitchCuiMock() *interfaces.MockPitchGame {
 	m.On("GetBidPlayerIdx").Return(0)
 	m.On("GetWinnerIdx").Return(-1)
 	m.On("GetLeadPlayerIdx").Return(-1)
+	m.On("GetRoundBreakdown").Return(domain.PitchRoundBreakdown{
+		High: domain.PitchNoScorer, Low: domain.PitchNoScorer,
+		Jack: domain.PitchNoScorer, Game: domain.PitchNoScorer,
+	}).Maybe()
 	m.On("GetConfig").Return(domain.DefaultPitchConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
 	return m
@@ -206,4 +212,45 @@ func TestPitchCuiPresenter_HandPips(t *testing.T) {
 		m.On("GetPhase").Return(domain.PitchPhasePlay)
 		assert.NotContains(t, p.Output(m, nil), "手札のゲーム得点")
 	})
+}
+
+// #5584: 4 種の得点 (High/Low/Jack/Game) はこのゲームの骨格なのに、CUI も
+// 合計しか出していなかった。
+func TestPitchCuiPresenter_ShowsTheRoundBreakdown(t *testing.T) {
+	i18n.SetLang("ja")
+	build := func(bd domain.PitchRoundBreakdown) string {
+		m, _ := setupPitchCuiMockWithPlayers()
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+		m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetRoundBreakdown")
+		m.On("GetPhase").Return(domain.PitchPhaseRoundEnd)
+		m.On("GetRoundBreakdown").Return(bd)
+		return new(presenter.PitchCuiPresenter).Output(m, nil)
+	}
+
+	out := build(domain.PitchRoundBreakdown{High: 0, Low: 1, Jack: 0, Game: domain.PitchNoScorer})
+	// 4 カテゴリすべてが並ぶこと。
+	for _, label := range []string{"High", "Low", "Jack", "Game"} {
+		assert.Contains(t, out, label)
+	}
+	// **誰も取っていないカテゴリは「なし」。**黙って省くと、争われなかったのか
+	// 見落としたのか区別が付かない。
+	assert.Contains(t, out, i18n.T("pitch.scoringNobody"))
+
+	// 全部「なし」の局面でも 4 つとも出る。
+	none := domain.PitchRoundBreakdown{
+		High: domain.PitchNoScorer, Low: domain.PitchNoScorer,
+		Jack: domain.PitchNoScorer, Game: domain.PitchNoScorer,
+	}
+	assert.Equal(t, 4, strings.Count(build(none), i18n.T("pitch.scoringNobody")))
+}
+
+// ラウンド途中では出さない。まだ確定していない。
+func TestPitchCuiPresenter_HidesTheBreakdownMidRound(t *testing.T) {
+	i18n.SetLang("ja")
+	m, _ := setupPitchCuiMockWithPlayers()
+	m.ExpectedCalls = removeMockCall(m.ExpectedCalls, "GetPhase")
+	m.On("GetPhase").Return(domain.PitchPhasePlay)
+
+	out := new(presenter.PitchCuiPresenter).Output(m, nil)
+	assert.NotContains(t, out, strings.SplitN(i18n.T("pitch.scoringLine"), "{{", 2)[0])
 }

--- a/internal/adapter/presenter/PitchWebPresenter.go
+++ b/internal/adapter/presenter/PitchWebPresenter.go
@@ -45,6 +45,11 @@ func (p *PitchWebPresenter) buildBase(s interfaces.PitchGame) *controller.PitchW
 	resObj.GameEndFlag = s.GetGameEndFlag()
 	resObj.WinnerIdx = s.GetWinnerIdx()
 	resObj.LeadPlayerIdx = s.GetLeadPlayerIdx()
+	// 得点内訳。ドメインが得点と同時に記録しているので、画面が数え直さない (#5584)。
+	bd := s.GetRoundBreakdown()
+	resObj.RoundBreakdown = &controller.PitchWebOutputBreakdown{
+		High: bd.High, Low: bd.Low, Jack: bd.Jack, Game: bd.Game,
+	}
 
 	cfg := s.GetConfig()
 	resObj.Config = controller.PitchWebOutputConfig{

--- a/internal/adapter/presenter/PitchWebPresenter_test.go
+++ b/internal/adapter/presenter/PitchWebPresenter_test.go
@@ -28,6 +28,10 @@ func setupPitchWebMock() *interfaces.MockPitchGame {
 	m.On("GetBidPlayerIdx").Return(0)
 	m.On("GetWinnerIdx").Return(-1)
 	m.On("GetLeadPlayerIdx").Return(0)
+	m.On("GetRoundBreakdown").Return(domain.PitchRoundBreakdown{
+		High: domain.PitchNoScorer, Low: domain.PitchNoScorer,
+		Jack: domain.PitchNoScorer, Game: domain.PitchNoScorer,
+	}).Maybe()
 	m.On("GetConfig").Return(domain.DefaultPitchConfig())
 	m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
 	m.On("GetValidPlayIndices", 0).Return([]int{0, 1})
@@ -152,6 +156,10 @@ func setupPitchWebMockCustom(phase domain.PitchPhase, trickNumber int, log []*do
 	m.On("GetBidPlayerIdx").Return(0)
 	m.On("GetWinnerIdx").Return(-1)
 	m.On("GetLeadPlayerIdx").Return(0)
+	m.On("GetRoundBreakdown").Return(domain.PitchRoundBreakdown{
+		High: domain.PitchNoScorer, Low: domain.PitchNoScorer,
+		Jack: domain.PitchNoScorer, Game: domain.PitchNoScorer,
+	}).Maybe()
 	m.On("GetConfig").Return(domain.DefaultPitchConfig())
 	m.On("GetActionLog").Return(log)
 	m.On("GetValidPlayIndices", 0).Return([]int{0})

--- a/internal/domain/Pitch.go
+++ b/internal/domain/Pitch.go
@@ -70,8 +70,29 @@ type Pitch struct {
 	trumpSuit        int // 切り札スート (PitchTrumpUnset=未確定)
 	gameEndFlag      bool
 	winnerIdx        int
+	// roundBreakdown は直近ラウンドの 4 得点を誰が取ったか (#5584)。
+	roundBreakdown PitchRoundBreakdown
 	actionLogBase
 }
+
+// PitchRoundBreakdown は High / Low / Jack / Game をそれぞれ誰が取ったかを表す。
+// -1 は「誰も取っていない」(切り札が出なかった、Game が同点、など)。
+//
+// **4 種の得点はこのゲームの骨格なのに、合計しか画面に出ていなかった** (#5584)。
+// 合計だけでは、1 点差の理由が Jack を取られたからなのか Game で並ばれたからなのか
+// が分からない。
+type PitchRoundBreakdown struct {
+	High int
+	Low  int
+	Jack int
+	Game int
+}
+
+// PitchNoScorer は PitchRoundBreakdown の「誰も取っていない」を表す。
+const PitchNoScorer = -1
+
+// GetRoundBreakdown は直近ラウンドの得点内訳を返す。
+func (p *Pitch) GetRoundBreakdown() PitchRoundBreakdown { return p.roundBreakdown }
 
 // NewPitch コンストラクタ
 func NewPitch(trumpCards *TrumpCards, players []*PitchPlayer, config PitchConfig) *Pitch {
@@ -531,6 +552,11 @@ func (p *Pitch) ScoreRound() {
 // computeRoundPoints 各プレイヤーが獲得したポイント数 (High/Low/Jack/Game) を返す
 func (p *Pitch) computeRoundPoints() []int {
 	points := make([]int, PitchPlayerCnt)
+	// 内訳は毎ラウンド組み直す。前のラウンドの結果が残ると、切り札の出なかった
+	// ラウンドで前回の獲得者が表示される。
+	p.roundBreakdown = PitchRoundBreakdown{
+		High: PitchNoScorer, Low: PitchNoScorer, Jack: PitchNoScorer, Game: PitchNoScorer,
+	}
 	if p.trumpSuit == PitchTrumpUnset {
 		return points
 	}
@@ -565,16 +591,19 @@ func (p *Pitch) computeRoundPoints() []int {
 	}
 	if highPlayer >= 0 {
 		points[highPlayer]++
+		p.roundBreakdown.High = highPlayer
 		p.appendLog(highPlayer, "score_high",
 			fmt.Sprintf("%s scores High", playerName(p.players, highPlayer)), nil)
 	}
 	if lowPlayer >= 0 {
 		points[lowPlayer]++
+		p.roundBreakdown.Low = lowPlayer
 		p.appendLog(lowPlayer, "score_low",
 			fmt.Sprintf("%s scores Low", playerName(p.players, lowPlayer)), nil)
 	}
 	if jackPlayer >= 0 {
 		points[jackPlayer]++
+		p.roundBreakdown.Jack = jackPlayer
 		p.appendLog(jackPlayer, "score_jack",
 			fmt.Sprintf("%s scores Jack", playerName(p.players, jackPlayer)), nil)
 	}
@@ -601,6 +630,7 @@ func (p *Pitch) computeRoundPoints() []int {
 	}
 	if !tied && gameWinner >= 0 && maxTotal > 0 {
 		points[gameWinner]++
+		p.roundBreakdown.Game = gameWinner
 		p.appendLog(gameWinner, "score_game",
 			fmt.Sprintf("%s scores Game (%d pip)", playerName(p.players, gameWinner), maxTotal), nil)
 	}

--- a/internal/domain/Pitch.go
+++ b/internal/domain/Pitch.go
@@ -149,6 +149,10 @@ func (p *Pitch) Reset() {
 	p.sortAllHands()
 
 	p.phase = PitchPhaseBid
+	// 新しいゲームでは誰も取っていない。ゼロ値のままだと席 0 が全部取ったように出る。
+	p.roundBreakdown = PitchRoundBreakdown{
+		High: PitchNoScorer, Low: PitchNoScorer, Jack: PitchNoScorer, Game: PitchNoScorer,
+	}
 }
 
 // dealRound Pitch 用に各プレイヤーへ PitchHandSize 枚配る (52枚デッキから 24枚のみ使用)
@@ -415,6 +419,10 @@ func (p *Pitch) ResolveTrick() {
 	p.leadPlayerIdx = winnerIdx
 	if p.trickNumber >= PitchTotalTricks {
 		p.phase = PitchPhaseRoundEnd
+		// **内訳は画面に出る時点で確定していること。**得点の確定 (ScoreRound) は
+		// プレイヤーが次のラウンドへ進めたときに走るので、そこで初めて作ると、
+		// ラウンド終了画面には前のラウンドの内訳 (初回はゼロ値) が出る (#5584)。
+		p.roundBreakdown = p.computeRoundBreakdown()
 	} else {
 		p.phase = PitchPhaseTrickEnd
 	}
@@ -552,13 +560,55 @@ func (p *Pitch) ScoreRound() {
 // computeRoundPoints 各プレイヤーが獲得したポイント数 (High/Low/Jack/Game) を返す
 func (p *Pitch) computeRoundPoints() []int {
 	points := make([]int, PitchPlayerCnt)
-	// 内訳は毎ラウンド組み直す。前のラウンドの結果が残ると、切り札の出なかった
-	// ラウンドで前回の獲得者が表示される。
-	p.roundBreakdown = PitchRoundBreakdown{
+	bd := p.computeRoundBreakdown()
+	p.roundBreakdown = bd
+	for _, idx := range []int{bd.High, bd.Low, bd.Jack, bd.Game} {
+		if idx != PitchNoScorer {
+			points[idx]++
+		}
+	}
+	if bd.High != PitchNoScorer {
+		p.appendLog(bd.High, "score_high",
+			fmt.Sprintf("%s scores High", playerName(p.players, bd.High)), nil)
+	}
+	if bd.Low != PitchNoScorer {
+		p.appendLog(bd.Low, "score_low",
+			fmt.Sprintf("%s scores Low", playerName(p.players, bd.Low)), nil)
+	}
+	if bd.Jack != PitchNoScorer {
+		p.appendLog(bd.Jack, "score_jack",
+			fmt.Sprintf("%s scores Jack", playerName(p.players, bd.Jack)), nil)
+	}
+	if bd.Game != PitchNoScorer {
+		p.appendLog(bd.Game, "score_game",
+			fmt.Sprintf("%s scores Game (%d pip)", playerName(p.players, bd.Game), p.gamePipTotal(bd.Game)), nil)
+	}
+	return points
+}
+
+// gamePipTotal は席 idx が取った札のピップ合計。Game ポイントの根拠を棋譜に残すため。
+func (p *Pitch) gamePipTotal(idx int) int {
+	total := 0
+	for _, trick := range p.players[idx].GetTricksTaken() {
+		for _, card := range trick {
+			total += pitchPipValue(card.GetValue())
+		}
+	}
+	return total
+}
+
+// computeRoundBreakdown は High/Low/Jack/Game をそれぞれ誰が取ったかを数える。
+//
+// **副作用を持たない。**ラウンドが終わった時点 (ResolveTrick) と、点を確定する
+// 時点 (ScoreRound) の両方から呼ぶので、棋譜に書いたり得点を動かしたりしない
+// (#5584 のレビュー指摘: 内訳を ScoreRound でしか作らないと、画面に出る
+// ラウンド終了時にはまだ前のラウンドの値が残っている)。
+func (p *Pitch) computeRoundBreakdown() PitchRoundBreakdown {
+	bd := PitchRoundBreakdown{
 		High: PitchNoScorer, Low: PitchNoScorer, Jack: PitchNoScorer, Game: PitchNoScorer,
 	}
 	if p.trumpSuit == PitchTrumpUnset {
-		return points
+		return bd
 	}
 	// 全カード走査でトランプの最高/最低と J of trump 所有者を特定
 	highPlayer := -1
@@ -590,22 +640,13 @@ func (p *Pitch) computeRoundPoints() []int {
 		}
 	}
 	if highPlayer >= 0 {
-		points[highPlayer]++
-		p.roundBreakdown.High = highPlayer
-		p.appendLog(highPlayer, "score_high",
-			fmt.Sprintf("%s scores High", playerName(p.players, highPlayer)), nil)
+		bd.High = highPlayer
 	}
 	if lowPlayer >= 0 {
-		points[lowPlayer]++
-		p.roundBreakdown.Low = lowPlayer
-		p.appendLog(lowPlayer, "score_low",
-			fmt.Sprintf("%s scores Low", playerName(p.players, lowPlayer)), nil)
+		bd.Low = lowPlayer
 	}
 	if jackPlayer >= 0 {
-		points[jackPlayer]++
-		p.roundBreakdown.Jack = jackPlayer
-		p.appendLog(jackPlayer, "score_jack",
-			fmt.Sprintf("%s scores Jack", playerName(p.players, jackPlayer)), nil)
+		bd.Jack = jackPlayer
 	}
 	// Game ポイント: 全カードのピップ値合計, 最大が単独なら +1
 	gameTotals := make([]int, PitchPlayerCnt)
@@ -629,12 +670,9 @@ func (p *Pitch) computeRoundPoints() []int {
 		}
 	}
 	if !tied && gameWinner >= 0 && maxTotal > 0 {
-		points[gameWinner]++
-		p.roundBreakdown.Game = gameWinner
-		p.appendLog(gameWinner, "score_game",
-			fmt.Sprintf("%s scores Game (%d pip)", playerName(p.players, gameWinner), maxTotal), nil)
+		bd.Game = gameWinner
 	}
-	return points
+	return bd
 }
 
 // checkGameEnd ゲーム終了判定: PointLimit 到達者がいれば終了。

--- a/internal/domain/Pitch_test.go
+++ b/internal/domain/Pitch_test.go
@@ -702,3 +702,72 @@ func TestPitchHandPips(t *testing.T) {
 		assert.Equal(t, 10, domain.PitchHandPips([]*domain.Card{nil, card(10), nil}))
 	})
 }
+
+// #5584: 4 種の得点 (High/Low/Jack/Game) はこのゲームの骨格なのに、合計しか
+// 画面に出ていなかった。内訳は**得点そのものと一致していること**が肝心で、
+// 別に数え直すと表示と点数がずれる。
+func TestPitch_RoundBreakdownAgreesWithThePoints(t *testing.T) {
+	p := newTestPitch()
+	p.Reset()
+
+	// 切り札を決めて、全員に取り札を配った状態を作る。
+	p.SetTrumpSuit(domain.CardDesignHeart)
+	// P0: ♥A (High) と ♥2 (Low) と絵札で pip を稼ぐ
+	p.GetPlayer(0).AddTrick([]*domain.Card{
+		newPitchCard(domain.CardDesignHeart, 1),
+		newPitchCard(domain.CardDesignHeart, 2),
+		newPitchCard(domain.CardDesignSpade, 13),
+	})
+	// P1: ♥J (Jack)
+	p.GetPlayer(1).AddTrick([]*domain.Card{newPitchCard(domain.CardDesignHeart, 11)})
+
+	// ビッド勝者がいない (bidWinnerIdx=-1) ので、ラウンド得点は獲得点そのもの。
+	p.SetPhase(domain.PitchPhaseRoundEnd)
+	p.ScoreRound()
+	points := pitchRoundScores(p)
+	bd := p.GetRoundBreakdown()
+
+	// **内訳で名指しされた席は、その分だけ点を得ていること。**
+	counted := make([]int, len(points))
+	for _, idx := range []int{bd.High, bd.Low, bd.Jack, bd.Game} {
+		if idx != domain.PitchNoScorer {
+			counted[idx]++
+		}
+	}
+	assert.Equal(t, points, counted, "the breakdown must account for every point awarded")
+
+	assert.Equal(t, 0, bd.High, "P0 holds the ace of trumps")
+	assert.Equal(t, 0, bd.Low, "P0 holds the two of trumps")
+	assert.Equal(t, 1, bd.Jack, "P1 holds the jack of trumps")
+}
+
+// 切り札が決まらなかったラウンドは誰も取っていない。前のラウンドの内訳が
+// 残ると、取っていない人が取ったように見える。
+func TestPitch_RoundBreakdownResetsWhenNoTrump(t *testing.T) {
+	p := newTestPitch()
+	p.Reset()
+	p.SetTrumpSuit(domain.CardDesignHeart)
+	p.GetPlayer(0).AddTrick([]*domain.Card{newPitchCard(domain.CardDesignHeart, 1)})
+	p.SetPhase(domain.PitchPhaseRoundEnd)
+	p.ScoreRound()
+	assert.NotEqual(t, domain.PitchNoScorer, p.GetRoundBreakdown().High)
+
+	p.SetTrumpSuit(domain.PitchTrumpUnset)
+	p.SetPhase(domain.PitchPhaseRoundEnd)
+	p.ScoreRound()
+	bd := p.GetRoundBreakdown()
+	assert.Equal(t, domain.PitchNoScorer, bd.High)
+	assert.Equal(t, domain.PitchNoScorer, bd.Low)
+	assert.Equal(t, domain.PitchNoScorer, bd.Jack)
+	assert.Equal(t, domain.PitchNoScorer, bd.Game)
+}
+
+// pitchRoundScores は各席のラウンド得点を並べる。ビッド勝者がいない局面では
+// 獲得点そのものになる。
+func pitchRoundScores(p *domain.Pitch) []int {
+	out := make([]int, domain.PitchPlayerCnt)
+	for i := range domain.PitchPlayerCnt {
+		out[i] = p.GetPlayer(i).GetRoundScore()
+	}
+	return out
+}

--- a/internal/domain/Pitch_test.go
+++ b/internal/domain/Pitch_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 )
@@ -770,4 +771,70 @@ func pitchRoundScores(p *domain.Pitch) []int {
 		out[i] = p.GetPlayer(i).GetRoundScore()
 	}
 	return out
+}
+
+// レビュー (#5942) の指摘: 内訳を ScoreRound でしか作らないと、**画面に出る時点では
+// まだ前のラウンドの値**（初回はゼロ値＝席0が全部取った形）が残る。
+// 実際の順序 ── 最後のトリックが解決してラウンド終了フェーズになり、そこで表示される ──
+// を通して確かめる。
+func TestPitch_RoundBreakdownIsReadyWhenTheRoundEndScreenAppears(t *testing.T) {
+	p := newTestPitch()
+	p.Reset()
+
+	// 配り直後 (まだ何も争われていない) は誰も取っていないこと。
+	fresh := p.GetRoundBreakdown()
+	assert.Equal(t, domain.PitchNoScorer, fresh.High, "a fresh game has no High winner")
+	assert.Equal(t, domain.PitchNoScorer, fresh.Game, "a fresh game has no Game winner")
+
+	// 最後のトリックまで進める。ここでフェーズが RoundEnd になり、画面に出る。
+	// ResolveTrick は「4 枚出そろった (TrickEnd)」状態からしか動かない。
+	p.SetPhase(domain.PitchPhaseTrickEnd)
+	p.SetTrumpSuit(domain.CardDesignHeart)
+	p.SetTrickNumber(domain.PitchTotalTricks)
+	p.SetLeadPlayerIdx(0)
+	p.SetCurrentPlayerIdx(0)
+	p.GetPlayer(0).AddTrick([]*domain.Card{
+		newPitchCard(domain.CardDesignHeart, 1),
+		newPitchCard(domain.CardDesignHeart, 2),
+	})
+	p.SetCurrentTrick([]*domain.TrickCard{
+		{PlayerIdx: 0, Card: newPitchCard(domain.CardDesignHeart, 11)},
+		{PlayerIdx: 1, Card: newPitchCard(domain.CardDesignSpade, 3)},
+		{PlayerIdx: 2, Card: newPitchCard(domain.CardDesignSpade, 4)},
+		{PlayerIdx: 3, Card: newPitchCard(domain.CardDesignSpade, 5)},
+	})
+	p.ResolveTrick()
+
+	require.Equal(t, domain.PitchPhaseRoundEnd, p.GetPhase(), "the last trick ends the round")
+	bd := p.GetRoundBreakdown()
+	// **ScoreRound を呼ぶ前に**、この画面の内訳が確定していること。
+	assert.Equal(t, 0, bd.High, "P0 holds the ace of trumps")
+	assert.Equal(t, 0, bd.Low, "P0 holds the two of trumps")
+	assert.Equal(t, 0, bd.Jack, "P0 took the jack of trumps in the last trick")
+
+	// ScoreRound を通しても同じ答え。二度数えて食い違わないこと。
+	after := bd
+	p.ScoreRound()
+	assert.Equal(t, after, p.GetRoundBreakdown())
+}
+
+// 得点の確定は棋譜を 1 度だけ書くこと。内訳を 2 箇所で作るようにしたので、
+// ログまで二重にならないことを見る。
+func TestPitch_ScoreRoundLogsEachCategoryOnce(t *testing.T) {
+	p := newTestPitch()
+	p.Reset()
+	p.SetTrumpSuit(domain.CardDesignHeart)
+	p.GetPlayer(0).AddTrick([]*domain.Card{
+		newPitchCard(domain.CardDesignHeart, 1),
+		newPitchCard(domain.CardDesignHeart, 11),
+	})
+	p.SetPhase(domain.PitchPhaseRoundEnd)
+	p.ScoreRound()
+
+	counts := map[string]int{}
+	for _, e := range p.GetActionLog() {
+		counts[e.ActionType]++
+	}
+	assert.Equal(t, 1, counts["score_high"])
+	assert.Equal(t, 1, counts["score_jack"])
 }

--- a/internal/domain/interfaces/pitch.go
+++ b/internal/domain/interfaces/pitch.go
@@ -4,6 +4,8 @@ import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 
 // PitchGame ピッチゲームインタフェース
 type PitchGame interface {
+	// GetRoundBreakdown 直近ラウンドの High/Low/Jack/Game をそれぞれ誰が取ったか
+	GetRoundBreakdown() domain.PitchRoundBreakdown
 	BaseGame
 	// Reset ゲームを初期化する
 	Reset()

--- a/internal/domain/interfaces/pitch_mock.go
+++ b/internal/domain/interfaces/pitch_mock.go
@@ -17,6 +17,13 @@ func (m *MockPitchGame) Reset() {
 	m.Called()
 }
 
+// GetRoundBreakdown は直近ラウンドの得点内訳を返す。
+func (m *MockPitchGame) GetRoundBreakdown() domain.PitchRoundBreakdown {
+	args := m.Called()
+	bd, _ := args.Get(0).(domain.PitchRoundBreakdown)
+	return bd
+}
+
 func (m *MockPitchGame) NextRound() {
 	m.Called()
 }

--- a/internal/i18n/locales/en/pitch.json
+++ b/internal/i18n/locales/en/pitch.json
@@ -31,5 +31,7 @@
   "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Easy, 1=Normal, 2=Hard)",
   "helpSetLimit": "  sl <n>               point limit",
   "helpExamplePlay": "  p 0                  play hand card 0",
-  "helpHint": "  h                    show a hint"
+  "helpHint": "  h                    show a hint",
+  "scoringLine": "Points: High={{high}} / Low={{low}} / Jack={{jack}} / Game={{game}}",
+  "scoringNobody": "nobody"
 }

--- a/internal/i18n/locales/ja/pitch.json
+++ b/internal/i18n/locales/ja/pitch.json
@@ -31,5 +31,7 @@
   "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Easy, 1=Normal, 2=Hard)",
   "helpSetLimit": "  sl <n>               ポイント上限",
   "helpExamplePlay": "  p 0                  手札の 0 番のカードを出す",
-  "helpHint": "  h                    助言を表示"
+  "helpHint": "  h                    助言を表示",
+  "scoringLine": "内訳: High={{high}} / Low={{low}} / Jack={{jack}} / Game={{game}}",
+  "scoringNobody": "なし"
 }


### PR DESCRIPTION
Closes #5584

## 何が問題だったか

ピッチのラウンドを決めるのは **High / Low / Jack / Game の 4 点**なのに、Web も CUI も
その合計しか出していなかった。1 点差が「Jack を取られた」のか「Game で並ばれた」のかが分からない。

`frontend/src/i18n/locales/*/pitch.json` の `scoring.high/low/jack/game` は**用意されていたのに
どこからも参照されていなかった**。唯一内訳が見えるのは英語ハードコードのアクションログで、
しかも追加クリックの先。

## 変更

- `PitchRoundBreakdown` を**得点を確定するのと同じ場所** (`computeRoundPoints`) で埋める。
  表示側が数え直さないので、内訳と点数がずれない。
- CUI: ラウンド終了時に 4 カテゴリの獲得者を 1 行で。
- Web: スコア表の下に 4 行。**未使用だった `scoring.*` キーを実際に使う**（受け入れ条件2）。
- **誰も取っていないカテゴリは「なし」と出す。**黙って省くと、そもそも争われなかったのか
  見落としたのか区別が付かない（切り札が出なければ High/Low/Jack は無く、Game は同点で消える）。
- `api/openapi.yaml` も更新（CRLF 維持 15/0）。

## テスト

- ドメイン: **内訳で名指しされた席の数が、実際に配られた点と一致する**こと（受け入れ条件4）/
  ♥A=High, ♥2=Low, ♥J=Jack が正しい席に付く / **切り札が決まらなければ全部「なし」に戻る**
  （前ラウンドの結果が残らない）
- CUI: 4 カテゴリ全部が並ぶ / 全部「なし」の局面でも 4 つ出る / ラウンド途中は出さない
- ページ: カテゴリごとに**違う席**が出る（1 席に固定する実装では通らない）/ -1 は「なし」/
  ラウンド途中は出さない

変異テスト2件: Jack の記録を落とす → 4件検出 / ラウンド頭のリセットを消す → 4件検出。

`golangci-lint` 0 issues / `go test ./internal/...` 全 green / `bun run check` / `bun run typecheck`。