### PR TITLE
feat(flowergarden): 積み方ルールを盤面に常設する

### DIFF
--- a/frontend/src/i18n/locales/en/flowergarden.json
+++ b/frontend/src/i18n/locales/en/flowergarden.json
@@ -32,6 +32,7 @@
   "playing": "Move cards to build foundations",
   "reserve": "Bouquet",
   "reserveCardAriaLabel": "{{card}} (reserve slot {{idx}})",
+  "rulesNote": "Suit is ignored — only the next rank down stacks. An empty bed takes any card.",
   "stalemate": "Stalemate",
   "tableau": "Flower bed",
   "tutorial": {

--- a/frontend/src/i18n/locales/ja/flowergarden.json
+++ b/frontend/src/i18n/locales/ja/flowergarden.json
@@ -32,6 +32,7 @@
   "playing": "カードを移動してください",
   "reserve": "ブーケ",
   "reserveCardAriaLabel": "{{card}}（リザーブ枠 {{idx}}）",
+  "rulesNote": "スートは無視。1つ下のランクだけ重ねられます（空のベッドには任意のカード）。",
   "stalemate": "手詰まりです",
   "tableau": "フラワーベッド",
   "tutorial": {

--- a/frontend/src/pages/FlowerGardenPage.test.tsx
+++ b/frontend/src/pages/FlowerGardenPage.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest';
 import { flowerGardenApi } from '../api/gameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { flushPendingDispatch } from '../test/flushPendingDispatch';
@@ -193,7 +193,12 @@ describe('FlowerGardenPage', () => {
   // チュートリアルにしか書かれていなかった。読み飛ばした後に思い出す手掛かりが
   // 盤面に無いので、**チュートリアルの状態に関係なく**出る注記を置く。
   it('states the suit-agnostic packing rule next to the tableau', async () => {
+    // 既読フラグは**このテストの中だけ**の状態。残すと、順序を変えた瞬間に別の
+    // テストがチュートリアル無しで走る隠れた依存になる。
     localStorage.setItem('tutorial-flowergarden-done', 'true');
+    onTestFinished(() => {
+      localStorage.clear();
+    });
     mockExec.mockResolvedValue(playingState);
     renderWithProviders(<FlowerGardenPage />);
     await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());

--- a/frontend/src/pages/FlowerGardenPage.test.tsx
+++ b/frontend/src/pages/FlowerGardenPage.test.tsx
@@ -188,6 +188,22 @@ describe('FlowerGardenPage', () => {
     await waitFor(() => expect(screen.getAllByLabelText(/リザーブ枠 \d+/).length).toBeGreaterThan(0));
     expect(screen.getAllByLabelText(/空のリザーブ枠 \d+/).length).toBeGreaterThan(0);
   });
+
+  // #5599: 「スートを問わない」という他のソリティアと違う規則が、初回だけ出る
+  // チュートリアルにしか書かれていなかった。読み飛ばした後に思い出す手掛かりが
+  // 盤面に無いので、**チュートリアルの状態に関係なく**出る注記を置く。
+  it('states the suit-agnostic packing rule next to the tableau', async () => {
+    localStorage.setItem('tutorial-flowergarden-done', 'true');
+    mockExec.mockResolvedValue(playingState);
+    renderWithProviders(<FlowerGardenPage />);
+    await waitFor(() => expect(screen.getByTestId('phase-indicator')).toBeInTheDocument());
+
+    const note = screen.getByTestId('fg-rules-note');
+    expect(note).toHaveTextContent('スートは無視');
+    expect(note).toHaveTextContent('1つ下のランク');
+    // 空のベッドの扱いも書く ── 規則の半分だけ出すと、空きに置けないと誤解する。
+    expect(note).toHaveTextContent('任意のカード');
+  });
 });
 
 // Keyboard shortcuts are bound by useActionKeyboardNav and advertised by

--- a/frontend/src/pages/FlowerGardenPage.tsx
+++ b/frontend/src/pages/FlowerGardenPage.tsx
@@ -397,6 +397,12 @@ function FlowerGardenPageContent() {
               </div>
             </div>
 
+            {/* 他のソリティアと違う規則なので常設で出す。初回だけのチュートリアルに
+                書いてあっても、読み飛ばした後は盤面に手掛かりが無い (#5599)。 */}
+            <div className="mb-1 text-center text-ds-text-muted text-xs" data-testid="fg-rules-note">
+              {t('rulesNote')}
+            </div>
+
             <div className="flex gap-1 sm:gap-2" data-tutorial="fg-tableau">
               {[0, 1, 2, 3, 4, 5].map(renderTableauColumn)}
             </div>


### PR DESCRIPTION
## 背景

フラワーベッドは `FlowerGarden.canPlaceOnTableau`（`internal/domain/FlowerGarden.go`）のとおり **スートを見ず、1 つ下のランクだけ**積める。姉妹ソリティア（Klondike 等）の赤黒交互とは違う規則なのに、説明は初回のみのチュートリアル `tutorial.moves` だけで、スキップ／既読後は盤面に手掛かりが無かった。

## 変更

フラワーベッドの上に常設の 1 行注記（`data-testid="fg-rules-note"`）。`KillePage` の `rulesNote` と同じ形・同じトーン。

- ja: 「スートは無視。1つ下のランクだけ重ねられます（空のベッドには任意のカード）。」
- en: "Suit is ignored — only the next rank down stacks. An empty bed takes any card."

**空のベッドの扱いも書いた。**規則の半分だけ出すと、空きに置けないと誤解させる（domain は空列に任意のカードを許す）。`tutorial.moves` と矛盾しない要約になっている。

## テスト

`tutorial-flowergarden-done` を立てた状態（＝チュートリアル既読）で描画し、注記に「スートは無視」「1つ下のランク」「任意のカード」が出ることを検証。ja/en のキー数は一致（parity チェック済み）。

Closes #5599