### PR TITLE
feat(russianpoker): 発生済みのコストをショーダウンまで表示し続ける

### DIFF
--- a/frontend/src/i18n/locales/en/russianpoker.json
+++ b/frontend/src/i18n/locales/en/russianpoker.json
@@ -43,6 +43,11 @@
     "forceExchange": "Force exchange fee",
     "total": "Total"
   },
+  "paidCosts": {
+    "exchange": "Exchange fee: {{count}} card(s) -{{fee}}",
+    "buy6th": "6th-card fee -{{fee}}",
+    "forceExchange": "Forced-exchange fee -{{fee}}"
+  },
   "handRank": {
     "0": "High Card",
     "1": "One Pair",

--- a/frontend/src/i18n/locales/ja/russianpoker.json
+++ b/frontend/src/i18n/locales/ja/russianpoker.json
@@ -43,6 +43,11 @@
     "forceExchange": "強制交換手数料",
     "total": "合計"
   },
+  "paidCosts": {
+    "exchange": "交換手数料: {{count}}枚 -{{fee}}",
+    "buy6th": "6枚目手数料 -{{fee}}",
+    "forceExchange": "強制交換手数料 -{{fee}}"
+  },
   "handRank": {
     "0": "ハイカード",
     "1": "ワンペア",

--- a/frontend/src/pages/RussianPokerPage.test.tsx
+++ b/frontend/src/pages/RussianPokerPage.test.tsx
@@ -214,3 +214,52 @@ describe('RussianPokerPage', () => {
     expect(screen.getByLabelText(/ヒント/)).toBeInTheDocument();
   });
 });
