### PR TITLE
feat(piquet): 出せないカードを無効化する

### DIFF
--- a/frontend/src/pages/PiquetPage.test.tsx
+++ b/frontend/src/pages/PiquetPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import i18n from 'i18next';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { actionLogApi, piquetApi } from '../api/gameApi';
+import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { PiquetResponse } from '../types/card';
 import { PiquetDeclarationKind, PiquetExchangeTurn, PiquetPhase } from '../types/phases';
@@ -284,6 +285,39 @@ describe('PiquetPage', () => {
     renderWithProviders(<PiquetPage />);
     const hint = await screen.findByTestId('piquet-hint');
     expect(hint).toHaveTextContent('1, 2');
+  });
+
+  // #5603: 出せないカードも押せて、サーバーに move を投げてエラーで返ってくる形
+  // だった。マストフォローの相手は presenter が毎回計算して返しているので、
+  // それをそのまま使う。
+  it('disables the cards that legalPlayIndices leaves out', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: PiquetPhase.PLAY, legalPlayIndices: [1] }));
+    renderWithProviders(<PiquetPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+
+    const cards = await screen.findAllByRole('button', { name: /♠|♥/ });
+    const playable = cards.filter((c) => c.getAttribute('data-hint-action') === 'play');
+    expect(playable).toHaveLength(2);
+    expect(playable[0]).toBeDisabled();
+    expect(playable[1]).not.toBeDisabled();
+
+    mockExec.mockClear();
+    fireEvent.click(playable[0] as HTMLElement);
+    await flushPendingDispatch();
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  // 交換フェーズには legalPlayIndices が載らない。**載っていないことを
+  // 「どれも出せない」と読むと、手札が全部死ぬ。**
+  it('leaves every card usable when no legal set is present', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: PiquetPhase.PLAY }));
+    renderWithProviders(<PiquetPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+
+    const cards = await screen.findAllByRole('button', { name: /♠|♥/ });
+    for (const c of cards.filter((b) => b.getAttribute('data-hint-action') === 'play')) {
+      expect(c).not.toBeDisabled();
+    }
   });
 
   it('does not show the action log view button before the partie ends', async () => {

--- a/frontend/src/pages/PiquetPage.test.tsx
+++ b/frontend/src/pages/PiquetPage.test.tsx
@@ -298,8 +298,11 @@ describe('PiquetPage', () => {
     const cards = await screen.findAllByRole('button', { name: /♠|♥/ });
     const playable = cards.filter((c) => c.getAttribute('data-hint-action') === 'play');
     expect(playable).toHaveLength(2);
-    expect(playable[0]).toBeDisabled();
-    expect(playable[1]).not.toBeDisabled();
+    // 共有の PlayerHandSection と同じ扱い: aria-disabled で**フォーカスは残す**。
+    // HTML の disabled にすると、読み上げ利用者から札そのものが消える。
+    expect(playable[0]).toHaveAttribute('aria-disabled', 'true');
+    expect(playable[0]).not.toBeDisabled();
+    expect(playable[1]).not.toHaveAttribute('aria-disabled');
 
     mockExec.mockClear();
     fireEvent.click(playable[0] as HTMLElement);
@@ -317,6 +320,7 @@ describe('PiquetPage', () => {
     const cards = await screen.findAllByRole('button', { name: /♠|♥/ });
     for (const c of cards.filter((b) => b.getAttribute('data-hint-action') === 'play')) {
       expect(c).not.toBeDisabled();
+      expect(c).not.toHaveAttribute('aria-disabled');
     }
   });
 

--- a/frontend/src/pages/PiquetPage.tsx
+++ b/frontend/src/pages/PiquetPage.tsx
@@ -129,9 +129,11 @@ function PiquetPageContent() {
   // presenter がマストフォローの合法手を毎回返している (PiquetWebPresenter.go)。
   // **空/未設定は「どれも出せない」ではなく「制限なし」。**交換フェーズなど、
   // そもそも載らない状態で手札を全部殺さないため (#5603)。
+  // 未設定は「制限なし」。presenter 側が `omitempty` なので、プレイフェーズの
+  // 人間手番以外では**キーごと来ない** ── それを「どれも出せない」と読むと
+  // 交換フェーズで手札が全部死ぬ。
   const legalPlays = state.legalPlayIndices;
-  const isPlayable = (i: number): boolean =>
-    !humanCanPlay || legalPlays === undefined || legalPlays.length === 0 || legalPlays.includes(i);
+  const isPlayable = (i: number): boolean => legalPlays === undefined || legalPlays.includes(i);
 
   return (
     <GamePageShell
@@ -198,19 +200,20 @@ function PiquetPageContent() {
                     : 'ring-2 ring-ds-error'
                   : '';
                 const handlePlay = () => game.handlePlay(i);
-                const handleClick = humanCanExchange
-                  ? () => toggleDiscard(i)
-                  : humanCanPlay && isPlayable(i)
-                    ? handlePlay
-                    : undefined;
+                const handleClick = humanCanExchange ? () => toggleDiscard(i) : humanCanPlay ? handlePlay : undefined;
+                // 出せない札は PlayerHandSection と同じ扱い ── `aria-disabled` で
+                // フォーカスは残したまま押しても何も起きない形にする。HTML の
+                // `disabled` にすると読み上げ側から札そのものが消える (#5603)。
+                const restricted = humanCanPlay && !isPlayable(i);
                 return (
                   <button
                     key={`hand-${i}-${c.design}-${c.value}`}
                     type="button"
                     aria-pressed={humanCanExchange ? selected : undefined}
                     data-hint-action={humanCanExchange ? 'discard' : 'play'}
-                    className="rounded"
-                    onClick={handleClick}
+                    className={`rounded ${restricted ? 'opacity-50 cursor-not-allowed' : ''}`}
+                    onClick={restricted ? undefined : handleClick}
+                    aria-disabled={restricted || undefined}
                     disabled={handleClick == null}
                   >
                     <AnimatedCard card={c} width={cardWidth} isSelected={selected} wrapperClassName={ringClass} />

--- a/frontend/src/pages/PiquetPage.tsx
+++ b/frontend/src/pages/PiquetPage.tsx
@@ -126,6 +126,12 @@ function PiquetPageContent() {
     ((state.exchangeTurn === PiquetExchangeTurn.ELDER && isHumanElder) ||
       (state.exchangeTurn === PiquetExchangeTurn.YOUNGER && !isHumanElder));
   const humanCanPlay = inPlayPhase && human?.id === state.currentPlayerIdx;
+  // presenter がマストフォローの合法手を毎回返している (PiquetWebPresenter.go)。
+  // **空/未設定は「どれも出せない」ではなく「制限なし」。**交換フェーズなど、
+  // そもそも載らない状態で手札を全部殺さないため (#5603)。
+  const legalPlays = state.legalPlayIndices;
+  const isPlayable = (i: number): boolean =>
+    !humanCanPlay || legalPlays === undefined || legalPlays.length === 0 || legalPlays.includes(i);
 
   return (
     <GamePageShell
@@ -192,7 +198,11 @@ function PiquetPageContent() {
                     : 'ring-2 ring-ds-error'
                   : '';
                 const handlePlay = () => game.handlePlay(i);
-                const handleClick = humanCanExchange ? () => toggleDiscard(i) : humanCanPlay ? handlePlay : undefined;
+                const handleClick = humanCanExchange
+                  ? () => toggleDiscard(i)
+                  : humanCanPlay && isPlayable(i)
+                    ? handlePlay
+                    : undefined;
                 return (
                   <button
                     key={`hand-${i}-${c.design}-${c.value}`}


### PR DESCRIPTION
## 背景

`PiquetWebPresenter.go:26` は人間の手番ごとに `GetLegalPlayIndices` を計算して返しており、`PiquetResponse.legalPlayIndices` も型に存在するのに、`PiquetPage.tsx` は一度も読んでいなかった。出せないカードもクリックでき、サーバーに move を投げてエラーで返ってくる形。Belote / Hearts / Euchre / CourtPiece は同種の値で制御しており、Piquet だけ取り残されていた。

## 変更

手札ボタンの `handleClick` を合法手に限定（`disabled` は既存の `handleClick == null` 判定がそのまま効く）。

**未設定・空配列は「制限なし」として扱う。**交換フェーズなど presenter が載せない状態で「どれも出せない」と読むと手札が全部死ぬ。`data-hint-action` とレイアウトは変更していない。

## テスト

- `legalPlayIndices: [1]` のとき index 0 が `disabled` で、クリックしても `exec` が呼ばれない
- 値が無い play フェーズではどのカードも `disabled` にならない

ミューテーション実測: 空配列を「出せない」と読む形にする→1 failed、制限を外す→1 failed。

Closes #5603