### PR TITLE
feat(contractrummy): let the web pick the CPU difficulty

### DIFF
--- a/frontend/src/i18n/locales/en/contractrummy.json
+++ b/frontend/src/i18n/locales/en/contractrummy.json
@@ -40,5 +40,12 @@
     "contractrummyMeetContract": "The contract is not met yet — even heavy cards are material",
     "contractrummyDiscardHeavy": "Your heaviest unconnected card"
   },
-  "invalidExtraMeld": "Not a valid set or run"
+  "invalidExtraMeld": "Not a valid set or run",
+  "settings": {
+    "title": "Settings",
+    "cpuDifficulty": "CPU difficulty",
+    "easy": "Easy",
+    "normal": "Normal",
+    "hard": "Hard"
+  }
 }

--- a/frontend/src/i18n/locales/ja/contractrummy.json
+++ b/frontend/src/i18n/locales/ja/contractrummy.json
@@ -40,5 +40,12 @@
     "contractrummyMeetContract": "まだ契約を満たしていません。重い札も材料です",
     "contractrummyDiscardHeavy": "繋がっていない札のうち一番重い札です"
   },
-  "invalidExtraMeld": "セットまたはランとして成立していません"
+  "invalidExtraMeld": "セットまたはランとして成立していません",
+  "settings": {
+    "title": "設定",
+    "cpuDifficulty": "CPU難易度",
+    "easy": "Easy",
+    "normal": "Normal",
+    "hard": "Hard"
+  }
 }

--- a/frontend/src/pages/ContractRummyPage.test.tsx
+++ b/frontend/src/pages/ContractRummyPage.test.tsx
@@ -476,6 +476,21 @@ describe('ContractRummyPage', () => {
       await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', { config: { cpuDifficulty: 0 } }));
     });
 
+    // **リセットでも難易度を持ち越す。**config を付けずに reset すると、サーバは
+    // 既定値に戻す ── 選んだ直後は効くのに、次に「最初から」を押した時点で黙って戻る。
+    it('keeps the chosen difficulty when the game is reset', async () => {
+      mockExec.mockResolvedValue({ ...drawState, config: { cpuDifficulty: 2, failContractPenalty: 25 } });
+      renderWithProviders(<ContractRummyPage />);
+      await waitFor(() => expect(screen.getByLabelText('CPU難易度')).toBeInTheDocument());
+      mockExec.mockClear();
+
+      fireEvent.click(screen.getByRole('button', { name: 'リセット' }));
+      // 途中リセットは確認ダイアログを挟む。
+      fireEvent.click(await screen.findByRole('button', { name: '確認' }));
+
+      await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', { config: { cpuDifficulty: 2 } }));
+    });
+
     it('offers exactly the three levels', async () => {
       mockExec.mockResolvedValue(drawState);
       renderWithProviders(<ContractRummyPage />);

--- a/frontend/src/pages/ContractRummyPage.test.tsx
+++ b/frontend/src/pages/ContractRummyPage.test.tsx
@@ -454,4 +454,34 @@ describe('ContractRummyPage', () => {
     expect(meldExtra).toBeEnabled();
     expect(screen.queryByTestId('cr-invalid-extra-meld')).not.toBeInTheDocument();
   });
+
+  // #5588: 難易度はドメインにもレスポンス型にも API にもあるのに、**Web からは
+  // 触れなかった** (CUI の `sd` だけ)。
+  describe('cpu difficulty setting', () => {
+    it('shows the current difficulty from the response', async () => {
+      mockExec.mockResolvedValue({ ...drawState, config: { cpuDifficulty: 2, failContractPenalty: 25 } });
+      renderWithProviders(<ContractRummyPage />);
+      const select = await screen.findByLabelText('CPU難易度');
+      expect((select as HTMLSelectElement).value).toBe('2');
+    });
+
+    // **数値は CUI の `sd` と同じ 0/1/2** (受け入れ条件2)。reset に載せて渡す ──
+    // 難易度は配り直しでしか効かない。
+    it('resets with the chosen difficulty', async () => {
+      mockExec.mockResolvedValue(drawState);
+      renderWithProviders(<ContractRummyPage />);
+      const select = await screen.findByLabelText('CPU難易度');
+      mockExec.mockClear();
+      fireEvent.change(select, { target: { value: '0' } });
+      await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset', { config: { cpuDifficulty: 0 } }));
+    });
+
+    it('offers exactly the three levels', async () => {
+      mockExec.mockResolvedValue(drawState);
+      renderWithProviders(<ContractRummyPage />);
+      const select = await screen.findByLabelText('CPU難易度');
+      const values = [...(select as HTMLSelectElement).options].map((o) => o.value);
+      expect(values).toEqual(['0', '1', '2']);
+    });
+  });
 });

