### PR TITLE
feat(chinesepoker): 推奨の3/5/5分割をWebのヒントにも出す

### DIFF
--- a/frontend/src/pages/ChinesePokerPage.test.tsx
+++ b/frontend/src/pages/ChinesePokerPage.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../test/renderWithProviders';
 import type { Card, CardDesign, ChinesePokerResponse } from '../types/card';
 import { ChinesePokerPhase } from '../types/phases';
@@ -8,10 +8,11 @@ vi.mock('../api/gameApi', () => ({
   chinesepokerApi: { exec: vi.fn() },
 }));
 vi.mock('../hooks/useGameHint', () => ({
-  useGameHint: () => ({ hint: null, hintEnabled: false, setHintEnabled: vi.fn() }),
+  useGameHint: vi.fn(() => ({ hint: null, hintEnabled: false, setHintEnabled: vi.fn() })),
 }));
 
 import { chinesepokerApi } from '../api/gameApi';
+import { useGameHint } from '../hooks/useGameHint';
 import { flushPendingDispatch } from '../test/flushPendingDispatch';
 import { ChinesePokerPage } from './ChinesePokerPage';
 
@@ -249,5 +250,53 @@ describe('ChinesePokerPage', () => {
     expect(screen.queryByTestId('cp-foul-warning')).not.toBeInTheDocument();
     assignFrontMiddle([0, 1, 2, 3, 4, 5, 6, 7]);
     expect(screen.queryByTestId('cp-foul-warning')).not.toBeInTheDocument();
+  });
+});
+
+// #5615: ヒントは「ファウルの危険がある」としか言わず、**どの札をどこへ**は
+// プレイヤーの試行錯誤だった。サーバー (CUI と同じ計算) が前列に勧める札を
+// 名指しできるようになったので、その札を盤面で示す。
+describe('ChinesePokerPage suggested front row', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useGameHint).mockReturnValue({ hint: null, hintEnabled: false, setHintEnabled: vi.fn() });
+  });
+
+  it('marks the cards the hint names for the front row', async () => {
+    vi.mocked(useGameHint).mockReturnValue({
+      hint: {
+        targetAction: 'setHands',
+        reason: 'frontendHint.chinesepokerSplit',
+        confidence: 'moderate',
+        targetIndices: [10, 11, 12],
+      },
+      hintEnabled: true,
+      setHintEnabled: vi.fn(),
+    });
+    mockExec.mockResolvedValue(setHandsState);
+    renderWithProviders(<ChinesePokerPage />);
+
+    await waitFor(() => expect(screen.getByTestId('cp-hand-card-10')).toHaveAttribute('data-hint-front', 'true'));
+    expect(screen.getByTestId('cp-hand-card-12')).toHaveAttribute('data-hint-front', 'true');
+    // 名指しされていない札は印を持たない。
+    expect(screen.getByTestId('cp-hand-card-0')).not.toHaveAttribute('data-hint-front');
+  });
+
+  it('marks nothing while the hint is switched off', async () => {
+    vi.mocked(useGameHint).mockReturnValue({
+      hint: {
+        targetAction: 'setHands',
+        reason: 'frontendHint.chinesepokerSplit',
+        confidence: 'moderate',
+        targetIndices: [10, 11, 12],
+      },
+      hintEnabled: false,
+      setHintEnabled: vi.fn(),
+    });
+    mockExec.mockResolvedValue(setHandsState);
+    renderWithProviders(<ChinesePokerPage />);
+
+    await waitFor(() => expect(screen.getByTestId('cp-hand-card-10')).toBeInTheDocument());
+    expect(screen.getByTestId('cp-hand-card-10')).not.toHaveAttribute('data-hint-front');
   });
 });

