### PR TITLE
feat(mississippistud): say which odds paid the hand

### DIFF
--- a/frontend/src/i18n/locales/en/mississippistud.json
+++ b/frontend/src/i18n/locales/en/mississippistud.json
@@ -73,5 +73,6 @@
     "raiseBig": "Strong made hand — 3x recommended",
     "raiseSmall": "Marginal hand — 1x recommended",
     "fold": "Weak hand — Fold recommended"
-  }
+  },
+  "payoutMultiplier": "pays {{multiplier}}:1"
 }

--- a/frontend/src/i18n/locales/ja/mississippistud.json
+++ b/frontend/src/i18n/locales/ja/mississippistud.json
@@ -73,5 +73,6 @@
     "raiseBig": "強いハンド — 3倍ベット推奨",
     "raiseSmall": "微妙なハンド — 1倍ベット推奨",
     "fold": "弱いハンド — フォールド推奨"
-  }
+  },
+  "payoutMultiplier": "配当倍率 x{{multiplier}}"
 }

--- a/frontend/src/pages/MississippiStudPage.test.tsx
+++ b/frontend/src/pages/MississippiStudPage.test.tsx
@@ -380,4 +380,33 @@ describe('MississippiStudPage keyboard shortcuts', () => {
     await flushPendingDispatch();
     expect(mockApi).not.toHaveBeenCalled();
   });
