### PR TITLE
fix(penguin): 空き列への移動上限をWebでも使う

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -54718,6 +54718,8 @@ components:
         - freeCells
         - foundation
         - baseRank
+        - maxMovableCards
+        - maxMovableCardsToEmptyColumn
         - phase
         - moveCount
         - canUndo
@@ -54748,6 +54750,19 @@ components:
           type: integer
           description: The base rank for foundations (1-13, determined by the first dealt card)
           example: 5
+        maxMovableCards:
+          type: integer
+          description: >-
+            How many cards may move as one stack right now, from the domain's
+            own calculation. The web client must not recompute this.
+          example: 4
+        maxMovableCardsToEmptyColumn:
+          type: integer
+          description: >-
+            The same limit when the destination is an empty column, which is
+            lower because that column cannot also serve as a staging slot.
+            0 when there is no empty column.
+          example: 2
         phase:
           type: integer
           description: "Game phase: 0 = Playing, 1 = GameClear, 2 = GameOver"

--- a/frontend/src/i18n/locales/en/penguin.json
+++ b/frontend/src/i18n/locales/en/penguin.json
@@ -23,6 +23,8 @@
   "supermoveLimitTooltip": "Only {{limit}} card(s) can be moved at once ({{cells}} free cell(s), {{cols}} empty column(s))",
   "supermoveBadge": "Max move: {{limit}}",
   "supermoveBadgeTooltip": "Max cards movable at once ({{cells}} free cell(s), {{cols}} empty column(s)). More free space allows moving more",
