### PR TITLE
feat(dragontiger): repeat the last wager with one command

### DIFF
--- a/docs/manual/cui/dragontiger.md
+++ b/docs/manual/cui/dragontiger.md
@@ -56,6 +56,7 @@ flowchart TD
 | `reset` | `r` | ゲームリセット |
 | `bet <amount> <d\|t\|e>` | `b` | ベット（`d`=ドラゴン, `t`=タイガー, `e`=タイ） |
 | `bet <amount> <dragon\|tiger\|tie>` | `b` | 上記の長い形式 |
+| `rebet` | `rb` | 直前と同じ額・同じ種別をもう一度賭ける（リセット → 賭けを 1 コマンドで） |
 | `clear` |  | Big Road（履歴）をクリア |
 | `log` | `l` | 棋譜を表示 |
 | `quit` | `q` | 終了 |

--- a/internal/adapter/controller/DragonTigerCuiController.go
+++ b/internal/adapter/controller/DragonTigerCuiController.go
@@ -57,8 +57,6 @@ func (dc *DragonTigerCuiController) Exec(command string) string {
 				}
 				// **受け付けた後に覚える。**額や種別が不正なまま覚えると、
 				// `rb` が通らないベットを繰り返す。
-				// **受け付けた後に覚える。**額や種別が不正なまま覚えると、
-				// `rb` が通らないベットを繰り返す。
 				dc.lastBet = &dragonTigerBet{amount: amount, betType: betType}
 				return dc.di.Bet(amount, betType), true
 			case "rb", "rebet":

