### PR TITLE
feat(kingalbert): 移動先リングを合法手だけに絞る

### DIFF
--- a/frontend/src/pages/KingAlbertPage.test.tsx
+++ b/frontend/src/pages/KingAlbertPage.test.tsx
@@ -173,7 +173,10 @@ describe('KingAlbertPage', () => {
     await waitFor(() => expect(screen.getByTestId('stalemate-escape-button')).toBeInTheDocument());
   });
 
-  it('rings every zone that can accept the selected card', async () => {
+  // #5598: リングは「選択中」というだけで全部の最上段カードと全部の組札に付いていた。
+  // 光っている先をクリックしてエラーになって初めて置けないと分かる状態だったので、
+  // **置ける先だけ**に付くことを、置けない先を名指しして確かめる。
+  it('rings only the zones that can actually accept the selected card', async () => {
     localStorage.clear();
     mockExec.mockReset();
     mockExec.mockResolvedValue(playingState);
@@ -181,10 +184,33 @@ describe('KingAlbertPage', () => {
     await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
     expect(document.querySelectorAll('[data-target-candidate]')).toHaveLength(0);
 
-    const source = screen.getAllByRole('button').find((b) => b.querySelector('img')) as HTMLButtonElement;
-    fireEvent.click(source);
-    // Foundations accept the card as readily as the tableau does.
-    await waitFor(() => expect(document.querySelectorAll('[data-target-candidate]').length).toBeGreaterThan(1));
+    // ♥5 (列0の最上段) を選ぶ。置けるのは ♣6 (交互の色で1つ上) と空き列だけ。
+    fireEvent.click(screen.getByRole('button', { name: '♥ 5' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: '♣ 6' })).toHaveAttribute('data-target-candidate'));
+
+    // ♥5 は組札 (♥A の上) には置けない ── 2 でないので。
+    for (const f of screen.getAllByLabelText(/組札/)) {
+      expect(f).not.toHaveAttribute('data-target-candidate');
+    }
+    // 自分の下の札も、自分自身の列も候補ではない。
+    expect(screen.getByRole('button', { name: '♠ K' })).not.toHaveAttribute('data-target-candidate');
+    // 空き列 7 本 + ♣6 = 8 箇所ちょうど。
+    expect(document.querySelectorAll('[data-target-candidate]')).toHaveLength(8);
+  });
+
+  it('rings the foundation when the selected card is the one it wants', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    // ♦2 を予備に置くと、♦A の組札だけが候補になる。
+    mockExec.mockResolvedValue({ ...playingState, reserve: [card('DIAMOND', 2), null, null, null, null, null, null] });
+    renderWithProviders(<KingAlbertPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: '♦ 2' }));
+    await waitFor(() => {
+      const rung = screen.getAllByLabelText(/組札/).filter((f) => f.hasAttribute('data-target-candidate'));
+      expect(rung).toHaveLength(1);
+    });
   });
 });
 

--- a/frontend/src/pages/KingAlbertPage.test.tsx
+++ b/frontend/src/pages/KingAlbertPage.test.tsx
@@ -198,6 +198,27 @@ describe('KingAlbertPage', () => {
     expect(document.querySelectorAll('[data-target-candidate]')).toHaveLength(8);
   });
 