+  "supermoveToEmpty": "(to an empty column: {{limit}})",
+  "emptyColLimitTooltip": "An empty column takes at most {{limit}} cards (selected: {{size}})",
   "tutorial": {
     "freeCells": "Seven free cells. Three start occupied after the deal. More empty cells allow moving more cards at once.",
     "foundation": "Foundation piles. Build each suit from the base rank upward, wrapping K to A.",

--- a/frontend/src/i18n/locales/ja/penguin.json
+++ b/frontend/src/i18n/locales/ja/penguin.json
@@ -23,6 +23,8 @@
   "supermoveLimitTooltip": "一度に動かせるのは{{limit}}枚まで（空きセル{{cells}}・空き列{{cols}}）",
   "supermoveBadge": "最大移動: {{limit}}枚",
   "supermoveBadgeTooltip": "一度に動かせる最大枚数（空きセル{{cells}}・空き列{{cols}}）。空きが増えるほど多く動かせます",
+  "supermoveToEmpty": "(空き列へは{{limit}}枚)",
+  "emptyColLimitTooltip": "空き列へ動かせるのは{{limit}}枚まで（選択中: {{size}}枚）",
   "tutorial": {
     "freeCells": "7つのフリーセルです。初期配置で3セルが使用済みの状態からスタートします。空きセルが多いほど多くのカードを一度に移動できます。",
     "foundation": "ファンデーションです。各スートを基準ランクから順番に積み上げます（Kの次はAに回ります）。",

--- a/frontend/src/pages/PenguinPage.test.tsx
+++ b/frontend/src/pages/PenguinPage.test.tsx
@@ -25,6 +25,8 @@ const playingState: PenguinResponse = {
   freeCells: [card('DIAMOND', 3), card('CLOVER', 5), card('HEART', 7), null, null, null, null],
   foundation: [[], [], [], []],
   baseRank: 4,
+  maxMovableCards: 8,
+  maxMovableCardsToEmptyColumn: 4,
   phase: 0,
   moveCount: 5,
   canUndo: true,
@@ -33,10 +35,14 @@ const playingState: PenguinResponse = {
   messageCode: 'penguin.playing',
 };
 
-// All free cells occupied and every column non-empty → supermoveLimit = (1+0)*2^0 = 1,
-// so the 2-card stack in column 0 exceeds the limit and shows the tooltip.
+// All free cells occupied and every column non-empty, so the domain reports a
+// limit of 1 and the 2-card stack in column 0 exceeds it. The limit now comes
+// from the response (#5614) rather than being recomputed here, so the fixture
+// states it instead of implying it.
 const supermoveExceedState: PenguinResponse = {
   ...playingState,
+  maxMovableCards: 1,
+  maxMovableCardsToEmptyColumn: 0,
   freeCells: [
     card('DIAMOND', 3),
     card('CLOVER', 5),
@@ -150,17 +156,16 @@ describe('PenguinPage', () => {
   });
 
   it('shows a supermove-limit badge reflecting the free-cell/column counts', async () => {
-    // playingState: 4 empty free cells, 5 empty columns → (1+4)*2^5 = 160.
+    // 数字はサーバーが返した maxMovableCards をそのまま出す (#5614)。
     renderWithProviders(<PenguinPage />);
     const badge = await screen.findByTestId('pg-supermove-badge');
-    expect(badge).toHaveTextContent('最大移動: 160枚');
+    expect(badge).toHaveTextContent('最大移動: 8枚');
   });
 
   it('supermove-limit badge updates when free space shrinks', async () => {
     mockExec.mockResolvedValue(supermoveExceedState);
     renderWithProviders(<PenguinPage />);
     const badge = await screen.findByTestId('pg-supermove-badge');
-    // 0 empty free cells, 0 empty columns → (1+0)*2^0 = 1.
     expect(badge).toHaveTextContent('最大移動: 1枚');
   });
 
@@ -574,5 +579,59 @@ describe('PenguinPage', () => {
   it('renders tutorial button', async () => {
     renderWithProviders(<PenguinPage />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'チュートリアル' })).toBeInTheDocument());
+  });
+});
+
+// #5614: 空き列へ動かすときの上限はドメインが別に持っている (その空き列自身を
+// 経由地に使えないぶん低い)。ページは一般式で計算し直していたので、空き列宛ての
+// 束を「動かせる」と見せてサーバーに弾かれることがあった。
+describe('PenguinPage empty-column move limit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useGameHint).mockReturnValue({ hint: null, hintEnabled: false, setHintEnabled: vi.fn() });
+  });
+
+  it('shows the server limits instead of recomputing them', async () => {
+    // 一般式なら (1 + 空きセル4) * 2^空き列5 = 160。サーバーは 8 と言っている。
+    mockExec.mockResolvedValue({ ...playingState, maxMovableCards: 8, maxMovableCardsToEmptyColumn: 4 });
+    renderWithProviders(<PenguinPage />);
+
+    const badge = await screen.findByTestId('pg-supermove-badge');
+    expect(badge).toHaveTextContent('8');
+    // 空き列宛ての低い方も出す ── CUI の penguin.supermoveToEmpty と同じ数字。
+    expect(badge).toHaveTextContent('4');
+  });
+
+  it('marks the empty column as out of reach for a stack that only the lower limit blocks', async () => {
+    // 3 枚の束: 一般上限 8 なら動かせるが、空き列上限 2 は超える。
+    mockExec.mockResolvedValue({
+      ...playingState,
+      tableau: [[card('SPADE', 13), card('SPADE', 12), card('SPADE', 11)], [], [], [], [], [], []],
+      maxMovableCards: 8,
+      maxMovableCardsToEmptyColumn: 2,
+    });
+    renderWithProviders(<PenguinPage />);
+
+    const deep = await screen.findByTestId('pg-tableau-0-0');
+    // 一般上限では動く ── 札そのものはブロックしない。
+    expect(deep).not.toHaveAttribute('data-supermove-blocked');
+
+    fireEvent.click(deep);
+    const emptyCol = await screen.findByTestId('pg-empty-col-1');
+    expect(emptyCol).toHaveAttribute('data-empty-col-blocked', 'true');
+    expect(emptyCol.getAttribute('title') ?? '').toContain('2');
+  });
+
+  it('leaves the empty column usable when the stack fits the lower limit', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      tableau: [[card('SPADE', 13), card('SPADE', 12)], [], [], [], [], [], []],
+      maxMovableCards: 8,
+      maxMovableCardsToEmptyColumn: 2,
+    });
+    renderWithProviders(<PenguinPage />);
+
+    fireEvent.click(await screen.findByTestId('pg-tableau-0-0'));
+    expect(await screen.findByTestId('pg-empty-col-1')).not.toHaveAttribute('data-empty-col-blocked');
   });
 });

