### PR TITLE
feat(spiderette): explain how the score moves

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -40770,6 +40770,19 @@ components:
           description: Number of suits completed (max 4)
         score:
           type: integer
+        scoring:
+          type: object
+          description: >-
+            How the score moves: where it starts, what a move costs, what a
+            completed suit pays. Sent so an explanation cannot quote figures
+            the game stopped using.
+          properties:
+            start:
+              type: integer
+            movePenalty:
+              type: integer
+            suitBonus:
+              type: integer
         phase:
           type: integer
           enum: [0, 1, 2]

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -40751,6 +40751,7 @@ components:
         - stockCount
         - completedSuits
         - score
+        - scoring
         - phase
         - moveCount
         - canUndo

--- a/frontend/src/i18n/locales/en/spiderette.json
+++ b/frontend/src/i18n/locales/en/spiderette.json
@@ -39,5 +39,6 @@
     "revealFaceDown": "Move cards to reveal face-down cards underneath",
     "useEmptyColumn": "An empty column is available — use it to reorganize",
     "dealFromStock": "No obvious moves — try dealing from the stock"
-  }
+  },
+  "scoreRule": "Starts at {{start}}, -{{penalty}} per move, +{{bonus}} per completed suit"
 }

--- a/frontend/src/i18n/locales/ja/spiderette.json
+++ b/frontend/src/i18n/locales/ja/spiderette.json
@@ -39,5 +39,6 @@
     "revealFaceDown": "カードを動かして裏向きのカードをめくりましょう",
     "useEmptyColumn": "空の列があります — 整理に活用しましょう",
     "dealFromStock": "すぐにできる手がありません — 山札から配ってみましょう"
-  }
+  },
+  "scoreRule": "{{start}} 点から始まり、1 手ごとに -{{penalty}}、スート完成ごとに +{{bonus}}"
 }

--- a/frontend/src/pages/SpiderettePage.test.tsx
+++ b/frontend/src/pages/SpiderettePage.test.tsx
@@ -64,6 +64,7 @@ const playingState: SpideretteResponse = {
   stockCount: 24,
   completedSuits: 0,
   score: 500,
+  scoring: { start: 500, movePenalty: 1, suitBonus: 100 },
   phase: 0,
   moveCount: 5,
   canUndo: false,
@@ -238,5 +239,28 @@ describe('SpiderettePage keyboard shortcuts', () => {
     }
     await flushPendingDispatch();
     expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  // #5593: スコアが動く理由（手数の減点・スート完成の加点）はどこにも書かれて
+  // いなかった。
+  describe('score rule tooltip', () => {
+    it('explains the arithmetic with the figures the server sent', async () => {
+      mockSend.mockResolvedValue({ ...playingState, scoring: { start: 500, movePenalty: 1, suitBonus: 100 } });
+      renderWithProviders(<SpiderettePage />);
+      const score = await screen.findByTestId('spiderette-score');
+      const tip = score.getAttribute('title') ?? '';
+      expect(tip).toContain('500');
+      expect(tip).toContain('100');
+    });
+
+    // **数字を焼き込んでいない証拠。**別の決まりを返せばそのまま出る。
+    it('renders whatever rule the server sends', async () => {
+      mockSend.mockResolvedValue({ ...playingState, scoring: { start: 900, movePenalty: 5, suitBonus: 250 } });
+      renderWithProviders(<SpiderettePage />);
+      const tip = (await screen.findByTestId('spiderette-score')).getAttribute('title') ?? '';
+      expect(tip).toContain('900');
+      expect(tip).toContain('250');
+      expect(tip).not.toContain('500');
+    });
   });
 });

