### PR TITLE
feat(truco): マッチ目標点をCUIから設定できるようにする

### DIFF
--- a/docs/manual/cui/truco.md
+++ b/docs/manual/cui/truco.md
@@ -81,6 +81,7 @@ flowchart TD
 | `accept` | `a` | 宣言を受諾（Quiero） |
 | `decline` | `d` | 宣言を拒否（No Quiero） |
 | `next` | `n` | 次のバサ / マノへ進む |
+| `setmatchtarget <n>` | `sm` | マッチ目標点を変更してリセット（1〜60、既定 15） |
 | `hint` | `h` | ヒントを表示 |
 | `log` | `l` | 棋譜を表示 |
 | `quit` | `q` | ゲーム終了 |

--- a/internal/adapter/controller/TrucoCuiController.go
+++ b/internal/adapter/controller/TrucoCuiController.go
@@ -1,7 +1,10 @@
 package controller
 
 import (
+	"strconv"
+
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller/cuiutil"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/usecase"
 )
 
@@ -15,6 +18,25 @@ func NewTrucoCuiController(ti usecase.TrucoInteractorIF) *TrucoCuiController {
 	return &TrucoCuiController{ti: ti}
 }
 
+// setMatchTarget はマッチ目標点を設定してリセットする。
+// 値を文言に埋め込まず {{min}}/{{max}} で渡すのは、定数を変えたときに
+// メッセージだけ古いまま残るのを避けるため。
+func (c *TrucoCuiController) setMatchTarget(args []string) string {
+	if len(args) < 1 {
+		return invalidArg("targetScoreRequired")
+	}
+	v, err := strconv.Atoi(args[0])
+	if err != nil || v < domain.TrucoMinMatchTarget || v > domain.TrucoMaxMatchTarget {
+		return invalidArg("invalidTargetScoreRange",
+			"val", args[0],
+			"min", strconv.Itoa(domain.TrucoMinMatchTarget),
+			"max", strconv.Itoa(domain.TrucoMaxMatchTarget))
+	}
+	cfg := c.ti.GetConfig()
+	cfg.MatchTarget = v
+	return c.ti.ResetWithConfig(cfg)
+}
+
 // Exec コマンド実行
 // コマンド一覧:
 //