--- a/frontend/src/pages/PenguinPage.tsx
+++ b/frontend/src/pages/PenguinPage.tsx
@@ -201,7 +201,17 @@ function PenguinPageContent() {
 
   const emptyFreeCells = state.freeCells.filter((c) => c === null).length;
   const emptyTableauCols = state.tableau.filter((col: (Card | null)[]) => col.length === 0).length;
-  const supermoveLimit = (1 + emptyFreeCells) * 2 ** emptyTableauCols;
+  // **上限はドメインが決める。**ここで一般式を持つと、空き列自身を経由地に
+  // 使えないぶんの差 (maxMovableCardsToEmptyColumn) が抜け、空き列宛ての束を
+  // 「動かせる」と見せてサーバーに弾かれる (#5614)。
+  const supermoveLimit = state.maxMovableCards;
+  const emptyColLimit = state.maxMovableCardsToEmptyColumn;
+
+  // 選択中の束の枚数。空き列が受け取れるかはこれと emptyColLimit で決まる。
+  const selectedStackSize =
+    selectedSource?.zone === 'tableau' && selectedSource.col !== undefined && selectedSource.cardIndex !== undefined
+      ? (state.tableau[selectedSource.col]?.length ?? 0) - selectedSource.cardIndex
+      : 0;
 
   const emptyColPlaceholder = prevRankLabel(state.baseRank);
 
@@ -246,6 +256,7 @@ function PenguinPageContent() {
               cells: emptyFreeCells,
               cols: emptyTableauCols,
             })}
+            {emptyColLimit > 0 && <> {t('supermoveToEmpty', { limit: emptyColLimit })}</>}
           </span>
           <CliToggle cliEnabled={cliEnabled} onToggle={toggleCli} />
         </>