+  // レビュー #5957: 空の組札は A を選んでも光っていなかった ── 「置ける先には付く」の
+  // 反対側の抜け。空の枠こそ A の唯一の行き先なので、ここが暗いと詰まって見える。
+  it('rings an empty foundation when an ace is selected', async () => {
+    localStorage.clear();
+    mockExec.mockReset();
+    mockExec.mockResolvedValue({
+      ...playingState,
+      reserve: [card('DIAMOND', 1), null, null, null, null, null, null],
+      foundation: [[card('SPADE', 1)], [card('CLOVER', 1)], [card('HEART', 1)], []],
+    });
+    renderWithProviders(<KingAlbertPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: '♦ A' }));
+    await waitFor(() => expect(screen.getByLabelText(/空の組札/)).toHaveAttribute('data-target-candidate'));
+    // 既に A が乗っている 3 つは 2 を待っているので、A では光らない。
+    for (const f of screen.getAllByLabelText(/組札 1枚/)) {
+      expect(f).not.toHaveAttribute('data-target-candidate');
+    }
+  });
+
   it('rings the foundation when the selected card is the one it wants', async () => {
     localStorage.clear();
     mockExec.mockReset();

--- a/frontend/src/pages/KingAlbertPage.tsx
+++ b/frontend/src/pages/KingAlbertPage.tsx
@@ -416,7 +416,14 @@ function KingAlbertPageContent() {
                             disabled={!isPlaying || loading || !selectedSource}
                             aria-label={t('emptyFoundationAriaLabel', { suit: FOUNDATION_SUITS[idx] })}
                             style={{ width: dims.cw, height: dims.ch }}
-                            className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}`}
+                            // 空の枠は A の唯一の行き先。ここを暗いままにすると、
+                            // 「置ける先には光る」が片側だけ嘘になる。
+                            data-target-candidate={legalTargets.foundation.has(idx) || undefined}
+                            className={`rounded border-2 border-dashed border-white/30 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite} ${
+                              legalTargets.foundation.has(idx)
+                                ? 'ring-1 ring-ds-info motion-safe:hover:ring-2 focus:ring-2'
+                                : ''
+                            }`}
                           >
                             A
                           </button>

--- a/frontend/src/pages/KingAlbertPage.tsx
+++ b/frontend/src/pages/KingAlbertPage.tsx
@@ -27,13 +27,14 @@ import { useKingAlbertGame } from '../hooks/useKingAlbertGame';
 import { useSolitaireDragDrop } from '../hooks/useSolitaireDragDrop';
 import { btnDanger, btnPrimary, btnSuccess, focusRingWhite } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
-import type { KingAlbertResponse } from '../types/card';
+import type { Card, KingAlbertResponse } from '../types/card';
 import { KingAlbertPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
 import { cardAlt } from '../utils/cardAlt';
 import { KINGALBERT_HELP, parseKingAlbertCommand } from '../utils/cli/commands/kingalbertCommands';
 import { formatKingAlbertState } from '../utils/cli/formatters/kingalbertFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
+import { kingAlbertLegalTargets } from '../utils/kingAlbertLegalTargets';
 import { hintCheckboxItem } from '../utils/settingsItems';
 
 const FOUNDATION_SUITS = ['♠', '♣', '♥', '♦'] as const;
@@ -196,6 +197,17 @@ function KingAlbertPageContent() {
     selectedSource.col === col &&
     selectedSource.cardIndex === cardIndex;
 
+  // 選択中の札そのもの。タブローは最上段しか動かせないので、列の一番上を読む。
+  const selectedCard = ((): Card | null => {
+    if (!selectedSource || selectedSource.col === undefined) return null;
+    if (selectedSource.zone === 'reserve') return state.reserve[selectedSource.col] ?? null;
+    const col = state.tableau[selectedSource.col];
+    return col?.[col.length - 1]?.card ?? null;
+  })();
+  // リングは**置ける先だけ**に付ける。「選択中なら全部光る」だと、エラーになる手を
+  // 勧めることになる (#5598)。
+  const legalTargets = kingAlbertLegalTargets(state.tableau, state.foundation, selectedCard);
+
   const renderTableauColumn = (colIdx: number) => {
     const col = state.tableau[colIdx];
     const tableauColZone: KingAlbertMoveZone = { zone: 'tableau', col: colIdx };
@@ -215,9 +227,9 @@ function KingAlbertPageContent() {
                 onClick={() => game.handleSelectTarget(tableauColZone)}
                 disabled={!isPlaying || loading || !selectedSource}
                 style={{ height: dims.ch }}
-                data-target-candidate={selectedSource ? true : undefined}
+                data-target-candidate={legalTargets.tableau.has(colIdx) || undefined}
                 className={`w-full rounded border-2 border-dashed border-white/20 text-game-text-muted text-xs flex items-center justify-center bg-transparent ${focusRingWhite} ${
-                  selectedSource ? 'ring-1 ring-ds-info' : ''
+                  legalTargets.tableau.has(colIdx) ? 'ring-1 ring-ds-info' : ''
                 }`}
               >
                 {t('empty')}
@@ -230,7 +242,8 @@ function KingAlbertPageContent() {
                   cardIndex: cardIdx,
                 };
                 const isTop = cardIdx === col.length - 1;
-                const isTargetCandidate = !!selectedSource && isTop && !isSourceSelected('tableau', colIdx, cardIdx);
+                const isTargetCandidate =
+                  isTop && legalTargets.tableau.has(colIdx) && !isSourceSelected('tableau', colIdx, cardIdx);
                 return (
                   <div
                     key={`tc-${colIdx.toString()}-${cardIdx.toString()}`}
@@ -382,9 +395,11 @@ function KingAlbertPageContent() {
                               suit: FOUNDATION_SUITS[idx],
                               count: pile.length,
                             })}
-                            data-target-candidate={selectedSource ? true : undefined}
+                            data-target-candidate={legalTargets.foundation.has(idx) || undefined}
                             className={`p-0 border-0 bg-transparent cursor-pointer rounded ${focusRingWhite} ${
-                              selectedSource ? 'ring-1 ring-ds-info motion-safe:hover:ring-2 focus:ring-2' : ''
+                              legalTargets.foundation.has(idx)
+                                ? 'ring-1 ring-ds-info motion-safe:hover:ring-2 focus:ring-2'
+                                : ''
                             }`}
                           >
                             <AnimatedCard

--- a/frontend/src/utils/kingAlbertLegalTargets.test.ts
+++ b/frontend/src/utils/kingAlbertLegalTargets.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, CardDesign } from '../types/card';
+import type { KingAlbertTableauCard } from '../types/games/kingalbert';
+import { kingAlbertLegalTargets } from './kingAlbertLegalTargets';
+
+const card = (design: CardDesign, value: number): Card => ({ design, value });
+const tc = (design: CardDesign, value: number): KingAlbertTableauCard => ({ card: card(design, value), faceUp: true });
+
+describe('kingAlbertLegalTargets', () => {
+  it('accepts only the alternate-colour column one rank higher', () => {
+    const tableau: KingAlbertTableauCard[][] = [
+      [tc('HEART', 8)], // 赤8 ← 黒7 は置ける
+      [tc('SPADE', 8)], // 黒8 ← 黒7 は色が同じなので置けない
+      [tc('HEART', 9)], // ランクが合わない
+    ];
+    const targets = kingAlbertLegalTargets(tableau, [[], [], [], []], card('CLOVER', 7));
+    expect([...targets.tableau]).toEqual([0]);
+  });
+
+  it('accepts any card on an empty column', () => {
+    const targets = kingAlbertLegalTargets([[], [tc('SPADE', 2)]], [[], [], [], []], card('HEART', 13));
+    expect(targets.tableau.has(0)).toBe(true);
+    expect(targets.tableau.has(1)).toBe(false);
+  });
+
+  // 自分の列を明示的に除く必要が無いことの確認 ── 一番上の札と自分自身を比べるので、
+  // ランクの条件が必ず偽になる。除外処理を足すと、テストの無い分岐が増えるだけになる。
+  it('does not offer the column the card is sitting on', () => {
+    const tableau: KingAlbertTableauCard[][] = [[tc('HEART', 8), tc('CLOVER', 7)], []];
+    const targets = kingAlbertLegalTargets(tableau, [[], [], [], []], card('CLOVER', 7));
+    expect(targets.tableau.has(0)).toBe(false);
+    expect(targets.tableau.has(1)).toBe(true);
+  });
+
+  it('takes an ace onto an empty foundation and nothing else', () => {
+    const empty = kingAlbertLegalTargets([], [[], [], [], []], card('SPADE', 1));
+    expect(empty.foundation.size).toBe(4);
+    const two = kingAlbertLegalTargets([], [[], [], [], []], card('SPADE', 2));
+    expect(two.foundation.size).toBe(0);
+  });
+
+  it('builds a foundation up in the same suit only', () => {
+    const foundation: Card[][] = [[card('SPADE', 1)], [card('HEART', 1)], [], []];
+    const targets = kingAlbertLegalTargets([], foundation, card('SPADE', 2));
+    expect([...targets.foundation]).toEqual([0]);
+  });
+
+  it('returns nothing when no card is selected', () => {
+    const targets = kingAlbertLegalTargets([[]], [[]], null);
+    expect(targets.tableau.size).toBe(0);
+    expect(targets.foundation.size).toBe(0);
+  });
+});

--- a/frontend/src/utils/kingAlbertLegalTargets.ts
+++ b/frontend/src/utils/kingAlbertLegalTargets.ts
@@ -1,0 +1,59 @@
+import type { Card } from '../types/card';
+import type { KingAlbertTableauCard } from '../types/games/kingalbert';
+
+/** Where the selected card may legally go. */
+export interface KingAlbertLegalTargets {
+  /** Tableau column indices that accept the card. */
+  tableau: Set<number>;
+  /** Foundation indices that accept the card. */
+  foundation: Set<number>;
+}
+
+const BLACK = new Set(['SPADE', 'CLOVER']);
+
+const isBlack = (card: Card): boolean => BLACK.has(card.design);
+
+/**
+ * Legal destinations for the selected card.
+ *
+ * Sync: `KingAlbert.canPlaceOnTableau` / `canPlaceOnFoundation`
+ * (`internal/domain/KingAlbert.go`).
+ *
+ * **タブローは交互の色で1つ下がるときだけ。**姉妹の包囲された城は色を見ないので、
+ * そちらの規則を流用すると置けない列まで光る。空き列にはどのカードでも置ける。
+ *
+ * 選択中の札が乗っている列を除く必要は無い。列の一番上と自分自身を比べることになり、
+ * `value === value - 1` は必ず偽になるので、その列は元から候補にならない。
+ */
+export function kingAlbertLegalTargets(
+  tableau: KingAlbertTableauCard[][],
+  foundation: Card[][],
+  card: Card | null | undefined,
+): KingAlbertLegalTargets {
+  const result: KingAlbertLegalTargets = { tableau: new Set(), foundation: new Set() };
+  if (!card) return result;
+
+  tableau.forEach((col, idx) => {
+    if (col.length === 0) {
+      result.tableau.add(idx);
+      return;
+    }
+    const top = col[col.length - 1]?.card;
+    if (top && card.value === top.value - 1 && isBlack(card) !== isBlack(top)) {
+      result.tableau.add(idx);
+    }
+  });
+
+  foundation.forEach((pile, idx) => {
+    if (pile.length === 0) {
+      if (card.value === 1) result.foundation.add(idx);
+      return;
+    }
+    const top = pile[pile.length - 1];
+    if (top && card.design === top.design && card.value === top.value + 1) {
+      result.foundation.add(idx);
+    }
+  });
+
+  return result;
+}


### PR DESCRIPTION
## 背景

`data-target-candidate` の判定が `!!selectedSource && isTop`（組札は `selectedSource` の有無だけ）で、ランク・スート適合を一切見ていなかった。置けない列・組札も同じリングで光り、クリックしてエラーになって初めて置けないと分かる。

## 変更

`frontend/src/utils/kingAlbertLegalTargets.ts` を追加し、`KingAlbert.canPlaceOnTableau` / `canPlaceOnFoundation`（`internal/domain/KingAlbert.go:528-550`）を写した:

- タブロー: **交互の色**で 1 つ下がるときだけ。空き列はどのカードでも可（従来どおり候補）
- 組札: 空なら A、そうでなければ同スートで 1 つ上

移動確定のロジック（`handleSelectTarget` / DnD / `disabled`）は変更していない。光り方だけが狭まる。

**選択中の札が乗っている列を除く処理は入れていない。**列の一番上と自分自身を比べることになり `value === value - 1` が必ず偽になるので元から候補にならない。除外を書くとテストの通らない分岐が増えるだけだったので、その旨をコメントとテストに残した（実際、除外を消すミューテーションはどのテストにも検出されなかった＝不要の証拠）。

## テスト

- util 6 件（交互色・空き列・自列・A の扱い・同スート・未選択）
- ページ 2 件: ♥5 を選ぶと候補は **♣6 と空き列 7 本のちょうど 8 箇所**、組札は 0 箇所。♦2 を選ぶと組札は ♦ の 1 枚だけ
- 既存の「候補が 1 個より多い」テストは旧実装でも自明に通る**空振り**だったので、置けない先を名指しする形へ書き換えた

ミューテーション実測: 交互色チェックを外す→1 failed、組札のスート一致を外す→2 failed。

Closes #5598