### PR TITLE
feat(streetsandalleys): ヒント表示をライブ領域にする

### DIFF
--- a/frontend/src/pages/StreetsAndAlleysPage.test.tsx
+++ b/frontend/src/pages/StreetsAndAlleysPage.test.tsx
@@ -256,6 +256,43 @@ describe('StreetsAndAlleysPage', () => {
     await waitFor(() => expect(sourceBtn).toHaveAttribute('aria-pressed', 'true'));
   });
 
+  // 読み上げられる文全体を固定する。部分一致だと矢印だけ見て通ってしまう。
+  const EXPECTED_HINT_SENTENCE = 'ヒントがあります: タブロー列1 → 組札';
+
+  // #5597: ヒント表示は無言で書き換わっていた。**空のまま先にマウントしてある**
+  // 領域の中身が変わることが読み上げの条件なので、hint がある間だけ現れる内側の
+  // div ではなく、常設のラッパーがライブ領域でなければならない。
+  it('keeps the hint live region mounted before there is any hint to announce', async () => {
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<StreetsAndAlleysPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+
+    const region = screen.getByTestId('sa-hint-live');
+    expect(region).toHaveAttribute('role', 'status');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    expect(region).toHaveTextContent('');
+  });
+
+  it('announces the recommended move through that same region', async () => {
+    mockExec.mockReset();
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<StreetsAndAlleysPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+    const region = screen.getByTestId('sa-hint-live');
+    expect(region).toHaveTextContent('');
+
+    mockExec.mockResolvedValue({
+      ...playingState,
+      hint: { fromCol: 1, cardIndex: 0, toZone: 'foundation', toCol: 2 },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    // **同じ要素**の中身が変わる (別の要素が現れるのではない) ことが読み上げの条件。
+    await waitFor(() => expect(region).toHaveTextContent(/→/));
+    expect(region.textContent).toBe(EXPECTED_HINT_SENTENCE);
+  });
+
   it('rings every zone that can accept the selected card', async () => {
     localStorage.clear();
     mockExec.mockReset();

--- a/frontend/src/pages/StreetsAndAlleysPage.tsx
+++ b/frontend/src/pages/StreetsAndAlleysPage.tsx
@@ -370,7 +370,12 @@ function StreetsAndAlleysPageContent() {
               <div className="flex-1 flex gap-1 sm:gap-2">{[4, 5, 6, 7].map(renderTableauColumn)}</div>
             </div>
 
-            <div data-tutorial="sa-hint-display">
+            {/*
+              ライブ領域は**常設**。hint がある間だけ現れる内側の div に付けると、
+              領域と中身が同じコミットで現れるので変化として扱われず、読み上げられない
+              ことがある (#5597)。
+            */}
+            <div data-tutorial="sa-hint-display" data-testid="sa-hint-live" role="status" aria-live="polite">
               {hint && (
                 <div className="text-ds-warning text-sm mb-2 mt-3">
                   {t('hintAvailable')}: {formatHintZone(t, 'tableau', hint.fromCol)} →{' '}


### PR DESCRIPTION
## 背景

`StreetsAndAlleysPage` の `sa-hint-display` は `role` も `aria-live` も持たず、`h` を押しても推奨手がスクリーンリーダーに届かなかった。#5596（PR #5954）と同じ欠落・同じ形。

## 変更

**常設のラッパー**に `role="status" aria-live="polite"`。hint がある間だけ現れる内側の div ではない理由は #5954 と同じ — 領域と中身が同じコミットで DOM に入ると変化として扱われず読み上げられないため。

## テスト

- ヒントが無い時点で領域がマウント済みかつ空
- `ヒント` 押下で**同じ要素**の中身が `ヒントがあります: タブロー列1 → 組札` になる（文全体を固定。部分一致だと矢印だけ見て通る）

ミューテーション: `role`/`aria-live` を内側の条件付き div へ移すと 2 件とも落ちる（実測 2 failed / 19 passed）。

残り 67 ページは #5955 で追跡。

Closes #5597