@@ -406,7 +417,18 @@ function PenguinPageContent() {
                               disabled={!isPlaying || loading || !selectedSource}
                               aria-label={t('emptyColumnAriaLabel', { rank: emptyColPlaceholder })}
                               style={{ height: cardHeight }}
-                              className={`w-full rounded border-2 border-dashed border-white/20 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite}`}
+                              data-testid={`pg-empty-col-${colIdx.toString()}`}
+                              // 空き列だけ上限が低い。選んだ束が超えているなら、
+                              // クリックする前に分かるようにする (#5614)。
+                              data-empty-col-blocked={selectedStackSize > emptyColLimit ? 'true' : undefined}
+                              title={
+                                selectedStackSize > emptyColLimit
+                                  ? t('emptyColLimitTooltip', { limit: emptyColLimit, size: selectedStackSize })
+                                  : undefined
+                              }
+                              className={`w-full rounded border-2 border-dashed border-white/20 text-game-text-muted text-xs flex items-center justify-center ${focusRingWhite} ${
+                                selectedStackSize > emptyColLimit ? 'opacity-50' : ''
+                              }`}
                             >
                               {emptyColPlaceholder}
                             </button>

--- a/frontend/src/types/games/penguin.ts
+++ b/frontend/src/types/games/penguin.ts
@@ -18,6 +18,13 @@ export interface PenguinResponse extends BaseGameResponse {
   freeCells: (Card | null)[];
   foundation: Card[][];
   baseRank: number;
+  /** How many cards may move as one stack right now (from the domain). */
+  maxMovableCards: number;
+  /**
+   * The same limit when the destination is an empty column -- lower, because
+   * that column cannot also serve as a staging slot. 0 when there is none.
+   */
+  maxMovableCardsToEmptyColumn: number;
   phase: number;
   moveCount: number;
   canUndo: boolean;

--- a/frontend/src/utils/cli/formatters/penguinFormatter.test.ts
+++ b/frontend/src/utils/cli/formatters/penguinFormatter.test.ts
@@ -8,6 +8,8 @@ function makeState(overrides?: Partial<PenguinResponse>): PenguinResponse {
     freeCells: [null, null, null, null, null, null, null],
     foundation: [[], [], [], []],
     baseRank: 5,
+    maxMovableCards: 8,
+    maxMovableCardsToEmptyColumn: 4,
     phase: 0,
     moveCount: 0,
     canUndo: false,

--- a/frontend/src/utils/hints/penguinHint.test.ts
+++ b/frontend/src/utils/hints/penguinHint.test.ts
@@ -26,6 +26,8 @@ function makeState(overrides: Partial<PenguinResponse> = {}): PenguinResponse {
     freeCells: [card(S, 5), card(H, 5), card(D, 5), null, null, null, null],
     foundation: [[], [card(C, 5)], [], []],
     baseRank: 5,
+    maxMovableCards: 8,
+    maxMovableCardsToEmptyColumn: 4,
     phase: PenguinPhase.PLAYING,
     moveCount: 0,
     canUndo: false,

--- a/internal/adapter/controller/PenguinWebController.go
+++ b/internal/adapter/controller/PenguinWebController.go
@@ -34,11 +34,17 @@ type PenguinWebOutputHint struct {
 
 // PenguinWebOutput ペンギンWebアウトプット
 type PenguinWebOutput struct {
-	Tableau    [][]*WebOutputCard    `json:"tableau"`
-	FreeCells  []*WebOutputCard      `json:"freeCells"`
-	Foundation [][]*WebOutputCard    `json:"foundation"`
-	BaseRank   int                   `json:"baseRank"`
-	Hint       *PenguinWebOutputHint `json:"hint,omitempty"`
+	Tableau    [][]*WebOutputCard `json:"tableau"`
+	FreeCells  []*WebOutputCard   `json:"freeCells"`
+	Foundation [][]*WebOutputCard `json:"foundation"`
+	BaseRank   int                `json:"baseRank"`
+	// MaxMovableCards / MaxMovableCardsToEmptyColumn はドメインが決めた上限を
+	// そのまま運ぶ。フロントで数え直すと、空き列を経由地に使えない分の差
+	// (ドメインの maxMovableCards(toCol)) が抜け、動かせない束を「動かせる」と
+	// 表示してしまう (#5614)。
+	MaxMovableCards              int                   `json:"maxMovableCards"`
+	MaxMovableCardsToEmptyColumn int                   `json:"maxMovableCardsToEmptyColumn"`
+	Hint                         *PenguinWebOutputHint `json:"hint,omitempty"`
 	SolitaireWebOutputBase
 	WebOutputBase
 }

--- a/internal/adapter/presenter/PenguinWebPresenter.go
+++ b/internal/adapter/presenter/PenguinWebPresenter.go
@@ -50,6 +50,10 @@ func (p *PenguinWebPresenter) Output(pg interfaces.PenguinGame, lastErr error) s
 	// ベースランク
 	resObj.BaseRank = pg.GetBaseRank()
 
+	// 一度に動かせる枚数。空き列宛ては別枠 (#5614)。
+	resObj.MaxMovableCards = pg.GetMaxMovableCards()
+	resObj.MaxMovableCardsToEmptyColumn = pg.GetMaxMovableCardsToEmptyColumn()
+
 	// メッセージ
 	// **受動ヒントは Output() でも埋める。**HintOutput() は `command: "hint"`
 	// 専用のレスポンスで、ページの state にはマージされない。ここで埋めないと

--- a/internal/adapter/presenter/PenguinWebPresenter_test.go
+++ b/internal/adapter/presenter/PenguinWebPresenter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -95,6 +96,8 @@ func TestPenguinWebPresenterOutputStalemateWithEscape(t *testing.T) {
 	var foundation [domain.PenguinFoundationCnt][]*domain.Card
 	pg.On("GetFoundation").Return(foundation).Maybe()
 	pg.On("GetBaseRank").Return(1).Maybe()
+	pg.On("GetMaxMovableCards").Return(1).Maybe()
+	pg.On("GetMaxMovableCardsToEmptyColumn").Return(0).Maybe()
 	pg.On("GetActionLog").Return(nil).Maybe()
 	pg.On("GetGameEndFlag").Return(false).Maybe()
 
@@ -224,4 +227,43 @@ func TestPenguinWebPresenterActionLogGameOver(t *testing.T) {
 	err := json.Unmarshal([]byte(result), &out)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, out.Entries)
+}
+
+// #5614: 空き列へ動かすときの上限はドメインが別に持っており (その空き列自身を
+// 経由地に使えないぶん低い)、CUI は #4802 から毎ターン出している。Web の
+// レスポンスには**どちらの上限も入っていなかった**ので、ページは一般式で
+// 計算し直すしかなく、空き列宛ての手をサーバーが弾くまで気づけなかった。
+func TestPenguinWebPresenterCarriesBothMoveLimits(t *testing.T) {
+	p := new(PenguinWebPresenter)
+	g := domain.NewPenguin(domain.NewTrumpCards(0))
+	g.Reset()
+	g.SetPhase(domain.PenguinPhasePlaying)
+
+	var out controller.PenguinWebOutput
+	require.NoError(t, json.Unmarshal([]byte(p.Output(g, nil)), &out))
+
+	// **ドメインの値をそのまま運ぶ。**presenter で数え直すと、空き列の扱いが
+	// 食い違ったときに画面とサーバーで別の答えが出る。
+	assert.Equal(t, g.GetMaxMovableCards(), out.MaxMovableCards)
+	assert.Equal(t, g.GetMaxMovableCardsToEmptyColumn(), out.MaxMovableCardsToEmptyColumn)
+	assert.Positive(t, out.MaxMovableCards, "配り直後は必ず1枚以上動かせる")
+}
+
+// 空き列がある局面では、空き列宛ての上限が一般の上限より**低い**。
+// 同じ値が返るだけなら、フロントが低い方を使う意味が無い。
+func TestPenguinWebPresenterEmptyColumnLimitIsLower(t *testing.T) {
+	p := new(PenguinWebPresenter)
+	g := domain.NewPenguin(domain.NewTrumpCards(0))
+	g.Reset()
+	g.SetPhase(domain.PenguinPhasePlaying)
+	// 1 列空ける。
+	tableau := g.GetTableau()
+	tableau[0] = nil
+	g.SetTableau(tableau)
+
+	var out controller.PenguinWebOutput
+	require.NoError(t, json.Unmarshal([]byte(p.Output(g, nil)), &out))
+
+	assert.Less(t, out.MaxMovableCardsToEmptyColumn, out.MaxMovableCards,
+		"空き列自身を経由地に使えないぶん上限は下がる")
 }


### PR DESCRIPTION
## 背景

`Penguin.maxMovableCards(toCol)` は移動先が空き列のとき上限を下げる（その空き列自身を経由地に使えないため）。CUI は #4802 からこの値を毎ターン出しているが、**Web のレスポンスにはどちらの上限も入っていなかった**。そのため `PenguinPage.tsx` は `(1 + 空きセル) * 2 ** 空き列` の一般式で計算し直すしかなく、空き列宛ての束を「動かせる」と表示してサーバーに弾かれる食い違いが起こり得た。

## 変更

**上限はドメインが決め、フロントは運ばれた値を使う。**

- `PenguinWebOutput` に `maxMovableCards` / `maxMovableCardsToEmptyColumn`（presenter がドメインの値をそのまま入れる）
- `api/openapi.yaml` に両フィールド（required 込み。CRLF 維持を `git diff --numstat` で確認: 15/0）
- 型・ページ: バッジは `maxMovableCards` を表示し、空き列がある場合は低い方も併記。空き列のドロップ先は、選択中の束が超えていれば減光＋ツールチップで理由を出す
- 札そのものはブロックしない ── **他の列へは動かせる**ので、札を殺すのは行き過ぎ

## テスト

- presenter: 両方の上限がドメインの値と一致する / 空き列があるとき空き列上限の方が**低い**（同じ値なら分ける意味が無い）
- ページ: バッジがサーバーの値を出す（一般式なら 160 になる盤面で 8 と出る）/ 一般上限は超えないが空き列上限を超える束で空き列だけがブロック表示 / 収まるときはブロックしない

ミューテーション実測: 空き列判定を一般上限に変える→1 failed、ページで一般式に戻す→2 failed。

Closes #5614