--- a/frontend/src/pages/SpiderettePage.tsx
+++ b/frontend/src/pages/SpiderettePage.tsx
@@ -217,7 +217,17 @@ function SpiderettePageContent() {
           <span>
             {t('moveCount')}: {state.moveCount}
           </span>
-          <span className="ml-3">
+          {/* **数字が動く理由を推測させない** (#5593)。手数の減点とスート完成の
+              加点は、どちらの画面にも書かれていなかった。数字はサーバから。 */}
+          <span
+            className="ml-3"
+            data-testid="spiderette-score"
+            title={t('scoreRule', {
+              start: state.scoring.start,
+              penalty: state.scoring.movePenalty,
+              bonus: state.scoring.suitBonus,
+            })}
+          >
             {t('score')}: {state.score}
           </span>
           <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />

--- a/frontend/src/types/games/spiderette.ts
+++ b/frontend/src/types/games/spiderette.ts
@@ -22,6 +22,12 @@ export interface SpideretteResponse extends BaseGameResponse {
   stockCount: number;
   completedSuits: number;
   score: number;
+  /**
+   * How the score moves: where it starts, what a move costs, what a completed
+   * suit pays. Sent so the explanation cannot quote figures the game stopped
+   * using.
+   */
+  scoring: { start: number; movePenalty: number; suitBonus: number };
   phase: number;
   moveCount: number;
   canUndo: boolean;

--- a/frontend/src/utils/cli/formatters/spideretteFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/spideretteFormatter.test.ts
@@ -18,6 +18,7 @@ const baseState: SpideretteResponse = {
   stockCount: 20,
   completedSuits: 1,
   score: 40,
+  scoring: { start: 500, movePenalty: 1, suitBonus: 100 },
   phase: 0,
   moveCount: 3,
   canUndo: true,

--- a/frontend/src/utils/hints/spideretteHint.test.ts
+++ b/frontend/src/utils/hints/spideretteHint.test.ts
@@ -22,6 +22,7 @@ function makeState(overrides: Partial<SpideretteResponse> = {}): SpideretteRespo
     canUndo: false,
     isStalemate: false,
     score: 500,
+    scoring: { start: 500, movePenalty: 1, suitBonus: 100 },
     message: '',
     ...overrides,
   };

--- a/internal/adapter/controller/SpideretteWebController.go
+++ b/internal/adapter/controller/SpideretteWebController.go
@@ -36,12 +36,22 @@ type SpideretteWebOutputHint struct {
 }
 
 // SpideretteWebOutput スパイダレットWebアウトプット
+// SpideretteWebOutputScoring はスコアの決まり (開始点 / 1手あたりの減点 / スート完成の加点)。
+type SpideretteWebOutputScoring struct {
+	Start       int `json:"start"`
+	MovePenalty int `json:"movePenalty"`
+	SuitBonus   int `json:"suitBonus"`
+}
+
 type SpideretteWebOutput struct {
 	Tableau        [][]*SpideretteWebOutputTableauCard `json:"tableau"`
 	StockCount     int                                 `json:"stockCount"`
 	CompletedSuits int                                 `json:"completedSuits"`
 	Score          int                                 `json:"score"`
-	Hint           *SpideretteWebOutputHint            `json:"hint,omitempty"`
+	// Scoring はスコアの決まり (#5593)。数字が動く理由を説明するのに要る。
+	// 訳文に焼き込むと、計算を変えたとき案内だけが古くなる。
+	Scoring SpideretteWebOutputScoring `json:"scoring"`
+	Hint    *SpideretteWebOutputHint   `json:"hint,omitempty"`
 	SolitaireWebOutputBase
 	WebOutputBase
 }

--- a/internal/adapter/presenter/SpideretteCuiPresenter.go
+++ b/internal/adapter/presenter/SpideretteCuiPresenter.go
@@ -42,6 +42,13 @@ func (p *SpideretteCuiPresenter) Output(s interfaces.SpideretteGame, lastErr err
 		// 切り上げをバッジに出しているのに、CUI は暗算を強いていた。
 		b.WriteString(i18n.Tf("spiderette.dealsRemaining",
 			"count", strconv.Itoa(s.GetDealsRemaining())) + "\n")
+		// **数字が動く理由を推測させない。**スコアは常時出ているのに、
+		// 手数のペナルティとスート完成のボーナスはどこにも書かれていなかった
+		// (#5593)。数字はドメインの定数から差し込む。
+		b.WriteString(i18n.Tf("spiderette.scoreRule",
+			"start", strconv.Itoa(domain.SpideretteStartScore),
+			"penalty", strconv.Itoa(domain.SpideretteMovePenalty),
+			"bonus", strconv.Itoa(domain.SpideretteSuitBonus)) + "\n")
 
 		b.WriteString("----------\n")
 

--- a/internal/adapter/presenter/SpideretteCuiPresenter_test.go
+++ b/internal/adapter/presenter/SpideretteCuiPresenter_test.go
@@ -3,6 +3,7 @@
 package presenter
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +11,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 func setupSpideretteCuiMockDefaults(sg *interfaces.MockSpideretteGame) {
@@ -204,4 +206,22 @@ func TestSpideretteCuiPresenter_DealsRemaining(t *testing.T) {
 	t.Run("still says zero once the stock is spent", func(t *testing.T) {
 		assert.Contains(t, p.Output(withDeals(0, 0), nil), "残り配布: 0回")
 	})
+}
+
+// #5593: スコアは常時出ているのに、手数のペナルティとスート完成のボーナスは
+// どこにも書かれておらず、数字が動く理由を推測させていた。
+func TestSpideretteCuiPresenter_ExplainsTheScoreRule(t *testing.T) {
+	i18n.SetLang("ja")
+	g := domain.NewDefaultSpiderette()
+	g.Reset()
+
+	out := new(SpideretteCuiPresenter).Output(g, nil)
+	// **数字はドメインの定数から。**訳文に焼き込むと、計算を変えたとき案内だけが古くなる。
+	assert.Contains(t, out, i18n.Tf("spiderette.scoreRule",
+		"start", strconv.Itoa(domain.SpideretteStartScore),
+		"penalty", strconv.Itoa(domain.SpideretteMovePenalty),
+		"bonus", strconv.Itoa(domain.SpideretteSuitBonus)))
+	// 3 つが同じ数字ではないこと。1 つの値を 3 箇所に流す実装を弾く。
+	assert.NotEqual(t, domain.SpideretteStartScore, domain.SpideretteSuitBonus)
+	assert.NotEqual(t, domain.SpideretteMovePenalty, domain.SpideretteSuitBonus)
 }

--- a/internal/adapter/presenter/SpideretteWebPresenter.go
+++ b/internal/adapter/presenter/SpideretteWebPresenter.go
@@ -20,6 +20,11 @@ func (p *SpideretteWebPresenter) Output(s interfaces.SpideretteGame, lastErr err
 	resObj.StockCount = s.GetStockCount()
 	resObj.CompletedSuits = s.GetCompletedSuits()
 	resObj.Score = s.GetScore()
+	resObj.Scoring = controller.SpideretteWebOutputScoring{
+		Start:       domain.SpideretteStartScore,
+		MovePenalty: domain.SpideretteMovePenalty,
+		SuitBonus:   domain.SpideretteSuitBonus,
+	}
 
 	tableau := s.GetTableau()
 	resObj.Tableau = make([][]*controller.SpideretteWebOutputTableauCard, domain.SpideretteTableauCnt)
@@ -88,6 +93,11 @@ func (p *SpideretteWebPresenter) HintOutput(s interfaces.SpideretteGame) string 
 	resObj.StockCount = s.GetStockCount()
 	resObj.CompletedSuits = s.GetCompletedSuits()
 	resObj.Score = s.GetScore()
+	resObj.Scoring = controller.SpideretteWebOutputScoring{
+		Start:       domain.SpideretteStartScore,
+		MovePenalty: domain.SpideretteMovePenalty,
+		SuitBonus:   domain.SpideretteSuitBonus,
+	}
 	resObj.Tableau = make([][]*controller.SpideretteWebOutputTableauCard, 0)
 
 	if hint != nil {

--- a/internal/adapter/presenter/SpideretteWebPresenter_test.go
+++ b/internal/adapter/presenter/SpideretteWebPresenter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -221,4 +222,20 @@ func TestSpideretteWebPresenter_ActionLogOutput(t *testing.T) {
 	p := new(SpideretteWebPresenter)
 	result := p.ActionLogOutput(sg)
 	assert.Contains(t, result, "move")
+}
+
+// #5593: スコアの決まりはドメインの定数から渡すこと。3 つの値を取り違えると、
+// 説明だけが実際の計算と食い違う。
+func TestSpideretteWebPresenter_ShipsTheScoringRule(t *testing.T) {
+	g := domain.NewDefaultSpiderette()
+	g.Reset()
+
+	var out controller.SpideretteWebOutput
+	require.NoError(t, json.Unmarshal([]byte(new(SpideretteWebPresenter).Output(g, nil)), &out))
+	assert.Equal(t, domain.SpideretteStartScore, out.Scoring.Start)
+	assert.Equal(t, domain.SpideretteMovePenalty, out.Scoring.MovePenalty)
+	assert.Equal(t, domain.SpideretteSuitBonus, out.Scoring.SuitBonus)
+	// 3 つが同じ値でないこと (取り違えを見逃さない)。
+	assert.NotEqual(t, out.Scoring.Start, out.Scoring.SuitBonus)
+	assert.NotEqual(t, out.Scoring.MovePenalty, out.Scoring.SuitBonus)
 }

--- a/internal/domain/Spiderette.go
+++ b/internal/domain/Spiderette.go
@@ -22,6 +22,17 @@ const (
 )
 
 // SpideretteTableauCnt タブローの列数 (Klondike と同じ7列)
+// スコアの決まり。**説明はこの 3 つから書く。**数字を訳文に焼き込むと、
+// 計算を変えたとき案内だけが古くなる (#5593)。
+const (
+	// SpideretteStartScore は開始時のスコア。
+	SpideretteStartScore = 500
+	// SpideretteMovePenalty は 1 手ごとに引かれる点。
+	SpideretteMovePenalty = 1
+	// SpideretteSuitBonus はスートを 1 組完成させるたびに入る点。
+	SpideretteSuitBonus = 100
+)
+
 const SpideretteTableauCnt = 7
 
 // SpideretteFoundationCnt 完成スート数 (1デッキ4スート)
@@ -91,7 +102,7 @@ func (s *Spiderette) Reset() {
 	s.trumpCards.Shuffle()
 	s.phase = SpiderettePhasePlaying
 	s.moveCount = 0
-	s.score = 500
+	s.score = SpideretteStartScore
 	s.actionLog = nil
 	s.history = nil
 	s.isStalemate = false
@@ -162,7 +173,7 @@ func (s *Spiderette) Deal() error {
 		s.tableau[i] = append(s.tableau[i], &SpideretteTableauCard{Card: card, FaceUp: true})
 	}
 	s.moveCount++
-	s.score--
+	s.score -= SpideretteMovePenalty
 	s.appendLog("deal", "ストックから各列にカードを配りました", nil)
 	for i := range SpideretteTableauCnt {
 		s.checkAndRemoveCompletedSuit(i)
@@ -216,7 +227,7 @@ func (s *Spiderette) MoveTableauToTableau(fromCol, cardIndex, toCol int) error {
 	s.tableau[fromCol] = fromCards[:cardIndex]
 	s.autoFlipTableau(fromCol)
 	s.moveCount++
-	s.score--
+	s.score -= SpideretteMovePenalty
 	s.appendLog("move", fmt.Sprintf("タブロー列%d→タブロー列%d", fromCol, toCol), movedCards)
 	s.checkAndRemoveCompletedSuit(toCol)
 	s.checkSpideretteStalemate()
@@ -465,7 +476,7 @@ func (s *Spiderette) checkAndRemoveCompletedSuit(col int) bool {
 
 	s.tableau[col] = cards[:startIdx]
 	s.completedSuits++
-	s.score += 100
+	s.score += SpideretteSuitBonus
 	s.appendLog("complete", fmt.Sprintf("タブロー列%dでスートが完成しました", col), nil)
 
 	s.autoFlipTableau(col)

--- a/internal/i18n/locales/en/spiderette.json
+++ b/internal/i18n/locales/en/spiderette.json
@@ -13,5 +13,6 @@
   "dealsRemaining": " | Deals left: {{count}}",
   "helpExampleHint": "  h                        ask for a move",
   "helpExampleAuto": "  ac                       send everything that can go to a foundation",
-  "helpUndo": "  u                        undo one move"
+  "helpUndo": "  u                        undo one move",
+  "scoreRule": "Score: starts at {{start}}, -{{penalty}} per move, +{{bonus}} per completed suit"
 }

--- a/internal/i18n/locales/ja/spiderette.json
+++ b/internal/i18n/locales/ja/spiderette.json
@@ -13,5 +13,6 @@
   "dealsRemaining": " | 残り配布: {{count}}回",
   "helpExampleHint": "  h                        次の一手を教えてもらう",
   "helpExampleAuto": "  ac                       組札へ送れる札を自動で送る",
-  "helpUndo": "  u                        1手戻す"
+  "helpUndo": "  u                        1手戻す",
+  "scoreRule": "スコア: {{start}} 点から始まり、1 手ごとに -{{penalty}}、スート完成ごとに +{{bonus}}"
 }


### PR DESCRIPTION
Closes #5593

## 何が問題だったか

スコアは Web もCUI も常時出しているのに、**数字が動く理由**（1 手ごとの減点、スート完成の加点）は
どちらにも書かれていなかった。ロケールの `score` キーも「スコア」というラベルだけ。

## 数字は 3 つの定数から

500 / -1 / +100 は 4 箇所の literal だった。`SpideretteStartScore` /
`SpideretteMovePenalty` / `SpideretteSuitBonus` として名前を付け、
**CUI の行も Web のツールチップも定数から差し込む**（Web にはレスポンスの `scoring` で渡す）。
訳文に焼き込むと、計算を変えたとき案内だけが古くなる。

**スコアの計算そのものは変えていない**（受け入れ条件4）。`api/openapi.yaml` も更新（CRLF 維持 13/0）。

## テスト

- CUI: 定数どおりの行が出る / **3 つが同じ数字でない**（1 値を 3 箇所に流す実装を弾く）
- Web presenter: `scoring` が定数どおりに乗る / 3 値が取り違えられていない
- ページ: ツールチップに数字が出る / **サーバが別の決まりを返せばそのまま出る**

変異テスト2件: ツールチップが 100 を直書き → 1件検出 /
presenter が SuitBonus に StartScore を入れる（取り違え）→ 4件検出。

`golangci-lint` 0 issues / `go test ./internal/...` 全 green / `bun run check` / `bun run typecheck`。