@@ -25,6 +47,7 @@ func NewTrucoCuiController(ti usecase.TrucoInteractorIF) *TrucoCuiController {
 //	a / accept       → 宣言を受諾 (Quiero)
 //	d / decline      → 宣言を拒否 (No Quiero)
 //	n / next         → 次のバサ / マノへ
+//	sm / setmatchtarget <n> → マッチ目標点を変更してリセット
 //	h / hint         → ヒント表示
 //	log / l          → 棋譜表示
 func (c *TrucoCuiController) Exec(command string) string {
@@ -36,7 +59,7 @@ func (c *TrucoCuiController) Exec(command string) string {
 		},
 		[]string{
 			"p", "play", "t", "truco", "a", "accept", "d", "decline",
-			"n", "next", "h", "hint", "log", "l",
+			"n", "next", "sm", "setmatchtarget", "h", "hint", "log", "l",
 		},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
@@ -48,6 +71,10 @@ func (c *TrucoCuiController) Exec(command string) string {
 				return c.ti.Respond(true), true
 			case "d", "decline":
 				return c.ti.Respond(false), true
+			case "sm", "setmatchtarget":
+				// **範囲はドメインの定数から取る。**Web (TrucoWebController) も同じ
+				// 定数でクランプしているので、両方の入り口で同じ値が通る (#5618)。
+				return c.setMatchTarget(args), true
 			case "n", "next":
 				return c.ti.Next(), true
 			default:

--- a/internal/adapter/controller/TrucoCuiController_test.go
+++ b/internal/adapter/controller/TrucoCuiController_test.go
@@ -3,6 +3,7 @@
 package controller_test
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -104,5 +105,56 @@ func TestTrucoCuiController_Exec(t *testing.T) {
 		got := controller.NewTrucoCuiController(newMock()).Exec("xyz")
 		assert.NotEqual(t, "bye.", got)
 		assert.NotEmpty(t, got)
+	})
+}
+
+// #5618: Web は SettingsPanel で目標点 (9/12/15/18/24/30) を選んで reset に
+// 渡せるのに、CUI には目標点を触るコマンドが 1 つも無く、既定の 15 でしか
+// 遊べなかった。
+func TestTrucoCuiControllerSetsTheMatchTarget(t *testing.T) {
+	// **既定と違う設定を持たせる。**既定のままだと「今の設定を読んで書き換える」が
+	// 「既定から作り直す」実装でも通ってしまい、何も確かめない。難易度は現状
+	// Normal しか無いので、目標点そのものを既定から動かして区別する。
+	current := domain.DefaultTrucoConfig()
+	current.MatchTarget = 30
+	newMock := func() *mockUsecases.MockTrucoInteractor {
+		m := new(mockUsecases.MockTrucoInteractor)
+		m.On("GetConfig").Return(current)
+		m.On("ResetWithConfig", mock.Anything).Return(`{"phase":0}`)
+		return m
+	}
+
+	for _, alias := range []string{"sm", "setmatchtarget"} {
+		t.Run(alias, func(t *testing.T) {
+			m := newMock()
+			c := controller.NewTrucoCuiController(m)
+
+			assert.Equal(t, `{"phase":0}`, c.Exec(alias+" 24"))
+			// **設定を書き換えてリセットする。**目標点だけ変えて他の設定は保つ。
+			m.AssertCalled(t, "ResetWithConfig", mock.MatchedBy(func(cfg domain.TrucoConfig) bool {
+				return cfg.MatchTarget == 24
+			}))
+			// **今の設定を土台にする。**既定から作り直すと、他の設定 (将来増える
+			// ぶんも含めて) が黙って戻る。
+			m.AssertCalled(t, "GetConfig")
+		})
+	}
+
+	t.Run("rejects a value outside the domain range", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewTrucoCuiController(m)
+
+		// 上限は domain.TrucoMaxMatchTarget。Web も同じ範囲でクランプしている。
+		out := c.Exec("sm " + strconv.Itoa(domain.TrucoMaxMatchTarget+1))
+		assert.Contains(t, out, strconv.Itoa(domain.TrucoMaxMatchTarget))
+		m.AssertNotCalled(t, "ResetWithConfig", mock.Anything)
+	})
+
+	t.Run("asks for the value when it is missing", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewTrucoCuiController(m)
+
+		assert.NotEmpty(t, c.Exec("sm"))
+		m.AssertNotCalled(t, "ResetWithConfig", mock.Anything)
 	})
 }

--- a/internal/adapter/controller/TrucoCuiController_test.go
+++ b/internal/adapter/controller/TrucoCuiController_test.go
@@ -150,6 +150,17 @@ func TestTrucoCuiControllerSetsTheMatchTarget(t *testing.T) {
 		m.AssertNotCalled(t, "ResetWithConfig", mock.Anything)
 	})
 
