### PR TITLE
feat(beleagueredcastle): ヒント表示をライブ領域にする

### DIFF
--- a/frontend/src/pages/BeleagueredCastlePage.test.tsx
+++ b/frontend/src/pages/BeleagueredCastlePage.test.tsx
@@ -323,6 +323,39 @@ describe('BeleagueredCastlePage destination preview', () => {
     await waitFor(() => expect(targets()).toHaveLength(0));
   });
 
+  // #5596: ヒント表示は無言で書き換わっていた。**空のまま先にマウントしてある**
+  // 領域の中身が変わることが読み上げの条件なので、hint がある間だけ現れる内側の
+  // div ではなく、常設のラッパーがライブ領域でなければならない。
+  it('keeps the hint live region mounted before there is any hint to announce', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<BeleagueredCastlePage />);
+    await waitFor(() => expect(screen.getByText(/包囲された城/)).toBeInTheDocument());
+
+    const region = screen.getByTestId('bc-hint-live');
+    expect(region).toHaveAttribute('role', 'status');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    expect(region).toHaveTextContent('');
+  });
+
+  it('announces the recommended move through that same region', async () => {
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<BeleagueredCastlePage />);
+    await waitFor(() => expect(screen.getByText(/包囲された城/)).toBeInTheDocument());
+
+    const region = screen.getByTestId('bc-hint-live');
+    expect(region).toHaveTextContent('');
+
+    mockExec.mockResolvedValue({
+      ...playingState,
+      hint: { fromCol: 1, cardIndex: 0, toZone: 'foundation', toCol: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    // **同じ要素**の中身が変わる (別の要素が現れるのではない) ことが読み上げの条件。
+    await waitFor(() => expect(region).toHaveTextContent(/→/));
+    expect(region.textContent).toBe('ヒントがあります: タブロー列1 → 組札');
+  });
+
   // hover と選択で同じ集合を指す ── プレビューが嘘をつかないことの検証。
   it('previews exactly the set the selection then commits to', async () => {
     const spadeFive = await render();

--- a/frontend/src/pages/BeleagueredCastlePage.tsx
+++ b/frontend/src/pages/BeleagueredCastlePage.tsx
@@ -390,7 +390,12 @@ function BeleagueredCastlePageContent() {
               <div className="flex-1 flex gap-1 sm:gap-2">{[4, 5, 6, 7].map(renderTableauColumn)}</div>
             </div>
 
-            <div data-tutorial="bc-hint-display">
+            {/*
+              ライブ領域は**常設**。hint がある間だけ現れる内側の div に付けると、
+              領域と中身が同じコミットで現れるので変化として扱われず、読み上げられない
+              ことがある (#5596)。
+            */}
+            <div data-tutorial="bc-hint-display" data-testid="bc-hint-live" role="status" aria-live="polite">
               {hint && (
                 <div className="text-ds-warning text-sm mb-2 mt-3">
                   {t('hintAvailable')}: {formatHintZone(t, 'tableau', hint.fromCol)} →{' '}


### PR DESCRIPTION
## 背景

`BeleagueredCastlePage` の `bc-hint-display` ブロックは `role` も `aria-live` も持たず、`h` を押しても新しい推奨手がスクリーンリーダーに届かなかった。

## 変更

**常設のラッパー**（`data-tutorial="bc-hint-display"`）に `role="status" aria-live="polite"` を付けた。hint がある間だけ現れる内側の div ではない理由:

- ライブ領域が**中身と同じコミットで DOM に入る**と、支援技術は「既存領域の変化」として扱わず読み上げないことが多い（`LiveAnnouncement` が 1 コミット遅らせているのと同じ理由）。
- 姉妹ページ（FourSeasons 等）は条件付き div に付けているが、この形の方が確実。

## テスト

- ヒントが**無い**時点でライブ領域が既にマウントされ、中身が空であること
- `ヒント` ボタン→**同じ要素**の中身が `ヒントがあります: タブロー列1 → 組札` に変わること

ミューテーション: `role`/`aria-live` を内側の条件付き div へ移すと 2 件とも落ちる（実測）。

## 残件

同じ欠落が他に **68 ページ**ある（AmericanToad, Bisley, FreeCell, Klondike…）。件数が多く構造も一様でないため、追跡 issue を別に立てる。

Closes #5596