+
+  // #5591: 「役はフラッシュ、配当800」とは分かっても、その配当が**どの倍率から
+  // 来たのか**を説明していなかった。サーバは既に送っていたのに読んでいなかった。
+  describe('payout multiplier', () => {
+    it('shows the odds next to the hand name', async () => {
+      mockApi.mockResolvedValue({ ...endPhaseWin, payoutMultiplier: 8 });
+      renderWithProviders(<MississippiStudPage />);
+      const odds = await screen.findByTestId('ms-payout-multiplier');
+      expect(odds).toHaveTextContent('8');
+    });
+
+    // **プッシュ (-1) とロス (0) は倍率ではない** (受け入れ条件3)。
+    it.each([
+      ['push', -1],
+      ['loss', 0],
+    ])('says nothing on a %s', async (_name, multiplier) => {
+      mockApi.mockResolvedValue({ ...endPhaseWin, payoutMultiplier: multiplier });
+      renderWithProviders(<MississippiStudPage />);
+      await waitFor(() => expect(mockApi).toHaveBeenCalled());
+      expect(screen.queryByTestId('ms-payout-multiplier')).not.toBeInTheDocument();
+    });
+
+    it('stays hidden before the hand is settled', async () => {
+      mockApi.mockResolvedValue({ ...antePhaseState, payoutMultiplier: 8 });
+      renderWithProviders(<MississippiStudPage />);
+      await waitFor(() => expect(mockApi).toHaveBeenCalled());
+      expect(screen.queryByTestId('ms-payout-multiplier')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/pages/MississippiStudPage.tsx
+++ b/frontend/src/pages/MississippiStudPage.tsx
@@ -206,7 +206,20 @@ function MississippiStudPageContent() {
             <div className="text-ds-warning font-bold text-center mb-1">
               <span aria-hidden="true">🟡</span> {t('player')}
               {isEndPhase && (
-                <span className="ml-2 text-sm">({t(HAND_RANK_KEYS[state.handRank] ?? 'handRank.0')})</span>
+                <span className="ml-2 text-sm">
+                  ({t(HAND_RANK_KEYS[state.handRank] ?? 'handRank.0')}
+                  {/* **配当がどの倍率から来たのかを説明していなかった** (#5591)。
+                      サーバは既に送っているのに、画面が読んでいなかった。
+                      プッシュ (-1) とロス (0) は倍率でないので、数字を出すと
+                      「x-1」「x0」という存在しないオッズに読める。 */}
+                  {state.payoutMultiplier > 0 && (
+                    <span data-testid="ms-payout-multiplier">
+                      {', '}
+                      {t('payoutMultiplier', { multiplier: state.payoutMultiplier })}
+                    </span>
+                  )}
+                  )
+                </span>
               )}
             </div>
             <div className="flex justify-center gap-2 flex-wrap">

--- a/internal/adapter/presenter/MississippiStudCuiPresenter.go
+++ b/internal/adapter/presenter/MississippiStudCuiPresenter.go
@@ -71,6 +71,13 @@ func (mp *MississippiStudCuiPresenter) Output(g interfaces.MississippiStudGame, 
 			if rank := g.GetHandRank(); rank >= 0 && rank < len(domain.PokerHandNames) && !g.GetFolded() {
 				fmt.Fprintf(b, "%s\n", i18n.Tf("mississippistud.handLine", "hand", cuiPokerHandName(rank)))
 			}
+			// **配当がどの倍率から来たのかを説明していなかった** (#5591)。
+			// プッシュ (-1) とロス (0) は倍率ではないので出さない ── 出すと
+			// 「x-1」「x0」という存在しないオッズに読める。
+			if mult := g.GetPayoutMultiplier(); mult > 0 {
+				fmt.Fprintf(b, "%s\n", i18n.Tf("mississippistud.payoutMultiplierLine",
+					"multiplier", strconv.Itoa(mult)))
+			}
 			switch g.GetResult() {
 			case domain.GameResultWin:
 				b.WriteString(color.Green(i18n.T("mississippistud.playerWins")) + "\n")

--- a/internal/adapter/presenter/MississippiStudCuiPresenter_test.go
+++ b/internal/adapter/presenter/MississippiStudCuiPresenter_test.go
@@ -253,3 +253,38 @@ func TestMississippiStudCuiPresenter_HintOutput(t *testing.T) {
 		assert.Contains(t, p.HintOutput(game("", nil)), i18n.T("mississippistud.hintNone"))
 	})
 }
+
+// #5591: 「役はフラッシュ、配当800」とは分かっても、その配当が**どの倍率から
+// 来たのか**を両 UI とも説明していなかった。サーバは既に値を持っている。
+func TestMississippiStudCuiPresenter_ShowsThePayoutMultiplier(t *testing.T) {
+	i18n.SetLang("ja")
+	build := func(mult int) string {
+		m := new(interfaces.MockMississippiStudGame)
+		setupMississippiStudCuiMockDefaults(m)
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetGameEndFlag")
+		m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPayoutMultiplier")
+		m.On("GetGameEndFlag").Return(true)
+		m.On("GetPayoutMultiplier").Return(mult)
+		return new(MississippiStudCuiPresenter).Output(m, nil)
+	}
+
+	assert.Contains(t, build(8), i18n.Tf("mississippistud.payoutMultiplierLine", "multiplier", "8"))
+
+	// **プッシュ (-1) とロス (0) は倍率ではない** (受け入れ条件3)。数字を出すと
+	// 「x-1」「x0」という存在しないオッズに読める。
+	head := strings.SplitN(i18n.T("mississippistud.payoutMultiplierLine"), "{{", 2)[0]
+	assert.NotContains(t, build(domain.MississippiStudPayPush), head)
+	assert.NotContains(t, build(domain.MississippiStudPayLoss), head)
+}
+
+// 決着前には出さない。倍率はまだ決まっていない。
+func TestMississippiStudCuiPresenter_HidesTheMultiplierBeforeTheEnd(t *testing.T) {
+	i18n.SetLang("ja")
+	m := new(interfaces.MockMississippiStudGame)
+	setupMississippiStudCuiMockDefaults(m)
+	m.ExpectedCalls = filterCalls(m.ExpectedCalls, "GetPayoutMultiplier")
+	m.On("GetPayoutMultiplier").Return(8).Maybe()
+
+	out := new(MississippiStudCuiPresenter).Output(m, nil)
+	assert.NotContains(t, out, strings.SplitN(i18n.T("mississippistud.payoutMultiplierLine"), "{{", 2)[0])
+}

--- a/internal/i18n/locales/en/mississippistud.json
+++ b/internal/i18n/locales/en/mississippistud.json
@@ -32,5 +32,6 @@
   "madeHandNotEligible": "does not pay",
   "helpExampleBet": "  b 10                 ante 10 and get a hand",
   "helpExamplePlay": "  p 1                  play at 1x the ante",
-  "helpHint": "  h                    show a hint"
+  "helpHint": "  h                    show a hint",
+  "payoutMultiplierLine": "Payout odds: {{multiplier}}:1"
 }

--- a/internal/i18n/locales/ja/mississippistud.json
+++ b/internal/i18n/locales/ja/mississippistud.json
@@ -32,5 +32,6 @@
   "madeHandNotEligible": "配当なし",
   "helpExampleBet": "  b 10                 アンテ 10 で参加する",
   "helpExamplePlay": "  p 1                  1 倍で勝負する",
-  "helpHint": "  h                    助言を表示"
+  "helpHint": "  h                    助言を表示",
+  "payoutMultiplierLine": "配当倍率: x{{multiplier}}"
 }


### PR DESCRIPTION
Closes #5591

## 何が問題だったか

「役はフラッシュ、配当 800」とは分かっても、**その 800 がどの倍率から来たのか**を
どちらの UI も説明していなかった。倍率はドメインが計算し、Web presenter が
`payoutMultiplier` として**既に送っていて**、TS の型にもある。画面が読んでいなかっただけ。

## プッシュとロスは倍率ではない（受け入れ条件3）

`-1` はプッシュ、`0` はロスの番兵。そのまま出すと「x-1」「x0」という、
配当表に存在しないオッズとして読める。**正の値のときだけ**出す。

## テスト

- Web: 役名の隣に倍率が出る / **プッシュ (-1) とロス (0) では出ない** / 決着前は出ない
- CUI: 終了分岐に倍率行が出る / 同じく -1・0 では出ない / 決着前は出ない

変異テスト2件: CUI の条件を `!= 0` に緩める（プッシュが通る）→ 4件検出 /
ページの条件を `!== 0` に緩める → 1件検出。

`golangci-lint` 0 issues / `go test ./internal/...` 全 green / `bun run check` / `bun run typecheck`。