--- a/internal/adapter/controller/DragonTigerCuiController.go
+++ b/internal/adapter/controller/DragonTigerCuiController.go
@@ -13,6 +13,17 @@ import (
 // DragonTigerCuiController ドラゴンタイガーCUIコントローラークラス
 type DragonTigerCuiController struct {
 	di usecase.DragonTigerInteractorIF
+	// lastBet は直近に受け付けたベット。`rb` はこれを reset の後に打ち直す (#5585)。
+	//
+	// **Web は 1 クリックで同じ賭けを繰り返せる** (`dt-rebet-button`) のに、CUI は
+	// 毎ラウンド `r` のあとフルの `b <額> <種別>` を打ち直す必要があった。
+	lastBet *dragonTigerBet
+}
+
+// dragonTigerBet は再賭けのために覚えておく 1 回分のベット。
+type dragonTigerBet struct {
+	amount  int
+	betType int
 }
 
 // NewDragonTigerCuiController コンストラクタ
@@ -29,7 +40,7 @@ func (dc *DragonTigerCuiController) Exec(command string) string {
 	return execCuiCommand(
 		command,
 		func(_ []string) string { return dc.di.Reset() },
-		[]string{"b", "bet", "clear", "log"},
+		[]string{"b", "bet", "rb", "rebet", "clear", "log"},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "b", "bet":
@@ -44,7 +55,14 @@ func (dc *DragonTigerCuiController) Exec(command string) string {
 				if !ok {
 					return invalidArg("invalidBetTypeDragonTiger"), true
 				}
+				// **受け付けた後に覚える。**額や種別が不正なまま覚えると、
+				// `rb` が通らないベットを繰り返す。
+				// **受け付けた後に覚える。**額や種別が不正なまま覚えると、
+				// `rb` が通らないベットを繰り返す。
+				dc.lastBet = &dragonTigerBet{amount: amount, betType: betType}
 				return dc.di.Bet(amount, betType), true
+			case "rb", "rebet":
+				return dc.handleRebet(), true
 			case "clear":
 				return dc.di.ClearHistory(), true
 			default:
@@ -52,6 +70,19 @@ func (dc *DragonTigerCuiController) Exec(command string) string {
 			}
 		},
 	)
+}
+
+// handleRebet は直前と同じ賭けを、リセットの後に打ち直す。
+//
+// Web の `handleRebet` と同じ順序 (reset → bet)。履歴が無ければ、黙って
+// 何もせずにエラーを返す ── 「リセットだけされた」状態は、打ち直したつもりの
+// プレイヤーには気づけない。
+func (dc *DragonTigerCuiController) handleRebet() string {
+	if dc.lastBet == nil {
+		return invalidArg("dragontiger.noPreviousBet")
+	}
+	dc.di.Reset()
+	return dc.di.Bet(dc.lastBet.amount, dc.lastBet.betType)
 }
 
 // dragonTigerParseBetType ベットタイプを文字列から解析する。

--- a/internal/adapter/controller/DragonTigerCuiController_test.go
+++ b/internal/adapter/controller/DragonTigerCuiController_test.go
@@ -6,10 +6,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/usecase"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func newMockDragonTigerInteractor() *usecase.MockDragonTigerInteractor {
@@ -82,4 +84,55 @@ func TestDragonTigerCuiController_Unknown(t *testing.T) {
 func TestDragonTigerCuiController_Empty(t *testing.T) {
 	c := controller.NewDragonTigerCuiController(newMockDragonTigerInteractor())
 	assert.Contains(t, c.Exec(""), "'help' でコマンド一覧を表示します。")
+}
+
+// #5585: Web は 1 クリックで同じ賭けを繰り返せるのに、CUI は毎ラウンド
+// `r` のあとフルの `b <額> <種別>` を打ち直す必要があった。
+func TestDragonTigerCuiControllerRebet(t *testing.T) {
+	for _, alias := range []string{"rb", "rebet"} {
+		t.Run(alias, func(t *testing.T) {
+			di := newMockDragonTigerInteractor()
+			c := controller.NewDragonTigerCuiController(di)
+			assert.Equal(t, "bet tiger", c.Exec("b 100 t"))
+			// **reset を挟んでから同じ賭けを打ち直す** (Web の handleRebet と同順)。
+			assert.Equal(t, "bet tiger", c.Exec(alias))
+			di.AssertCalled(t, "Reset")
+			di.AssertNumberOfCalls(t, "Bet", 2)
+		})
+	}
+}
+
+// 履歴が無ければ、リセットもせずにエラーを返す。**「リセットだけされた」状態は
+// 打ち直したつもりのプレイヤーには気づけない。**
+func TestDragonTigerCuiControllerRebetWithoutHistory(t *testing.T) {
+	di := newMockDragonTigerInteractor()
+	c := controller.NewDragonTigerCuiController(di)
+
+	out := c.Exec("rebet")
+	assert.Contains(t, out, i18n.T("dragontiger.noPreviousBet"))
+	di.AssertNotCalled(t, "Reset")
+	di.AssertNotCalled(t, "Bet", mock.Anything, mock.Anything)
+}
+
+// **不正なベットは覚えない。**覚えると、通らない賭けを rb が繰り返す。
+func TestDragonTigerCuiControllerDoesNotRememberARejectedBet(t *testing.T) {
+	di := newMockDragonTigerInteractor()
+	c := controller.NewDragonTigerCuiController(di)
+
+	c.Exec("b 100 zz") // 種別が不正
+	out := c.Exec("rb")
+	assert.Contains(t, out, i18n.T("dragontiger.noPreviousBet"))
+	di.AssertNotCalled(t, "Bet", mock.Anything, mock.Anything)
+}
+
+// 賭け直しは**最後の**ベットを繰り返す。
+func TestDragonTigerCuiControllerRebetUsesTheLatestBet(t *testing.T) {
+	di := newMockDragonTigerInteractor()
+	c := controller.NewDragonTigerCuiController(di)
+	di.On("Bet", 250, domain.DragonTigerBetTie).Return("bet 250 tie")
+
+	c.Exec("b 100 d")
+	c.Exec("b 250 e")
+	assert.Equal(t, "bet 250 tie", c.Exec("rb"))
+	di.AssertNumberOfCalls(t, "Bet", 3)
 }

--- a/internal/i18n/locales/en/dragontiger.json
+++ b/internal/i18n/locales/en/dragontiger.json
@@ -23,5 +23,7 @@
   "payoutLine": "payout: {{payout}}",
   "historyLine": "History: {{symbols}}",
   "historyCounts": "Totals: D:{{d}} T:{{t}} =:{{tie}}",
-  "helpExampleBet": "  b 100 d              bet 100 on the Dragon"
+  "helpExampleBet": "  b 100 d              bet 100 on the Dragon",
+  "noPreviousBet": "There is no previous bet. Place one first with b <amount> <type>",
+  "helpRebet": "  rb                       repeat the last wager"
 }

--- a/internal/i18n/locales/ja/dragontiger.json
+++ b/internal/i18n/locales/ja/dragontiger.json
@@ -23,5 +23,7 @@
   "payoutLine": "払戻し: {{payout}}",
   "historyLine": "履歴: {{symbols}}",
   "historyCounts": "集計: D:{{d}} T:{{t}} =:{{tie}}",
-  "helpExampleBet": "  b 100 d              100 をドラゴンに賭ける"
+  "helpExampleBet": "  b 100 d              100 をドラゴンに賭ける",
+  "noPreviousBet": "直前のベットがありません。まず b <額> <種別> で賭けてください",
+  "helpRebet": "  rb                       直前と同じ賭けをもう一度"
 }

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -2276,7 +2276,7 @@ var gameRegistry = []GameRegistryEntry{
 			ExampleKeys: []string{
 				"dragontiger.helpExampleBet",
 			},
-			CommandKeys:       []string{"dragontiger.helpBet", "dragontiger.helpClear"},
+			CommandKeys:       []string{"dragontiger.helpBet", "dragontiger.helpRebet", "dragontiger.helpClear"},
 			ExtraCommandLines: []string{"  log                  action log"},
 		}),
 	BindCuiFor("blackjackswitch",


### PR DESCRIPTION
Closes #5585

## 何が問題だったか

Web は END フェーズで `dt-rebet-button`（キー `e`）から**1 クリックで同じ賭けを繰り返せる**のに、
CUI は毎ラウンド `r` でリセットしてからフルの `b <額> <種別>` を打ち直す必要があった。
テンポが売りのゲームでこれは効く。

## 変更

- コントローラが直近のベットを 1 手分だけ覚え、`rb` / `rebet` で **reset → 同じ賭け**を実行
  （Web の `handleRebet` と同じ順序）。
- **履歴が無ければリセットもせずにエラー。**「リセットだけされた」状態はプロンプトからは
  賭け直しと見分けが付かず、1 ラウンド後に気づくことになる。
- **不正なベットは覚えない。**受け付けた後に覚えるので、`rb` が通らない賭けを繰り返さない。
- ヘルプ一覧と `docs/manual/cui/dragontiger.md` にも追記。

## テスト

- `rb` / `rebet` 両方で、**Reset を挟んで**同じ賭けが再実行される
- 履歴が無いとエラーになり、**Reset も Bet も呼ばれない**
- **種別が不正なベットの後の `rb` は履歴なし扱い**（覚えていない証拠）
- 賭け直しは**最後の**ベットを繰り返す

変異テスト2件: `rb` が Reset を呼ばない → 6件検出 / ベットを覚えない → 7件検出。

`golangci-lint` 0 issues / `go test ./internal/...` 全 green / `bun run check`。