### PR TITLE
feat(briscola): 決着後のリセットで確認を出さない

### DIFF
--- a/frontend/src/pages/BriscolaPage.test.tsx
+++ b/frontend/src/pages/BriscolaPage.test.tsx
@@ -4,6 +4,7 @@ import { briscolaApi } from '../api/gameApi';
 import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { BriscolaResponse, Card } from '../types/card';
+import { BriscolaPhase } from '../types/phases';
 import { BriscolaPage } from './BriscolaPage';
 
 vi.mock('../api/gameApi', () => ({
@@ -219,6 +220,23 @@ describe('BriscolaPage', () => {
 
     mockExec.mockClear();
     fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
+  });
+
+  // #5608: ゲームが終わった後は失うものが無いので、共通の GameResetButton は
+  // 確認を飛ばして「次のゲーム」になる。Briscola だけ自前ボタンで、決着後も
+  // 毎回確認を要求していた。
+  it('starts the next game without a confirm once the game has ended', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: BriscolaPhase.GAME_END, gameEndFlag: true }));
+    renderWithProviders(<BriscolaPage />);
+
+    const next = await screen.findByRole('button', { name: '次のゲーム' });
+    expect(screen.queryByRole('button', { name: 'リセット' })).not.toBeInTheDocument();
+
+    mockExec.mockClear();
+    fireEvent.click(next);
+    // ダイアログを挟まずに走る。
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
     await waitFor(() => expect(mockExec).toHaveBeenCalledWith('reset'));
   });
 

--- a/frontend/src/pages/BriscolaPage.tsx
+++ b/frontend/src/pages/BriscolaPage.tsx
@@ -6,6 +6,7 @@ import { SettingsPanel } from '../components/common/SettingsPanel';
 import { ErrorAlert } from '../components/ErrorAlert';
 import { GameMessageBox } from '../components/GameMessageBox';
 import { GamePageShell } from '../components/GamePageShell';
+import { GameResetButton } from '../components/GameResetButton';
 import { FrontendHintTooltip } from '../components/hint/FrontendHintTooltip';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
 import { AnimatedCardBack } from '../components/motion/AnimatedCardBack';
@@ -17,7 +18,7 @@ import { useCardKeyboardNav } from '../hooks/useCardKeyboardNav';
 import { useGameApi } from '../hooks/useGameApi';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
-import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
+import { btnSuccess } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { BriscolaResponse } from '../types/card';
 import { BriscolaPhase } from '../types/phases';
@@ -297,9 +298,13 @@ function BriscolaPageContent() {
               {t('actions.hint')}
             </button>
           )}
-          <button type="button" className={btnPrimary} onClick={() => requestConfirm(handleReset)} disabled={loading}>
-            {t('actions.reset')}
-          </button>
+          {/* 決着後は失うものが無いので確認を挟まない ── 共通ボタンに任せる (#5608)。 */}
+          <GameResetButton
+            isGameEnd={isGameEnd}
+            onReset={handleReset}
+            requestConfirm={requestConfirm}
+            loading={loading}
+          />
         </div>
       </div>
 


### PR DESCRIPTION
## 背景

`BriscolaPage` だけ共通の `GameResetButton` を使わず自前ボタンで、`requestConfirm(handleReset)` を無条件に通していた。GAME_END フェーズ（失うものが無い状態）でも確認ダイアログが出るので、他ゲームの「決着したらワンクリックで次へ」に慣れたプレイヤーほど引っかかる。

## 変更

自前ボタンを `GameResetButton` に置き換え、`isGameEnd` を渡す。ラベル・スタイル・確認の有無はコンポーネント側の既存仕様どおり（決着後は「次のゲーム」＋即実行、プレイ中は「リセット」＋確認）。`btnPrimary` はこのページで使われなくなったので import から削除。

## テスト

- 決着後: 「次のゲーム」ボタンが出て「リセット」は無く、押すと**ダイアログを挟まず** `reset` が飛ぶ
- プレイ中: 既存テストのまま（確認ダイアログ → 承認で `reset`）

ミューテーション実測: `isGameEnd={false}` を渡す形にすると 1 failed。

Closes #5608