--- a/frontend/src/pages/ChinesePokerPage.tsx
+++ b/frontend/src/pages/ChinesePokerPage.tsx
@@ -267,8 +267,16 @@ function ChinesePokerPageContent() {
                       key={`p-${card.design}-${card.value}-${i}`}
                       type="button"
                       data-testid={`cp-hand-card-${i}`}
+                      // サーバー (CUI と同じ計算) が前列に勧めた札を名指しする。
+                      // 「ファウルの危険がある」だけでは、どれを動かせばいいのか
+                      // プレイヤーが総当たりすることになる (#5615)。
+                      data-hint-front={hintEnabled && hint?.targetIndices?.includes(i) ? 'true' : undefined}
                       onClick={() => toggleCard(i)}
-                      className={`relative transition-transform ${ringClass(assignments[i])}`}
+                      className={`relative transition-transform ${ringClass(assignments[i])} ${
+                        hintEnabled && hint?.targetIndices?.includes(i) && !assignments[i]
+                          ? 'ring-2 ring-ds-warning rounded-lg'
+                          : ''
+                      }`}
                       aria-pressed={!!assignments[i]}
                       aria-label={
                         assignments[i]

--- a/frontend/src/types/games/chinesepoker.ts
+++ b/frontend/src/types/games/chinesepoker.ts
@@ -30,4 +30,18 @@ export interface ChinesePokerResponse extends BaseGameResponse {
   playerRoyalty: number;
   dealerRoyalty: number;
   scoop: boolean;
+  /**
+   * The split the server recommends, as indices into `playerCards`.
+   *
+   * Present only during SET_HANDS with a full hand. The CUI has printed this
+   * since #4717; the web page used to derive its own ranking instead, so the
+   * two surfaces could recommend different splits for the same hand (#5615).
+   */
+  suggestedArrangement?: {
+    front: number[];
+    middle: number[];
+    back: number[];
+    /** Whether that split fouls (front > middle, or middle > back). */
+    foul: boolean;
+  };
 }

--- a/frontend/src/utils/hints/chinesepokerHint.test.ts
+++ b/frontend/src/utils/hints/chinesepokerHint.test.ts
@@ -112,3 +112,31 @@ describe('getChinesePokerHint', () => {
     expect(getChinesePokerHint(base({ playerCards: LEGAL_HAND.slice(0, 5) }))).toBeNull();
   });
 });
+
+// #5615: ドメインの推奨分割 (CUI が #4717 から出しているもの) が Web にも
+// 届くようになった。**届いているなら、それを使う。**フロントで並べ直すと
+// 同じ手札で違う分け方を勧めることになる。
+describe('getChinesePokerHint with the server arrangement', () => {
+  it('points at the cards the server chose for the front row', () => {
+    const state = base({
+      suggestedArrangement: { front: [10, 11, 12], middle: [5, 6, 7, 8, 9], back: [0, 1, 2, 3, 4], foul: false },
+    });
+    const hint = getChinesePokerHint(state);
+    expect(hint?.targetIndices).toEqual([10, 11, 12]);
+    expect(hint?.reason).toBe('frontendHint.chinesepokerSplit');
+  });
+
+  it('warns when the server says its own split fouls', () => {
+    const state = base({
+      suggestedArrangement: { front: [10, 11, 12], middle: [5, 6, 7, 8, 9], back: [0, 1, 2, 3, 4], foul: true },
+    });
+    expect(getChinesePokerHint(state)?.reason).toBe('frontendHint.chinesepokerFoulRisk');
+  });
+
+  // 届いていないとき (古いサーバー等) は従来のフロント計算のまま。
+  it('falls back to its own ranking when the server sent nothing', () => {
+    const hint = getChinesePokerHint(base());
+    expect(hint?.targetAction).toBe('setHands');
+    expect(hint?.targetIndices).toBeUndefined();
+  });
+});

--- a/frontend/src/utils/hints/chinesepokerHint.ts
+++ b/frontend/src/utils/hints/chinesepokerHint.ts
@@ -42,6 +42,19 @@ export function getChinesePokerHint(state: ChinesePokerResponse): HintResult | n
   if (state.phase !== ChinesePokerPhase.SET_HANDS) return null;
   if (state.playerCards.length !== FULL_HAND) return null;
 
+  // **サーバーの案があるならそれを使う。**ドメインは同じ計算を CUI 向けに
+  // 出しており (#4717)、ここで並べ直すと同じ手札で違う分け方を勧めることに
+  // なる。targetIndices を付けるので、ページはどの札かを名指しできる (#5615)。
+  const suggested = state.suggestedArrangement;
+  if (suggested) {
+    return {
+      targetAction: 'setHands',
+      reason: suggested.foul ? 'frontendHint.chinesepokerFoulRisk' : 'frontendHint.chinesepokerSplit',
+      confidence: 'moderate',
+      targetIndices: suggested.front,
+    };
+  }
+
   const sorted = [...state.playerCards].sort((a, b) => rank(b) - rank(a));
   const back = sorted.slice(0, MIDDLE_SIZE);
   const middle = sorted.slice(MIDDLE_SIZE, MIDDLE_SIZE * 2);

--- a/internal/adapter/controller/ChinesePokerWebController.go
+++ b/internal/adapter/controller/ChinesePokerWebController.go
@@ -16,6 +16,18 @@ type ChinesePokerWebInput struct {
 	MiddleIndices []int `json:"middleIndices,omitempty"`
 }
 
