### PR TITLE
feat(sultan): ヒント表示をライブ領域にする

### DIFF
--- a/frontend/src/pages/SultanPage.test.tsx
+++ b/frontend/src/pages/SultanPage.test.tsx
@@ -323,6 +323,26 @@ describe('SultanPage', () => {
     await waitFor(() => expect(screen.getByText(/ヒントがあります/)).toBeInTheDocument());
   });
 
+  // #5602: ヒントは無言で現れていた。**空のまま先にマウントしてある**領域の中身が
+  // 変わることが読み上げの条件なので、hint がある間だけ現れる内側の div ではなく、
+  // 常設のラッパーがライブ領域でなければならない。
+  it('announces the hint through a region that was already mounted', async () => {
+    renderWithProviders(<SultanPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+
+    const region = screen.getByTestId('sultan-hint-live');
+    expect(region).toHaveAttribute('role', 'status');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    expect(region).toHaveTextContent('');
+
+    mockExec.mockResolvedValue(withHintState);
+    fireEvent.click(screen.getByRole('button', { name: 'ヒント' }));
+
+    // **同じ要素**の中身が変わる (別の要素が現れるのではない)。
+    await waitFor(() => expect(region).toHaveTextContent(/ヒントがあります/));
+    expect(region.textContent).toContain('→');
+  });
+
   it('game clear shows action log button', async () => {
     mockExec.mockResolvedValue(gameClearState);
     renderWithProviders(<SultanPage />);

--- a/frontend/src/pages/SultanPage.tsx
+++ b/frontend/src/pages/SultanPage.tsx
@@ -330,7 +330,12 @@ function SultanPageContent() {
             </div>
 
             {/* Hint display */}
-            <div data-tutorial="sultan-hint-display">
+            {/*
+              ライブ領域は**常設**。hint がある間だけ現れる内側の div に付けると、
+              領域と中身が同じコミットで現れるので変化として扱われず、読み上げられない
+              ことがある (#5602)。
+            */}
+            <div data-tutorial="sultan-hint-display" data-testid="sultan-hint-live" role="status" aria-live="polite">
               {hint && (
                 <div className="text-ds-warning text-sm mb-2">
                   {t('hintAvailable')}: {formatHintZone(t, hint.fromZone, hint.fromIdx)} →{' '}


### PR DESCRIPTION
## 背景

`SultanPage` のヒント表示は素の `div` で `role` も `aria-live` も無く、`h` を押しても推奨手がスクリーンリーダーに届かなかった。#5596 / #5597 と同じ形の 3 件目。

## 変更

**常設のラッパー**（`data-tutorial="sultan-hint-display"`）に `role="status" aria-live="polite"`。issue は「ヒント表示 div に付与」とあるが、hint がある間だけ現れる内側の div に付けると領域と中身が同じコミットで DOM に入り、変化と見なされず読み上げられないことがある。見た目（色・レイアウト）は変えていない。

## テスト

- ヒントが無い時点で領域がマウント済みかつ空、`role="status"` / `aria-live="polite"` を持つ
- `ヒント` 押下で**同じ要素**の中身が `ヒントがあります…→…` に変わる

ミューテーション実測: `role`/`aria-live` を内側の条件付き div へ移すと 1 failed。

残りのページは #5955 で追跡。

Closes #5602