+	// **下限側も踏む。**上限だけだと、`v < min` を落としたミューテーションが
+	// どのテストにも捕まらない (レビュー #5979)。
+	t.Run("rejects a value below the domain range", func(t *testing.T) {
+		m := newMock()
+		c := controller.NewTrucoCuiController(m)
+
+		out := c.Exec("sm " + strconv.Itoa(domain.TrucoMinMatchTarget-1))
+		assert.Contains(t, out, strconv.Itoa(domain.TrucoMinMatchTarget))
+		m.AssertNotCalled(t, "ResetWithConfig", mock.Anything)
+	})
+
 	t.Run("asks for the value when it is missing", func(t *testing.T) {
 		m := newMock()
 		c := controller.NewTrucoCuiController(m)

--- a/internal/i18n/locales/en/common.json
+++ b/internal/i18n/locales/en/common.json
@@ -161,6 +161,7 @@
   "invalidBetAmount": "Invalid bet amount. Please enter a number.",
   "targetScoreRequired": "Target score is required.",
   "invalidTargetScore": "Invalid target score: {{val}}. Please enter 1 or more.",
+  "invalidTargetScoreRange": "Invalid target score: {{val}}. Use {{min}}-{{max}}.",
   "anteAmountRequired": "Ante amount is required.",
   "invalidAnteAmount": "Invalid ante amount. Please enter a number.",
   "playerCountRequired": "Player count is required (2-4).",

--- a/internal/i18n/locales/ja/common.json
+++ b/internal/i18n/locales/ja/common.json
@@ -161,6 +161,7 @@
   "invalidBetAmount": "無効なベット額です。数値を入力してください。",
   "targetScoreRequired": "目標スコアを指定してください。",
   "invalidTargetScore": "無効な目標スコアです: {{val}}。1 以上を指定してください。",
+  "invalidTargetScoreRange": "無効な目標スコアです: {{val}}。{{min}}-{{max}} を指定してください。",
   "anteAmountRequired": "アンティ額を指定してください。",
   "invalidAnteAmount": "無効なアンティ額です。数値を入力してください。",
   "playerCountRequired": "プレイヤー数を指定してください (2-4)。",

--- a/internal/infrastructure/games/docs_consistency_test.go
+++ b/internal/infrastructure/games/docs_consistency_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/infrastructure/games"
 )
 
@@ -477,4 +478,32 @@ func TestOpenAPIErrorResponseMatchesTheSuccessSchema(t *testing.T) {
 		t.Fatal("no path documented both a 200 and a 400 -- the parse found nothing to check")
 	}
 	t.Logf("checked %d paths", checked)
+}
+
+// TestTrucoManualMatchTargetRangeMatchesDomain guards the match-target range
+// printed in the Truco CUI manual against the domain constants the command
+// actually enforces.
+//
+// **数字を書いた場所は、書いた瞬間から古くなりうる。**#5618 のレビューで、
+// エラーメッセージからは定数を追い出したのにマニュアルの表には「1〜60、既定
+// 15」と直書きしたままだと指摘された。ここで突き合わせておけば、定数を動かした
+// 側がマニュアルの更新を忘れても CI で止まる。
+func TestTrucoManualMatchTargetRangeMatchesDomain(t *testing.T) {
+	const path = "docs/manual/cui/truco.md"
+
+	got := struct{ min, max, def int }{
+		min: readDocNumber(t, path, regexp.MustCompile(`マッチ目標点を変更してリセット（(\d+)〜\d+、既定 \d+）`)),
+		max: readDocNumber(t, path, regexp.MustCompile(`マッチ目標点を変更してリセット（\d+〜(\d+)、既定 \d+）`)),
+		def: readDocNumber(t, path, regexp.MustCompile(`マッチ目標点を変更してリセット（\d+〜\d+、既定 (\d+)）`)),
+	}
+
+	if got.min != domain.TrucoMinMatchTarget {
+		t.Errorf("%s: min %d, domain %d", path, got.min, domain.TrucoMinMatchTarget)
+	}
+	if got.max != domain.TrucoMaxMatchTarget {
+		t.Errorf("%s: max %d, domain %d", path, got.max, domain.TrucoMaxMatchTarget)
+	}
+	if got.def != domain.TrucoDefaultMatchTarget {
+		t.Errorf("%s: default %d, domain %d", path, got.def, domain.TrucoDefaultMatchTarget)
+	}
 }


### PR DESCRIPTION
## 背景

`TrucoPage.tsx` は設定パネルで目標点（9/12/15/18/24/30）を選び `reset` に渡せるが、`TrucoCuiController.Exec` には目標点を触るコマンドが 1 つも無く、`reset` は常に既存 config を使い回すだけだった。CUI プレイヤーは既定の 15 でしか遊べない。

## 変更

Rummy500 の `sl`/`setlimit` と同じ形で `sm` / `setmatchtarget <n>` を追加:

- 範囲は **ドメイン定数** `TrucoMinMatchTarget`〜`TrucoMaxMatchTarget`（1〜60）。`TrucoWebController` も同じ定数でクランプしているので、両方の入り口で同じ値が通る
- 範囲外メッセージは新キー `invalidTargetScoreRange` で、**数字を文言に埋め込まず** `{{min}}`/`{{max}}` を渡す（定数を変えたときにメッセージだけ古く残らない）
- `GetConfig()` を土台に目標点だけ差し替えて `ResetWithConfig`
- CUI マニュアルのコマンド表に追記

## テスト

- `sm 24` / `setmatchtarget 24` の両別名で `ResetWithConfig` に 24 が渡る
- **`GetConfig` が呼ばれること**も確認 ── 既定から作り直す実装だと他の設定が黙って戻るため（難易度は現状 Normal しか無く値で区別できないので、呼び出し自体を見る）
- 上限 +1 は拒否し、メッセージに上限値が出る。`ResetWithConfig` は呼ばれない
- 引数無しは要求メッセージ

ミューテーション実測: 上限チェックを外す→FAIL、`GetConfig` ではなく既定から作る→FAIL。

Closes #5618