+
+// #5613: 交換手数料も6枚目購入料も、END の payout-breakdown にしか出ていなかった。
+// ACTION 中に見えていた見積もりは交換した瞬間に消えるので、**もう払ったコスト**を
+// 確認する手段が POST_ACTION / SELECT / FORCE_QUALIFY のどこにも無かった。
+// CUI は exchangeLine / buy6thLine を全フェーズで出し続けている。
+describe('RussianPokerPage paid costs', () => {
+  beforeEach(() => {
+    localStorage.removeItem('hint_enabled_russianpoker');
+    vi.clearAllMocks();
+  });
+
+  it('keeps the exchange fee on screen after the exchange', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: RussianPokerPhase.POST_ACTION, exchangeCount: 2, exchangeFee: 200 }));
+    renderWithProviders(<RussianPokerPage />);
+
+    const costs = await screen.findByTestId('rp-paid-costs');
+    expect(costs).toHaveTextContent('交換手数料');
+    expect(costs).toHaveTextContent('200');
+    // 枚数も出す ── CUI の exchangeLine と同じ情報量。
+    expect(costs).toHaveTextContent('2');
+  });
+
+  it('keeps the sixth-card fee on screen in the select phase', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: RussianPokerPhase.SELECT, bought6th: true, buy6thFee: 100 }));
+    renderWithProviders(<RussianPokerPage />);
+
+    const costs = await screen.findByTestId('rp-paid-costs');
+    expect(costs).toHaveTextContent('6枚目手数料');
+    expect(costs).toHaveTextContent('100');
+  });
+
+  it('shows nothing when no cost has been incurred', async () => {
+    mockExec.mockResolvedValue(makeState({ phase: RussianPokerPhase.POST_ACTION }));
+    renderWithProviders(<RussianPokerPage />);
+    await waitFor(() => expect(mockExec).toHaveBeenCalled());
+    expect(screen.queryByTestId('rp-paid-costs')).not.toBeInTheDocument();
+  });
+
+  // END の内訳は従来どおり別物 ── 二重に同じ金額が並ばないこと。
+  it('leaves the end-phase breakdown as the only summary at showdown', async () => {
+    mockExec.mockResolvedValue(
+      makeState({ phase: RussianPokerPhase.END, exchangeCount: 2, exchangeFee: 200, totalPayout: 0 }),
+    );
+    renderWithProviders(<RussianPokerPage />);
+
+    await waitFor(() => expect(screen.getByTestId('payout-breakdown')).toBeInTheDocument());
+    expect(screen.queryByTestId('rp-paid-costs')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/RussianPokerPage.test.tsx
+++ b/frontend/src/pages/RussianPokerPage.test.tsx
@@ -245,6 +245,18 @@ describe('RussianPokerPage paid costs', () => {
     expect(costs).toHaveTextContent('100');
   });
 
+  // 強制交換も同じ扱い。3 本目の分岐だけ未検証だと、そこだけ静かに壊れる。
+  it('keeps the forced-exchange fee on screen', async () => {
+    mockExec.mockResolvedValue(
+      makeState({ phase: RussianPokerPhase.FORCE_QUALIFY, forceExchanged: true, forceExchangeFee: 150 }),
+    );
+    renderWithProviders(<RussianPokerPage />);
+
+    const costs = await screen.findByTestId('rp-paid-costs');
+    expect(costs).toHaveTextContent('強制交換手数料');
+    expect(costs).toHaveTextContent('150');
+  });
+
   it('shows nothing when no cost has been incurred', async () => {
     mockExec.mockResolvedValue(makeState({ phase: RussianPokerPhase.POST_ACTION }));
     renderWithProviders(<RussianPokerPage />);

--- a/frontend/src/pages/RussianPokerPage.tsx
+++ b/frontend/src/pages/RussianPokerPage.tsx
@@ -293,6 +293,23 @@ function RussianPokerPageContent() {
               messageParams={state.messageParams}
             />
 
+            {/*
+              **もう払ったコストは、払った後こそ見えている必要がある。**ACTION 中の
+              見積もりは交換した瞬間に消えるので、POST_ACTION / SELECT /
+              FORCE_QUALIFY では確認する手段が無かった (#5613)。CUI は同じ内容を
+              全フェーズで出し続けている。END は payout-breakdown が担当するので
+              重ねない。
+            */}
+            {!isEndPhase && (state.exchangeCount > 0 || state.bought6th || state.forceExchanged) && (
+              <div className="text-ds-text-muted text-center text-sm mb-2" data-testid="rp-paid-costs">
+                {state.exchangeCount > 0 && (
+                  <div>{t('paidCosts.exchange', { count: state.exchangeCount, fee: state.exchangeFee })}</div>
+                )}
+                {state.bought6th && <div>{t('paidCosts.buy6th', { fee: state.buy6thFee })}</div>}
+                {state.forceExchanged && <div>{t('paidCosts.forceExchange', { fee: state.forceExchangeFee })}</div>}
+              </div>
+            )}
+
             {isBetPhase && (
               <div className="flex flex-col items-center justify-center py-4 gap-4">
                 <p className="text-ds-text-muted text-lg">{t('betGuide')}</p>


### PR DESCRIPTION
## 背景

`exchangeFee` / `buy6thFee` / `forceExchangeFee` は presenter が毎回返しており CUI は全フェーズで出しているのに、`RussianPokerPage.tsx` は **END の payout-breakdown 内でしか**参照していなかった。ACTION 中に出ている見積もり (`exchangeFeeInfo`) は交換した瞬間に消えるので、POST_ACTION / SELECT / FORCE_QUALIFY では「もういくら払ったか」を確認する手段が無い。

## 変更

カード領域の先頭に発生済みコストの要約（`data-testid="rp-paid-costs"`）を追加。CUI の `exchangeLine` / `buy6thLine` と同じ情報量（交換は枚数も出す）。

- `exchangeCount > 0` / `bought6th` / `forceExchanged` のいずれかが立っているときだけ描画
- **END では出さない。**同じ金額を payout-breakdown が内訳として出しており、二重に並ぶと足し算に見える

ja/en 両方に `paidCosts` を追加（キー数一致を確認済み、差分は 5 行 / 5 行の追加のみ）。

## テスト

- POST_ACTION で交換手数料（枚数と金額）が出る
- SELECT で 6 枚目購入料が出る
- 何も払っていなければ要素ごと出ない
- END では出ず、payout-breakdown だけが残る

ミューテーション実測: END の抑制を外す→1 failed、発生条件を外す→1 failed。

Closes #5613