### PR TITLE
feat(gaps): 手詰まり脱出ボタンをWeb画面にも出す

### DIFF
--- a/frontend/src/pages/GapsPage.test.tsx
+++ b/frontend/src/pages/GapsPage.test.tsx
@@ -137,6 +137,27 @@ describe('GapsPage', () => {
     await waitFor(() => expect(mockedRun).toHaveBeenCalledWith('undo'));
   });
 
+  // #5609: ドメインも presenter も手詰まりを返しており、CUI は #4800 で赤い警告を
+  // 出すようになったのに、Web 版は何も出さないままだった。動かせる札が見つからず
+  // 困るだけで、脱出手段があることに気づけない。
+  it('offers the stalemate escape when the server reports one', async () => {
+    mockedRun.mockResolvedValue({ ...playingState, isStalemate: true, undoToEscape: 3, canUndo: true });
+    renderWithProviders(<GapsPage />);
+
+    const btn = await screen.findByTestId('stalemate-escape-button');
+    mockedRun.mockClear();
+    fireEvent.click(btn);
+    // undo_n の 4 番目の引数が戻す手数 (gapsApi.exec(command, from, to, n))。
+    await waitFor(() => expect(mockedRun).toHaveBeenCalledWith('undo_n', undefined, undefined, 3));
+  });
+
+  it('shows no escape button while the game is not stuck', async () => {
+    mockedRun.mockResolvedValue({ ...playingState, isStalemate: false, undoToEscape: 3 });
+    renderWithProviders(<GapsPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+    expect(screen.queryByTestId('stalemate-escape-button')).not.toBeInTheDocument();
+  });
+
   it('calls run hint when hint clicked', async () => {
     renderWithProviders(<GapsPage />);
     const btn = await screen.findByRole('button', { name: 'ヒント' });

--- a/frontend/src/pages/GapsPage.test.tsx
+++ b/frontend/src/pages/GapsPage.test.tsx
@@ -151,6 +151,15 @@ describe('GapsPage', () => {
     await waitFor(() => expect(mockedRun).toHaveBeenCalledWith('undo_n', undefined, undefined, 3));
   });
 
+  // 手詰まりでも手数が来ないことはある (presenter が省略したとき)。ボタン側は
+  // 0 なら何も描かない約束なので、**壊れたボタンではなく無表示**になる。
+  it('renders no escape button when the server omits the undo count', async () => {
+    mockedRun.mockResolvedValue({ ...playingState, isStalemate: true, undoToEscape: undefined });
+    renderWithProviders(<GapsPage />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'ヒント' })).toBeInTheDocument());
+    expect(screen.queryByTestId('stalemate-escape-button')).not.toBeInTheDocument();
+  });
+
   it('shows no escape button while the game is not stuck', async () => {
     mockedRun.mockResolvedValue({ ...playingState, isStalemate: false, undoToEscape: 3 });
     renderWithProviders(<GapsPage />);

--- a/frontend/src/pages/GapsPage.tsx
+++ b/frontend/src/pages/GapsPage.tsx
@@ -11,6 +11,7 @@ import { FrontendHintTooltip } from '../components/hint/FrontendHintTooltip';
 import { KbdBadge } from '../components/KbdBadge';
 import { LandscapeBanner } from '../components/LandscapeBanner';
 import { AnimatedCard } from '../components/motion/AnimatedCard';
+import { StalemateEscapeButton } from '../components/StalemateEscapeButton';
 import { GameSkeleton } from '../components/skeleton/GameSkeleton';
 import { withTutorial } from '../components/tutorial/withTutorial';
 import { useActionKeyboardNav } from '../hooks/useActionKeyboardNav';
@@ -108,6 +109,14 @@ function GapsPageContent() {
   const handleUndo = useCallback(() => {
     void run('undo');
   }, [run]);
+
+  /** Undo N moves at once to escape a stalemate (mirrors Sultan / Forty and Eight). */
+  const handleUndoEscape = useCallback(
+    (n: number) => {
+      void run('undo_n', undefined, undefined, n);
+    },
+    [run],
+  );
 
   const handleRedeal = useCallback(() => {
     void run('redeal');
@@ -346,6 +355,15 @@ function GapsPageContent() {
                 {t('undo')}
                 <KbdBadge label={t('kbd.undo')} />
               </button>
+              {/* 手詰まりはドメインが判定して返している (#5609)。CUI は #4800 で
+                  警告を出しているのに、Web には脱出手段の案内が無かった。 */}
+              {state.isStalemate && (
+                <StalemateEscapeButton
+                  undoToEscape={state.undoToEscape ?? 0}
+                  onEscape={handleUndoEscape}
+                  disabled={loading}
+                />
+              )}
               <button
                 type="button"
                 className={btnPrimary}


### PR DESCRIPTION
## 背景

`isStalemate` / `undoToEscape` はドメイン → presenter → 型 まで揃っており、CUI は #4800 で手詰まり警告を出している。`GapsPage.tsx` だけが一度も読んでおらず、Web のプレイヤーは動かせる札が見つからないまま、脱出手段があることに気づけなかった。

## 変更

Sultan / FortyAndEight と同じ形:

- `handleUndoEscape(n)` を追加（`undo_n` は `GapsWebController.go:69` に既にある）
- `state.isStalemate` のときだけ `StalemateEscapeButton` を描画し、`undoToEscape` をそのまま渡す

## テスト

- 手詰まりのとき脱出ボタンが出て、押すと `exec('undo_n', undefined, undefined, 3)` が飛ぶ
- 手詰まりでないときは出ない

ミューテーション実測: 条件を `true` にする→1 failed、`undo_n` を素の `undo` にする→1 failed。

Closes #5609