### PR TITLE
fix(doudizhu): 地主表示をi18n経由にする

### DIFF
--- a/internal/adapter/presenter/DoudizhuCuiPresenter.go
+++ b/internal/adapter/presenter/DoudizhuCuiPresenter.go
@@ -44,7 +44,9 @@ func (p *DoudizhuCuiPresenter) Output(dg interfaces.DoudizhuGame, lastErr error)
 		if phase == domain.DoudizhuPhasePlay || phase == domain.DoudizhuPhaseEnd {
 			landlordIdx := dg.GetLandlordIdx()
 			if landlordIdx >= 0 {
-				fmt.Fprintf(b, "%s: Player %d\n", i18n.T("doudizhu.landlord"), landlordIdx)
+				// **名前は cuiPlayerName に通す。**ここだけ自前で組むと、
+				// 日本語ロケールでも "Player 2" と出て他の行と食い違う (#5617)。
+				fmt.Fprintf(b, "%s: %s\n", i18n.T("doudizhu.landlord"), cuiPlayerName(dg.GetPlayer(landlordIdx), landlordIdx))
 				fmt.Fprintf(b, "%s: %s\n", i18n.T("doudizhu.kittyCards"), cuiCardListStr(doudizhuCardSlice(dg.GetKittyCards())))
 			}
 

--- a/internal/adapter/presenter/DoudizhuCuiPresenter_test.go
+++ b/internal/adapter/presenter/DoudizhuCuiPresenter_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
@@ -79,4 +80,35 @@ func TestDoudizhuCuiPresenter_ActionLogOutput(t *testing.T) {
 
 	p := new(presenter.DoudizhuCuiPresenter)
 	assert.NotEmpty(t, p.ActionLogOutput(dg))
+}
+
+// #5617: 地主の行だけ `Player %d` を直接組み立てており、日本語ロケールでも
+// "Player 2" と出ていた。同じ画面の他の行は全部 cuiPlayerName を通っている。
+func TestDoudizhuCuiPresenterNamesTheLandlordLikeEveryOtherLine(t *testing.T) {
+	orig := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(orig)
+
+	t.Run("human landlord reads as you", func(t *testing.T) {
+		dg := newDoudizhuForPresenter()
+		dg.SetPhase(domain.DoudizhuPhasePlay)
+		dg.SetLandlordIdx(0) // 0 は人間
+		dg.SetCurrentTurn(0)
+
+		out := new(presenter.DoudizhuCuiPresenter).Output(dg, nil)
+		assert.Contains(t, out, i18n.T("doudizhu.landlord")+": "+i18n.T("cuiPlayerYou"))
+		// **英語の直書きが残っていないこと。**日本語ロケールで "Player 0" は出ない。
+		assert.NotContains(t, out, "Player 0")
+	})
+
+	t.Run("cpu landlord reads like the other cpu lines", func(t *testing.T) {
+		dg := newDoudizhuForPresenter()
+		dg.SetPhase(domain.DoudizhuPhasePlay)
+		dg.SetLandlordIdx(2)
+		dg.SetCurrentTurn(0)
+
+		out := new(presenter.DoudizhuCuiPresenter).Output(dg, nil)
+		assert.Contains(t, out, i18n.T("doudizhu.landlord")+": "+i18n.Tf("cuiPlayerCpu", "idx", "2"))
+		assert.NotContains(t, out, "Player 2")
+	})
 }


### PR DESCRIPTION
## 背景

`DoudizhuCuiPresenter.Output` の地主行だけが `fmt.Fprintf(b, "%s: Player %d\n", ...)` と英語を直書きしており、日本語ロケールでも `地主: Player 2` と出ていた。同じ画面の座席一覧は `cuiPlayerName` 経由で `CPU 2` / `あなた` と出るので、2 行のあいだで呼称が食い違う。

## 変更

`cuiPlayerName(dg.GetPlayer(landlordIdx), landlordIdx)` に置き換え。

## テスト

- 人間が地主のとき `地主: あなた`（`Player 0` が出ない）
- CPU が地主のとき `地主: CPU 2`（`Player 2` が出ない）

ミューテーション実測: 直書きに戻すと FAIL。

## 横断調査

同じ形を presenter 全体で探した結果:

- `EscobaWebPresenter.buildResultMessage` — コメントに「フォールバック (英語)」と明記された意図的なもの。据え置き
- `action_key_helper` ではなく `action_log_helper.go` — CUI 棋譜の見出し (`========== 棋譜 ==========`)、空メッセージ (`棋譜はありません。`)、プレイヤー名 (`Player %d`) が全部直書き。**全ゲーム共通**なので別 issue **#5977** で追跡

Closes #5617