--- a/frontend/src/pages/ContractRummyPage.tsx
+++ b/frontend/src/pages/ContractRummyPage.tsx
@@ -226,10 +226,14 @@ function ContractRummyPageContent() {
     clearSelection();
   }, [execApi, clearSelection]);
 
+  // **リセットでも難易度を持ち越す。**config を付けずに reset すると、サーバは
+  // 既定値 (Normal) に戻す。選んだ直後は効くのに、次に「最初から」を押した時点で
+  // 黙って戻る形になっていた (#5588 のレビュー指摘)。
+  const cpuDifficulty = state?.config.cpuDifficulty;
   const handleReset = useCallback(() => {
-    void execApi('reset');
+    void execApi('reset', cpuDifficulty === undefined ? undefined : { config: { cpuDifficulty } });
     clearSelection();
-  }, [execApi, clearSelection]);
+  }, [execApi, clearSelection, cpuDifficulty]);
 
   const phaseName = useMemo(() => {
     if (!state) return '';

--- a/frontend/src/pages/ContractRummyPage.tsx
+++ b/frontend/src/pages/ContractRummyPage.tsx
@@ -3,6 +3,7 @@ import { contractrummyApi } from '../api/gameApi';
 import { ActionLogSection } from '../components/ActionLogSection';
 import { CliTerminal } from '../components/cli/CliTerminal';
 import { CliToggle } from '../components/cli/CliToggle';
+import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameFooter } from '../components/GameFooter';
 import { GameMessageBox } from '../components/GameMessageBox';
@@ -31,6 +32,7 @@ import { formatContractRummyState } from '../utils/cli/formatters/contractrummyF
 import { hintLocalCommand } from '../utils/cli/hintText';
 import type { CliGameConfig } from '../utils/cli/types';
 import { evaluateContractSlot, isContractRummyMeld } from '../utils/contractRummyUtils';
+import { hintCheckboxItem } from '../utils/settingsItems';
 
 /** Phase identifiers for Contract Rummy. */
 const CR_PHASE = {
@@ -84,6 +86,16 @@ function formatSlot(
 }
 
 /** Inner content of the Contract Rummy page. */
+/**
+ * CPU difficulty values, matching the CUI's `sd` command and
+ * `domain.ContractRummyCpuDifficulty` (0=Easy, 1=Normal, 2=Hard).
+ */
+const CONTRACT_RUMMY_DIFFICULTY_OPTIONS = [
+  { value: 0, label: 'easy' },
+  { value: 1, label: 'normal' },
+  { value: 2, label: 'hard' },
+] as const;
+
 function ContractRummyPageContent() {
   const { t, tc, actionLog, showActionLog, hideActionLog, confirmOpen, requestConfirm, confirmReset, cancelReset } =
     useGamePageSetup('contractrummy');
@@ -270,6 +282,32 @@ function ContractRummyPageContent() {
         <CliTerminal logEntries={logEntries} onCommand={handleCommand} disabled={loading} />
       ) : (
         <>
+          {/* **CUI だけが難易度を変えられる状態だった** (`sd` コマンド)。設定は
+              ドメインにもレスポンス型にもあるのに、Web からは触れなかった (#5588)。
+              数値は CUI と同じ 0/1/2。 */}
+          <SettingsPanel
+            title={t('settings.title')}
+            groups={[
+              {
+                items: [
+                  {
+                    type: 'select',
+                    id: 'cpuDifficulty',
+                    label: t('settings.cpuDifficulty'),
+                    value: state.config.cpuDifficulty,
+                    options: CONTRACT_RUMMY_DIFFICULTY_OPTIONS.map((o) => ({
+                      value: o.value,
+                      label: t(`settings.${o.label}`),
+                    })),
+                    // 難易度は配り直しでしか効かないので、reset に載せて渡す。
+                    onSelect: (v) => void execApi('reset', { config: { cpuDifficulty: Number(v) } }),
+                  },
+                  hintCheckboxItem(tc, frontendHintEnabled, setFrontendHintEnabled),
+                ],
+              },
+            ]}
+          />
+
           {error && <ErrorAlert message={error} onRetry={retry} />}
 
           {/* Scrollable state display: this page had no play area, so its
@@ -429,14 +467,9 @@ function ContractRummyPageContent() {
             )}
           </div>
 
-          <label className="flex items-center gap-1 text-ds-text-primary text-xs px-4 cursor-pointer min-h-[44px]">
-            <input
-              type="checkbox"
-              checked={frontendHintEnabled}
-              onChange={(e) => setFrontendHintEnabled(e.target.checked)}
-            />
-            {tc('hint.toggle', { ns: 'tutorial' })}
-          </label>
+          {/* ヒントの切り替えは設定パネルへ移した (#5588)。同じ状態を切り替える
+              コントロールが 2 つあると、どちらを押しても効くのに片方しか見つけて
+              もらえない。 */}
           <FrontendHintTooltip hint={frontendHint} enabled={frontendHintEnabled} t={t} />
 
           <section className="px-4 py-2 flex flex-wrap gap-2" data-tutorial="cr-actions">

--- a/internal/domain/ContractRummy_test.go
+++ b/internal/domain/ContractRummy_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // helperContractRummyHand 任意の手札・スコア状態を持つ ContractRummy を構築する。
@@ -1020,4 +1022,48 @@ func TestContractRummy_GetterSetterCoverage(t *testing.T) {
 	if g.IsHumanTurn() {
 		t.Error("out-of-range index should not be human")
 	}
+}
+
+// #5588: 難易度が実際に CPU の拾い方を変えることを固定する。Web に選択肢を出す
+// にあたり、**選んでも何も変わらない**のでは意味がない (受け入れ条件3)。
+//
+// 拾うかどうかは乱数を含むので 1 回では測れない。同じ局面を何度も打たせて
+// 「拾った割合」で比べる。
+func TestContractRummy_CpuDifficultyChangesTheDiscardPickup(t *testing.T) {
+	// コントラクト未達で、拾っても進捗が上がらない札を出す。ここで初めて
+	// 難易度ごとの無作為性が効く。
+	// **手札を固定する。**配りごとに変えると、測っているものが試行ごとに変わり、
+	// 「進捗の上がらない札」が見つからない。バラバラのランクを持たせて、
+	// プローブ (♦2) がどのセットにも列にも寄与しないようにする。
+	hand := []*Card{
+		crCard(0, 5), crCard(1, 7), crCard(2, 9), crCard(3, 11), crCard(0, 13),
+	}
+	rate := func(difficulty ContractRummyCpuDifficulty) float64 {
+		took := 0
+		const trials = 600
+		for range trials {
+			g := helperContractRummyHand(t)
+			g.SetCurrentPlayerIdx(1)
+			cfg := g.GetConfig()
+			cfg.CpuDifficulty = difficulty
+			g.SetConfig(cfg)
+			cpu := g.GetPlayer(1)
+			cpu.SetContractMet(false)
+			setHand(cpu, hand)
+			if g.cpuShouldTakeDiscard(crCard(3, 2)) {
+				took++
+			}
+		}
+		return float64(took) / float64(trials)
+	}
+
+	hard := rate(ContractRummyCpuDifficultyHard)
+	normal := rate(ContractRummyCpuDifficultyNormal)
+	easy := rate(ContractRummyCpuDifficultyEasy)
+
+	// Hard は進捗の上がらない札を拾わない。
+	assert.Zero(t, hard, "hard never takes a useless discard")
+	// Easy ほど無駄拾いが多い。**順序を固定する**ので、3 値が同じ実装では通らない。
+	assert.Greater(t, easy, normal, "easy takes useless discards more often than normal")
+	assert.Greater(t, normal, hard, "normal takes them more often than hard")
 }


### PR DESCRIPTION
Closes #5588

## 何が問題だったか

難易度はドメイン (`cpuShouldTakeDiscard` が `CpuDifficulty` で乱数幅を切り替える) にも、
レスポンス型にも、API の `config` にもある。**CUI だけが `sd` で変えられて、Web からは
一切触れなかった** — `ContractRummyPage.tsx` は `SettingsPanel` を import すらしていなかった。

## 変更

- `SettingsPanel` に難易度セレクタ。**値は CUI の `sd` と同じ 0/1/2**（受け入れ条件2）。
- 難易度は配り直しでしか効かないので `reset` に載せて渡す。現在値は**レスポンスから読む**
  （自前で持たない）。
- ページに元からあった**単独のヒントチェックボックス**を同じパネルに移した（受け入れ条件4）。
  同じ状態を切り替えるコントロールが 2 つあると、見つけた方だけが使われ、もう片方は
  壊れているように見える。

## 「選んでも何も変わらない」を防ぐ（受け入れ条件3）

3 段階が**実際に拾い方を変える**ことをドメインのテストで固定した。拾うかどうかは乱数を
含むので 1 回では測れない ── **手札を固定**して同じ局面を 600 回打たせ、
無駄札を拾った割合を比べる（Hard=0 < Normal < Easy）。順序まで見るので、3 値が同じ実装では通らない。
手札を固定しないと、配りごとに「無駄な札」が変わって測定にならない（最初それで詰まった）。

## テスト

- ページ: 現在値がセレクタに出る / 選ぶと `reset` に `config.cpuDifficulty` が載る /
  選択肢がちょうど 3 つ
- ドメイン: 難易度ごとの拾い率（5 回連続実行で安定を確認）

変異テスト2件: `reset` から config を落とす → 1件検出 / セレクタが現在値を無視 → 1件検出。

`golangci-lint` 0 issues / `go test ./internal/...` 全 green / `bun run check` / `bun run typecheck`。