### PR TITLE
feat(eightoff): タッチ操作でもスーパームーブ範囲を出す

### DIFF
--- a/frontend/src/pages/EightOffPage.test.tsx
+++ b/frontend/src/pages/EightOffPage.test.tsx
@@ -1138,3 +1138,59 @@ describe('EightOffPage supermove badge', () => {
     expect(withAllFree).not.toEqual(withTwoUsed);
   });
 });
+
+// #5612: 一括移動される塊のプレビューが `hoveredStack` (onMouseEnter/onFocus) にしか
+// 追従していなかった。タッチ端末にホバーは無いので、タップで選んだ直後にフォーカスが
+// 外れると、どこまでが一緒に動くのか手がかりが消える。Easthaven は #4815 で
+// 選択状態にも追従させている。
+describe('EightOffPage supermove block preview on touch', () => {
+  // 2 枚の列を持ち、空きセル 8 + 空き列 6 → 上限は十分大きいので塊は動かせる。
+  const twoCardCol: EightOffResponse = {
+    ...playingState,
+    tableau: [[card('SPADE', 13), card('HEART', 12)], [card('CLOVER', 13)], [], [], [], [], [], []],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useGameHint).mockReturnValue({ hint: null, hintEnabled: false, setHintEnabled: vi.fn() });
+    mockExec.mockResolvedValue(twoCardCol);
+  });
+
+  it('keeps the block marked after a tap selects the stack', async () => {
+    renderWithProviders(<EightOffPage />);
+    const deep = await screen.findByTestId('eo-tableau-0-0');
+
+    // タップ = click。ホバーもフォーカスも無い状態にする。
+    fireEvent.click(deep);
+    await waitFor(() => expect(deep).toHaveAttribute('aria-pressed', 'true'));
+    fireEvent.blur(deep);
+
+    expect(deep).toHaveAttribute('data-supermove-block', 'true');
+    // 選んだ札より下 (後ろ) の札も同じ塊。
+    expect(screen.getByTestId('eo-tableau-0-1')).toHaveAttribute('data-supermove-block', 'true');
+    // 別の列は巻き込まない。
+    expect(screen.getByTestId('eo-tableau-1-0')).not.toHaveAttribute('data-supermove-block');
+  });
+
+  it('still marks the block on hover, as before', async () => {
+    renderWithProviders(<EightOffPage />);
+    const deep = await screen.findByTestId('eo-tableau-0-0');
+
+    fireEvent.mouseEnter(deep);
+    expect(deep).toHaveAttribute('data-supermove-block', 'true');
+    fireEvent.mouseLeave(deep);
+    expect(deep).not.toHaveAttribute('data-supermove-block');
+  });
+
+  // 上限を超える塊は、選んでもハイライトしない ── 動かない塊を「動く」と見せない。
+  it('does not mark a selected stack that exceeds the supermove limit', async () => {
+    mockExec.mockResolvedValue(supermoveBlockedState);
+    renderWithProviders(<EightOffPage />);
+    const deep = await screen.findByTestId('eo-tableau-0-0');
+    expect(deep).toHaveAttribute('data-supermove-blocked', 'true');
+
+    fireEvent.click(deep);
+    fireEvent.blur(deep);
+    expect(deep).not.toHaveAttribute('data-supermove-block');
+  });
+});

--- a/frontend/src/pages/EightOffPage.tsx
+++ b/frontend/src/pages/EightOffPage.tsx
@@ -451,10 +451,14 @@ function EightOffPageContent() {
                               // フォーカスが外れると、どこまでが一緒に動くのか
                               // 手がかりが消えるので、選択状態にも追従させる
                               // (Easthaven #4815 と同じ形) (#5612)。
+                              // `?? null` は置かない。タブローの**選択元**は必ず
+                              // cardIndex を持つ (cardIndex 無しの tableau zone は
+                              // 空列を指す移動先専用) ので、埋めようのない分岐が
+                              // 増えるだけになる。
                               const selectedBlockStart =
                                 selectedSource?.zone === 'tableau' && selectedSource.col === colIdx
-                                  ? (selectedSource.cardIndex ?? null)
-                                  : null;
+                                  ? selectedSource.cardIndex
+                                  : undefined;
                               // 上限判定は両方に掛ける ── 動かせない塊を「動く」と
                               // 見せてはいけない。
                               const blockStart =
@@ -462,7 +466,7 @@ function EightOffPageContent() {
                                   ? hoveredStack.cardIdx
                                   : selectedBlockStart;
                               const isInHoveredBlock =
-                                blockStart !== null &&
+                                blockStart !== undefined &&
                                 cardIdx >= blockStart &&
                                 col.length - blockStart <= supermoveLimit;
                               return (

--- a/frontend/src/pages/EightOffPage.tsx
+++ b/frontend/src/pages/EightOffPage.tsx
@@ -447,11 +447,24 @@ function EightOffPageContent() {
                               const stackSize = col.length - cardIdx;
                               const exceedsSupermove = stackSize > supermoveLimit;
                               const isTopCard = cardIdx === col.length - 1;
+                              // **タッチにはホバーが無い。**タップで選んだ直後に
+                              // フォーカスが外れると、どこまでが一緒に動くのか
+                              // 手がかりが消えるので、選択状態にも追従させる
+                              // (Easthaven #4815 と同じ形) (#5612)。
+                              const selectedBlockStart =
+                                selectedSource?.zone === 'tableau' && selectedSource.col === colIdx
+                                  ? (selectedSource.cardIndex ?? null)
+                                  : null;
+                              // 上限判定は両方に掛ける ── 動かせない塊を「動く」と
+                              // 見せてはいけない。
+                              const blockStart =
+                                hoveredStack !== null && hoveredStack.col === colIdx
+                                  ? hoveredStack.cardIdx
+                                  : selectedBlockStart;
                               const isInHoveredBlock =
-                                hoveredStack !== null &&
-                                hoveredStack.col === colIdx &&
-                                cardIdx >= hoveredStack.cardIdx &&
-                                col.length - hoveredStack.cardIdx <= supermoveLimit;
+                                blockStart !== null &&
+                                cardIdx >= blockStart &&
+                                col.length - blockStart <= supermoveLimit;
                               return (
                                 <div
                                   key={`tc-${colIdx.toString()}-${cardIdx.toString()}`}


### PR DESCRIPTION
## 背景

`isInHoveredBlock` が `hoveredStack`（`onMouseEnter`/`onFocus`）しか見ておらず、**タッチ端末にはホバーが無い**ため、タップで選んだあとフォーカスが外れると「どこまでが一緒に動く塊なのか」の手がかりが消えていた。姉妹の `EasthavenPage` は #4815 で選択状態にも追従させている。

## 変更

`selectedSource` が同じ列を指していれば、その位置を塊の起点として扱う（Easthaven と同じ形）。

**上限判定は両方の経路に掛けた。**Easthaven 版は選択側に上限チェックが無いが、Eight Off は `supermoveLimit` を超える塊を「動かせない」として別扱いしているので、選択経由でハイライトすると動かない塊を動くように見せてしまう。

## テスト

- タップ（click）→ blur のあとも、選んだ札とその下の札に `data-supermove-block` が付く。別の列には付かない
- 従来のホバー挙動（mouseEnter で付き、mouseLeave で消える）は変わらない
- 上限を超える塊は、選んでもハイライトされない

ミューテーション実測: 選択フォールバックを外す→1 failed、上限判定を外す→1 failed。

Closes #5612