+// ChinesePokerWebOutputArrangement は推奨する13枚の分け方。**インデックスは
+// playerCards のもの**で、カードそのものではない (フロントが手札の並びを
+// 変えても、同じ札を指し続ける)。
+type ChinesePokerWebOutputArrangement struct {
+	Front  []int `json:"front"`
+	Middle []int `json:"middle"`
+	Back   []int `json:"back"`
+	// Foul はこの分け方がファウルになるか。ランク順に切るだけでは合法とは
+	// 限らないので、勧めると同時に危険も伝える (#5615)。
+	Foul bool `json:"foul"`
+}
+
 // ChinesePokerWebOutput チャイニーズポーカーWebアウトプット
 type ChinesePokerWebOutput struct {
 	PlayerCards      []*WebOutputCard `json:"playerCards"`
@@ -43,6 +55,9 @@ type ChinesePokerWebOutput struct {
 	PlayerRoyalty    int              `json:"playerRoyalty"`
 	DealerRoyalty    int              `json:"dealerRoyalty"`
 	Scoop            bool             `json:"scoop"`
+	// SuggestedArrangement はセットハンドで13枚そろっているときだけ入る。
+	// 空配列ではなく省略するのは、「前列に置く札が無い」と読めてしまうため。
+	SuggestedArrangement *ChinesePokerWebOutputArrangement `json:"suggestedArrangement,omitempty"`
 	WebOutputBase
 }
 

--- a/internal/adapter/presenter/ChinesePokerWebPresenter.go
+++ b/internal/adapter/presenter/ChinesePokerWebPresenter.go
@@ -71,9 +71,9 @@ func (pp *ChinesePokerWebPresenter) Output(cp interfaces.ChinesePokerGame, lastE
 	return marshalOrError(resObj)
 }
 
-// HintOutput ヒントを出力する。Web ではヒントはクライアント側 (useGameHint) で
-// 算出するため、通常の状態出力を返す。ChinesePokerPresenter インタフェースを
-// 満たすための実装。
+// HintOutput ヒントを出力する。専用のレスポンスは持たず通常の状態出力を返すが、
+// **その状態に推奨分割 (SuggestedArrangement) が載っている** (#5615)。フロントの
+// useGameHint は、載っていればそれを使い、無いときだけ自前の計算に落ちる。
 func (cp *ChinesePokerWebPresenter) HintOutput(g interfaces.ChinesePokerGame) string {
 	return cp.Output(g, nil)
 }

--- a/internal/adapter/presenter/ChinesePokerWebPresenter.go
+++ b/internal/adapter/presenter/ChinesePokerWebPresenter.go
@@ -41,6 +41,8 @@ func (pp *ChinesePokerWebPresenter) Output(cp interfaces.ChinesePokerGame, lastE
 	resObj.PlayerRoyalty = cp.GetPlayerRoyalty()
 	resObj.DealerRoyalty = cp.GetDealerRoyalty()
 	resObj.Scoop = cp.GetScoop()
+	// 推奨分割はセットハンドで13枚そろっているときだけ入る (ドメイン側の判定)。
+	resObj.SuggestedArrangement = chinesePokerArrangementOutput(cp.GetSuggestedArrangement())
 
 	if lastErr != nil {
 		resObj.Message = lastErr.Error()
@@ -74,6 +76,21 @@ func (pp *ChinesePokerWebPresenter) Output(cp interfaces.ChinesePokerGame, lastE
 // 満たすための実装。
 func (cp *ChinesePokerWebPresenter) HintOutput(g interfaces.ChinesePokerGame) string {
 	return cp.Output(g, nil)
+}
+
+// chinesePokerArrangementOutput はドメインの推奨分割をレスポンス用に写す。
+// **並べ直さない。**presenter で組み直すと、CUI (#4717) と Web が同じ手札で
+// 違う分け方を勧めることになる (#5615)。
+func chinesePokerArrangementOutput(a *domain.ChinesePokerSuggestedArrangement) *controller.ChinesePokerWebOutputArrangement {
+	if a == nil {
+		return nil
+	}
+	return &controller.ChinesePokerWebOutputArrangement{
+		Front:  a.Front,
+		Middle: a.Middle,
+		Back:   a.Back,
+		Foul:   a.Foul,
+	}
 }
 
 // ActionLogOutput 棋譜をJSON出力

--- a/internal/adapter/presenter/ChinesePokerWebPresenter_test.go
+++ b/internal/adapter/presenter/ChinesePokerWebPresenter_test.go
@@ -101,3 +101,41 @@ func TestChinesePokerWebPresenter_ActionLogOutput(t *testing.T) {
 	result := pp.ActionLogOutput(cp)
 	assert.Contains(t, result, "[")
 }
+
+// #5615: CUI は #4717 から `GetSuggestedArrangement()` の具体的な分け方 (どの札を
+// どの列へ) とファウル警告を出しているのに、Web の HintOutput は Output() を
+// そのまま返すだけで、ページはフロント独自のランク降順スライスを使っていた。
+// 同じ盤面で違う答えが出る状態だった。
+func TestChinesePokerWebPresenterCarriesTheSuggestedArrangement(t *testing.T) {
+	pp := &ChinesePokerWebPresenter{}
+	cp := domain.NewDefaultChinesePoker()
+	require.NoError(t, cp.Bet(100))
+
+	var out controller.ChinesePokerWebOutput
+	require.NoError(t, json.Unmarshal([]byte(pp.HintOutput(cp)), &out))
+
+	want := cp.GetSuggestedArrangement()
+	require.NotNil(t, want, "セットハンドで13枚そろっていれば必ず案が出る")
+	require.NotNil(t, out.SuggestedArrangement)
+	// **ドメインの答えをそのまま運ぶ。**presenter で並べ直すと、CUI と Web が
+	// 同じ手札で違う分け方を勧めることになる。
+	assert.Equal(t, want.Front, out.SuggestedArrangement.Front)
+	assert.Equal(t, want.Middle, out.SuggestedArrangement.Middle)
+	assert.Equal(t, want.Back, out.SuggestedArrangement.Back)
+	assert.Equal(t, want.Foul, out.SuggestedArrangement.Foul)
+	// 3/5/5 の形も固定しておく (取り違えると列がずれる)。
+	assert.Len(t, out.SuggestedArrangement.Front, 3)
+	assert.Len(t, out.SuggestedArrangement.Middle, 5)
+	assert.Len(t, out.SuggestedArrangement.Back, 5)
+}
+
+// セットハンドでない (= 13枚そろっていない) ときは載せない。
+// 空の配列を返すと、フロントには「前列に置く札が無い」と読める。
+func TestChinesePokerWebPresenterOmitsTheArrangementOutsideSetHands(t *testing.T) {
+	pp := &ChinesePokerWebPresenter{}
+	cp := domain.NewDefaultChinesePoker()
+
+	var out controller.ChinesePokerWebOutput
+	require.NoError(t, json.Unmarshal([]byte(pp.HintOutput(cp)), &out))
+	assert.Nil(t, out.SuggestedArrangement)
+}


### PR DESCRIPTION
## 背景

`ChinesePoker.GetSuggestedArrangement()` は前列3・中列5・後列5のインデックスとファウル判定を返し、CUI は #4717 からこれを使って**具体的な札**を提示している。一方 `ChinesePokerWebPresenter.HintOutput()` は `Output()` をそのまま返すだけで、ページはフロント独自のランク降順スライスを使っていた。同じ手札に対して**2 つの実装が別々に答えを出す**状態で、Web 側は「ファウルの危険がある」という抽象的な警告しか受け取れなかった。

## 変更

- `ChinesePokerWebOutput` に `suggestedArrangement`（front/middle/back のインデックス + foul）。**カードではなくインデックス**にしたので、フロントが手札の並びを変えても同じ札を指し続ける
- セットハンドで13枚そろっているときだけ入れる（`omitempty`）。空配列で返すと「前列に置く札が無い」と読める
- `getChinesePokerHint`: 届いていればそれを使い、`targetIndices` に前列の札を入れる。**届いていなければ従来のフロント計算のまま**
- ページ: ヒントが有効なとき、名指しされた札にリングを出す

`/chinesepoker/exec` のレスポンスは openapi 上 `type: object` のみなので、スキーマ変更は不要（確認済み）。

## テスト

- presenter: レスポンスの分割がドメインの `GetSuggestedArrangement()` と**一致**する（3/5/5 の形も固定）/ セットハンド外では入らない
- hint: サーバー案があれば `targetIndices` が前列を指す / `foul` のときは警告文言 / 案が無ければ従来動作
- ページ: 名指しされた札だけに印が付く / ヒント OFF では付かない

ミューテーション実測: `targetIndices` を落とす→1 failed、`foul` を無視する→1 failed、ヒントのトグルを見ない→1 failed。

Closes #5615