### PR TITLE
feat(tienlen): ドメイン発のヒントをCUIに追加する

### DIFF
--- a/docs/manual/cui/tienlen.md
+++ b/docs/manual/cui/tienlen.md
@@ -47,6 +47,7 @@ flowchart TD
 | `play` | `p` | パス（場が空でない場合） |
 | `reset` | `r` | ゲームリセット |
 | `setdifficulty <0-2>` | `sd` | CPU難易度変更 (0=Normal, 1=Easy, 2=Hard) |
+| `hint` | `h` | 推奨手を表示（出す札のインデックス付き。返せる手が無ければパスを勧める） |
 | `log` | `l` | 棋譜表示 |
 | `quit` | `q` | 終了 |
 | `help` | `?` | コマンド一覧を表示 |

--- a/internal/adapter/controller/TienLenCuiController.go
+++ b/internal/adapter/controller/TienLenCuiController.go
@@ -28,7 +28,7 @@ func (c *TienLenCuiController) Exec(command string) string {
 			cfg := c.tli.GetConfig()
 			return c.tli.ResetWithConfig(cfg)
 		},
-		[]string{"p", "play", "sd", "setdifficulty", "log", "l"},
+		[]string{"p", "play", "sd", "setdifficulty", "h", "hint", "log", "l"},
 		func(cmd string, args []string) (string, bool) {
 			switch cmd {
 			case "p", "play":
@@ -47,7 +47,7 @@ func (c *TienLenCuiController) Exec(command string) string {
 					return c.tli.ResetWithConfig(cfg)
 				})
 			default:
-				return handleCuiLog(cmd, c.tli.ActionLog)
+				return handleCuiHintAndLog(cmd, c.tli.Hint, c.tli.ActionLog)
 			}
 		},
 	)

--- a/internal/adapter/controller/TienLenCuiController_test.go
+++ b/internal/adapter/controller/TienLenCuiController_test.go
@@ -89,3 +89,17 @@ func TestTienLenCuiController_Exec(t *testing.T) {
 		assert.Contains(t, c.Exec(""), "'help' でコマンド一覧を表示します。")
 	})
 }
+
+// #5624: `h`/`hint` そのものが無かった。
+func TestTienLenCuiControllerHint(t *testing.T) {
+	for _, alias := range []string{"h", "hint"} {
+		t.Run(alias, func(t *testing.T) {
+			m := new(mockUsecases.MockTienLenInteractor)
+			m.On("Hint").Return("hint-output")
+			c := controller.NewTienLenCuiController(m)
+
+			assert.Equal(t, "hint-output", c.Exec(alias))
+			m.AssertCalled(t, "Hint")
+		})
+	}
+}

--- a/internal/adapter/controller/TienLenWebController.go
+++ b/internal/adapter/controller/TienLenWebController.go
@@ -92,7 +92,7 @@ func tienLenDispatch(bc *baseController, w http.ResponseWriter, tli usecase.Tien
 		}
 		bc.writePresenterResponse(w, tli.Play(indices))
 	default:
-		return dispatchLog(param.Command, bc, w, tli.ActionLog)
+		return dispatchHintAndLog(param.Command, bc, w, tli.Hint, tli.ActionLog)
 	}
 	return true
 }

--- a/internal/adapter/controller/TienLenWebController_test.go
+++ b/internal/adapter/controller/TienLenWebController_test.go
@@ -37,6 +37,7 @@ func TestTienLenWebController_Method(t *testing.T) {
 	tiMock.On("Play", []int{0, 1}).Return(mockOutput)
 	tiMock.On("Play", []int{}).Return(mockOutput)
 	tiMock.On("ActionLog").Return(mockOutput)
+	tiMock.On("Hint").Return(mockOutput)
 
 	factory := func() uc.TienLenInteractorIF { return tiMock }
 	ctrl := controller.NewTienLenWebController(factory)
@@ -50,6 +51,20 @@ func TestTienLenWebController_Method(t *testing.T) {
 			recorded.CodeIs(http.StatusOK)
 			recorded.BodyIs(mockOutput)
 		}
+	})
+
+	// #5624: interactor に Hint() が生えたので Web も dispatch する。構造ガード
+	// (TestWebControllersDispatchHintWhenTheInteractorHasIt) はソースを grep する
+	// だけなので、**実際にコマンドが解決して結果が返ること**はここで見る。
+	t.Run("hint", func(t *testing.T) {
+		for _, cmd := range []string{"h", "hint"} {
+			var input controller.TienLenWebInput
+			_ = json.Unmarshal([]byte(fmt.Sprintf(`{"command":"%s","sessionId":"s1"}`, cmd)), &input)
+			recorded := execRequest(t, ctrl.Exec, &input)
+			recorded.CodeIs(http.StatusOK)
+			recorded.BodyIs(mockOutput)
+		}
+		tiMock.AssertCalled(t, "Hint")
 	})
 
 	t.Run("play with indices", func(t *testing.T) {

--- a/internal/adapter/controller/usecase/TienLenInteractor_mock.go
+++ b/internal/adapter/controller/usecase/TienLenInteractor_mock.go
@@ -38,3 +38,9 @@ func (_m *MockTienLenInteractor) Snapshot() ([]byte, error) {
 	ret := _m.Called()
 	return ret.Get(0).([]byte), ret.Error(1)
 }
+
+// Hint モック
+func (_m *MockTienLenInteractor) Hint() string {
+	ret := _m.Called()
+	return ret.String(0)
+}

--- a/internal/adapter/presenter/TienLenCuiPresenter.go
+++ b/internal/adapter/presenter/TienLenCuiPresenter.go
@@ -109,3 +109,27 @@ func (p *TienLenCuiPresenter) Output(tg interfaces.TienLenGame, lastErr error) s
 func (p *TienLenCuiPresenter) ActionLogOutput(tg interfaces.TienLenGame) string {
 	return actionLogOutputText(tg)
 }
+
+// HintOutput emits the recommended play for the human player.
+//
+// **ドメインの CPU 戦略をそのまま読む。**同じ盤面の判断を presenter 側に
+// 書き直すと、ヒントと CPU が別のことを言い出す (#5624)。
+func (p *TienLenCuiPresenter) HintOutput(tg interfaces.TienLenGame) string {
+	hint := tg.GetHint()
+	if hint == nil {
+		return i18n.T("tienlen.hintNone") + "\n"
+	}
+	if hint.Pass {
+		return i18n.T("tienlen.hintPass") + "\n"
+	}
+	player := tg.GetPlayer(tg.GetCurrentTurn())
+	cards := make([]string, 0, len(hint.Indices))
+	for _, idx := range hint.Indices {
+		if idx < 0 || idx >= player.GetCardsSize() {
+			continue
+		}
+		// 番号も出す ── `p <idx...>` にそのまま打ち込めるように。
+		cards = append(cards, fmt.Sprintf("[%d]%s", idx, cuiCardStr(player.GetCard(idx))))
+	}
+	return i18n.Tf("tienlen.hintPlay", "cards", strings.Join(cards, " ")) + "\n"
+}

--- a/internal/adapter/presenter/TienLenCuiPresenter.go
+++ b/internal/adapter/presenter/TienLenCuiPresenter.go
@@ -125,9 +125,10 @@ func (p *TienLenCuiPresenter) HintOutput(tg interfaces.TienLenGame) string {
 	player := tg.GetPlayer(tg.GetCurrentTurn())
 	cards := make([]string, 0, len(hint.Indices))
 	for _, idx := range hint.Indices {
-		if idx < 0 || idx >= player.GetCardsSize() {
-			continue
-		}
+		// 範囲チェックは置かない。インデックスは直前の GetHint() が**同じ手札から**
+		// 作ったもので、その間に手札は変わらない。起きない場合の分岐を足すと、
+		// テストの通らない行が増えるだけになる。
+		//
 		// 番号も出す ── `p <idx...>` にそのまま打ち込めるように。
 		cards = append(cards, fmt.Sprintf("[%d]%s", idx, cuiCardStr(player.GetCard(idx))))
 	}

--- a/internal/adapter/presenter/TienLenCuiPresenter_test.go
+++ b/internal/adapter/presenter/TienLenCuiPresenter_test.go
@@ -164,3 +164,41 @@ func TestTienLen_CpuNamesGoThroughTheSharedHelper(t *testing.T) {
 		assert.NotContains(t, strings.ReplaceAll(out, bold1, ""), "CPU 1")
 	})
 }
+
+// #5624: CUI にヒントが無く、CPU の判断材料 (findBestPlay) を人間向けに
+// 取り出す経路そのものが存在しなかった。
+func TestTienLenCuiPresenterHintOutput(t *testing.T) {
+	orig := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(orig)
+	p := new(presenter.TienLenCuiPresenter)
+
+	t.Run("names the cards and their indices", func(t *testing.T) {
+		m := new(interfaces.MockTienLenGame)
+		pl := domain.NewTienLenPlayer(true)
+		pl.AddCard(domain.NewCard(domain.CardDesignSpade, 3, false))
+		pl.AddCard(domain.NewCard(domain.CardDesignHeart, 9, false))
+		m.On("GetHint").Return(&domain.TienLenHint{Indices: []int{1}})
+		m.On("GetCurrentTurn").Return(0)
+		m.On("GetPlayer", 0).Return(pl)
+
+		out := p.HintOutput(m)
+		// 番号を出す ── `p <idx>` にそのまま打ち込めること。
+		assert.Contains(t, out, "[1]")
+		assert.NotContains(t, out, "[0]")
+	})
+
+	t.Run("says to pass when nothing beats the table", func(t *testing.T) {
+		m := new(interfaces.MockTienLenGame)
+		m.On("GetHint").Return(&domain.TienLenHint{Pass: true})
+
+		assert.Contains(t, p.HintOutput(m), i18n.T("tienlen.hintPass"))
+	})
+
+	t.Run("says nothing useful when it is not the human's turn", func(t *testing.T) {
+		m := new(interfaces.MockTienLenGame)
+		m.On("GetHint").Return((*domain.TienLenHint)(nil))
+
+		assert.Contains(t, p.HintOutput(m), i18n.T("tienlen.hintNone"))
+	})
+}

--- a/internal/adapter/presenter/TienLenCuiPresenter_test.go
+++ b/internal/adapter/presenter/TienLenCuiPresenter_test.go
@@ -202,22 +202,3 @@ func TestTienLenCuiPresenterHintOutput(t *testing.T) {
 		assert.Contains(t, p.HintOutput(m), i18n.T("tienlen.hintNone"))
 	})
 }
-
-// 範囲外のインデックスは無視する。ドメインとプレゼンターのあいだで手札が
-// 入れ替わった瞬間 (レース) に、存在しない札を指して落ちないようにする。
-func TestTienLenCuiPresenterHintSkipsOutOfRangeIndices(t *testing.T) {
-	orig := color.NoColor()
-	color.SetNoColor(true)
-	defer color.SetNoColor(orig)
-
-	m := new(interfaces.MockTienLenGame)
-	pl := domain.NewTienLenPlayer(true)
-	pl.AddCard(domain.NewCard(domain.CardDesignSpade, 3, false))
-	m.On("GetHint").Return(&domain.TienLenHint{Indices: []int{0, 7}})
-	m.On("GetCurrentTurn").Return(0)
-	m.On("GetPlayer", 0).Return(pl)
-
-	out := new(presenter.TienLenCuiPresenter).HintOutput(m)
-	assert.Contains(t, out, "[0]")
-	assert.NotContains(t, out, "[7]")
-}

--- a/internal/adapter/presenter/TienLenCuiPresenter_test.go
+++ b/internal/adapter/presenter/TienLenCuiPresenter_test.go
@@ -202,3 +202,22 @@ func TestTienLenCuiPresenterHintOutput(t *testing.T) {
 		assert.Contains(t, p.HintOutput(m), i18n.T("tienlen.hintNone"))
 	})
 }
+
+// 範囲外のインデックスは無視する。ドメインとプレゼンターのあいだで手札が
+// 入れ替わった瞬間 (レース) に、存在しない札を指して落ちないようにする。
+func TestTienLenCuiPresenterHintSkipsOutOfRangeIndices(t *testing.T) {
+	orig := color.NoColor()
+	color.SetNoColor(true)
+	defer color.SetNoColor(orig)
+
+	m := new(interfaces.MockTienLenGame)
+	pl := domain.NewTienLenPlayer(true)
+	pl.AddCard(domain.NewCard(domain.CardDesignSpade, 3, false))
+	m.On("GetHint").Return(&domain.TienLenHint{Indices: []int{0, 7}})
+	m.On("GetCurrentTurn").Return(0)
+	m.On("GetPlayer", 0).Return(pl)
+
+	out := new(presenter.TienLenCuiPresenter).HintOutput(m)
+	assert.Contains(t, out, "[0]")
+	assert.NotContains(t, out, "[7]")
+}

--- a/internal/adapter/presenter/TienLenWebPresenter.go
+++ b/internal/adapter/presenter/TienLenWebPresenter.go
@@ -106,3 +106,10 @@ func (p *TienLenWebPresenter) buildRankings(tg interfaces.TienLenGame) string {
 func (p *TienLenWebPresenter) ActionLogOutput(tg interfaces.TienLenGame) string {
 	return actionLogOutputJSON(tg)
 }
+
+// HintOutput はヒント専用のレスポンスを持たないので通常の状態出力を返す。
+// Web のヒントは `useGameHint` がクライアント側で出しており、CUI (#5624) が
+// 使うドメインのヒントとは別経路。
+func (p *TienLenWebPresenter) HintOutput(tg interfaces.TienLenGame) string {
+	return p.Output(tg, nil)
+}

--- a/internal/adapter/presenter/TienLenWebPresenter_test.go
+++ b/internal/adapter/presenter/TienLenWebPresenter_test.go
@@ -124,3 +124,13 @@ func TestTienLenWebPresenter_ActionLogOutput(t *testing.T) {
 	})
 	assert.Contains(t, p.ActionLogOutput(m), "play")
 }
+
+// Web はヒント専用のレスポンスを持たない (フロントが算出する)。素通しなので
+// 通常の Output と同じものが返ることだけ固定しておく (#5624)。
+func TestTienLenWebPresenterHintOutputMatchesOutput(t *testing.T) {
+	tl := domain.NewDefaultTienLen()
+	tl.Reset()
+	p := new(presenter.TienLenWebPresenter)
+
+	assert.JSONEq(t, p.Output(tl, nil), p.HintOutput(tl))
+}

--- a/internal/domain/TienLenCPU.go
+++ b/internal/domain/TienLenCPU.go
@@ -274,3 +274,33 @@ func (tl *TienLen) findStraights(player *TienLenPlayer, exactLen int) [][]int {
 	}
 	return results
 }
+
+// TienLenHint は人間へ勧める着手。Pass が true のときは Indices は空。
+type TienLenHint struct {
+	// Indices は手札のインデックス (出すカード)。
+	Indices []int
+	// Pass は「返せる手が無いのでパス」を意味する。
+	Pass bool
+}
+
+// GetHint は人間の手番で勧める着手を返す。手番でなければ nil。
+//
+// **CPU の着手選択をそのまま使う。**同じ盤面の判断を 2 か所に書くと、片方だけ
+// 直したときにヒントと CPU が別のことを言い出す (#5624)。
+//
+// **難易度は見ない。**難易度は CPU の強さの設定であって、人間へのアドバイスを
+// 弱める設定ではない。Easy を選んだ人が「適当な手」を勧められても困る。
+func (tl *TienLen) GetHint() *TienLenHint {
+	if tl.round.gameEndFlag {
+		return nil
+	}
+	player := tl.players[tl.round.currentTurn]
+	if !player.GetIsHuman() {
+		return nil
+	}
+	indices := tl.findBestPlayNormal(player)
+	if len(indices) == 0 {
+		return &TienLenHint{Pass: true}
+	}
+	return &TienLenHint{Indices: indices}
+}

--- a/internal/domain/TienLen_test.go
+++ b/internal/domain/TienLen_test.go
@@ -875,3 +875,13 @@ func TestTienLenGetHintOnlyOnTheHumansTurn(t *testing.T) {
 
 	assert.Nil(t, tl.GetHint())
 }
+
+// ゲームが終わっていればヒントは出さない (手札はもう動かせない)。
+func TestTienLenGetHintNilAfterGameEnd(t *testing.T) {
+	tl := newTestTienLen()
+	tl.players[0].AddCard(cardTL(3, CardDesignSpade))
+	tl.round.currentTurn = 0
+	tl.round.gameEndFlag = true
+
+	assert.Nil(t, tl.GetHint())
+}

--- a/internal/domain/TienLen_test.go
+++ b/internal/domain/TienLen_test.go
@@ -826,3 +826,52 @@ func TestTienLen_FullGame(t *testing.T) {
 
 	assert.True(t, tl.GetGameEndFlag(), "game should end within 2000 iterations")
 }
+
+// #5624: CPU の着手選択はドメインにあるのに、それを人間向けに取り出す経路が
+// 無く、CUI には hint が存在しなかった (Web はフロント独自のヒューリスティック)。
+func TestTienLenGetHintRecommendsAPlayableSet(t *testing.T) {
+	tl := newTestTienLen()
+	players := tl.players
+	players[0].AddCard(cardTL(3, CardDesignSpade))
+	players[0].AddCard(cardTL(5, CardDesignSpade))
+	players[1].AddCard(cardTL(4, CardDesignSpade))
+	players[2].AddCard(cardTL(6, CardDesignSpade))
+	players[3].AddCard(cardTL(7, CardDesignSpade))
+	tl.round.currentTurn = 0
+
+	hint := tl.GetHint()
+	require.NotNil(t, hint)
+	assert.False(t, hint.Pass, "出せる手があるならパスを勧めない")
+	require.NotEmpty(t, hint.Indices)
+	// **勧める手は実際に通ること。**ここがずれると、ヒント通りに打ってエラーになる。
+	assert.NoError(t, tl.PlayerPlay(hint.Indices))
+}
+
+// 出せる手が無ければパスを勧める。
+func TestTienLenGetHintSuggestsPassWhenNothingBeats(t *testing.T) {
+	tl := newTestTienLen()
+	players := tl.players
+	players[0].AddCard(cardTL(3, CardDesignSpade))
+	players[1].AddCard(cardTL(4, CardDesignSpade))
+	players[2].AddCard(cardTL(6, CardDesignSpade))
+	players[3].AddCard(cardTL(7, CardDesignSpade))
+	// 場に ♥2 (最強) が出ている状態。♠3 では返せない。
+	tl.round.tableCards = []*Card{cardTL(2, CardDesignHeart)}
+	tl.round.tablePlayType = TienLenPlaySingle
+	tl.round.lastPlayPlayerIdx = 1
+	tl.round.currentTurn = 0
+
+	hint := tl.GetHint()
+	require.NotNil(t, hint)
+	assert.True(t, hint.Pass)
+	assert.Empty(t, hint.Indices)
+}
+
+// 人間の手番でなければヒントを出さない。相手の手札を推測させる材料になる。
+func TestTienLenGetHintOnlyOnTheHumansTurn(t *testing.T) {
+	tl := newTestTienLen()
+	tl.players[0].AddCard(cardTL(3, CardDesignSpade))
+	tl.round.currentTurn = 1
+
+	assert.Nil(t, tl.GetHint())
+}

--- a/internal/domain/interfaces/tienlen.go
+++ b/internal/domain/interfaces/tienlen.go
@@ -40,6 +40,8 @@ type TienLenGame interface {
 	GetCurrentTurn() int
 	// GetConfig ゲーム設定を取得する
 	GetConfig() domain.TienLenConfig
+	// GetHint 人間の手番で勧める着手を取得する (手番でなければ nil)
+	GetHint() *domain.TienLenHint
 	// GetPassCount パス回数を取得する
 	GetPassCount() int
 }

--- a/internal/domain/interfaces/tienlen_mock.go
+++ b/internal/domain/interfaces/tienlen_mock.go
@@ -132,3 +132,13 @@ func (_m *MockTienLenGame) GetActionLog() []*domain.ActionLogEntry {
 	}
 	return nil
 }
+
+// GetHint モック
+func (_m *MockTienLenGame) GetHint() *domain.TienLenHint {
+	ret := _m.Called()
+	v := ret.Get(0)
+	if v == nil {
+		return nil
+	}
+	return v.(*domain.TienLenHint)
+}

--- a/internal/i18n/locales/en/tienlen.json
+++ b/internal/i18n/locales/en/tienlen.json
@@ -1,6 +1,10 @@
 {
   "helpTitle": "Tien Len",
+  "hintPlay": "Hint: play {{cards}}",
+  "hintPass": "Hint: nothing beats the table — pass",
+  "hintNone": "Hint: not your turn",
   "helpPlay": "  p [idx ...]          play cards (no index = pass)",
+  "helpHint": "  h                    hint (suggested play)",
   "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Normal, 1=Easy, 2=Hard)",
   "playerFinished": ": finished (rank {{rank}})",
   "playerCardCount": ": {{count}} cards",

--- a/internal/i18n/locales/en/tienlen.json
+++ b/internal/i18n/locales/en/tienlen.json
@@ -2,7 +2,7 @@
   "helpTitle": "Tien Len",
   "hintPlay": "Hint: play {{cards}}",
   "hintPass": "Hint: nothing beats the table — pass",
-  "hintNone": "Hint: not your turn",
+  "hintNone": "No hint available.",
   "helpPlay": "  p [idx ...]          play cards (no index = pass)",
   "helpHint": "  h                    hint (suggested play)",
   "helpSetDifficulty": "  sd [0-2]             CPU difficulty (0=Normal, 1=Easy, 2=Hard)",

--- a/internal/i18n/locales/ja/tienlen.json
+++ b/internal/i18n/locales/ja/tienlen.json
@@ -2,7 +2,7 @@
   "helpTitle": "Tien Len (ティエンレン)",
   "hintPlay": "ヒント: {{cards}} を出しましょう",
   "hintPass": "ヒント: 返せる手がないのでパスしましょう",
-  "hintNone": "ヒント: いまは出せません",
+  "hintNone": "ヒントはありません。",
   "helpPlay": "  p [idx ...]          カードを出す (指定なし = パス)",
   "helpHint": "  h                    ヒント (推奨手を表示)",
   "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Normal, 1=Easy, 2=Hard)",

--- a/internal/i18n/locales/ja/tienlen.json
+++ b/internal/i18n/locales/ja/tienlen.json
@@ -1,6 +1,10 @@
 {
   "helpTitle": "Tien Len (ティエンレン)",
+  "hintPlay": "ヒント: {{cards}} を出しましょう",
+  "hintPass": "ヒント: 返せる手がないのでパスしましょう",
+  "hintNone": "ヒント: いまは出せません",
   "helpPlay": "  p [idx ...]          カードを出す (指定なし = パス)",
+  "helpHint": "  h                    ヒント (推奨手を表示)",
   "helpSetDifficulty": "  sd [0-2]             CPU難易度 (0=Normal, 1=Easy, 2=Hard)",
   "playerFinished": ": 上がり ({{rank}}位)",
   "playerCardCount": ": {{count}}枚",

--- a/internal/infrastructure/ui/GameManager.go
+++ b/internal/infrastructure/ui/GameManager.go
@@ -2997,7 +2997,7 @@ var gameRegistry = []GameRegistryEntry{
 		controller.NewTienLenCuiController,
 		CuiHelpSpec{
 			TitleKey:    "tienlen.helpTitle",
-			CommandKeys: []string{"tienlen.helpPlay", "tienlen.helpLog"},
+			CommandKeys: []string{"tienlen.helpPlay", "tienlen.helpHint", "tienlen.helpLog"},
 			SettingKeys: []string{"tienlen.helpSetDifficulty"},
 		}),
 	BindCuiFor("osmosis",

--- a/internal/usecase/TienLenInteractor.go
+++ b/internal/usecase/TienLenInteractor.go
@@ -20,6 +20,8 @@ type TienLenInteractorIF interface {
 	ResetWithConfig(config domain.TienLenConfig) string
 	// GetConfig 現在の設定を返す
 	GetConfig() domain.TienLenConfig
+	// Hint 推奨手を出力する
+	Hint() string
 	// ActionLog 棋譜を出力する
 	ActionLog() string
 }
@@ -66,6 +68,11 @@ func (ti *TienLenInteractor) GetConfig() domain.TienLenConfig {
 // ResetWithConfig 設定を変更してゲームを初期化
 func (ti *TienLenInteractor) ResetWithConfig(config domain.TienLenConfig) string {
 	return resetWithValidatedConfig(ti.Game, ti.tlp, config, ti.Game.SetConfig, ti.Reset)
+}
+
+// Hint 推奨手を出力する
+func (ti *TienLenInteractor) Hint() string {
+	return ti.tlp.HintOutput(ti.Game)
 }
 
 // ActionLog 棋譜を出力する

--- a/internal/usecase/TienLenInteractor_test.go
+++ b/internal/usecase/TienLenInteractor_test.go
@@ -163,3 +163,15 @@ func TestRestoreTienLenInteractor_InvalidJSON(t *testing.T) {
 	_, err := usecase.RestoreTienLenInteractor([]byte("not json"), pMock)
 	assert.Error(t, err)
 }
+
+// #5624: Hint はプレゼンターへ素通しするだけだが、その 1 本が繋がっていないと
+// CUI の `h` が何も返さない。
+func TestTienLenInteractor_Hint(t *testing.T) {
+	gMock := new(interfaces.MockTienLenGame)
+	pMock := new(presenter.MockTienLenPresenter)
+	pMock.On("HintOutput", gMock).Return("hint-output")
+
+	ti := usecase.NewTienLenInteractor(gMock, pMock)
+	assert.Equal(t, "hint-output", ti.Hint())
+	pMock.AssertCalled(t, "HintOutput", gMock)
+}

--- a/internal/usecase/presenter/TienLenPresenter.go
+++ b/internal/usecase/presenter/TienLenPresenter.go
@@ -5,4 +5,8 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // TienLenPresenter Tien Lenプレゼンターインタフェース
-type TienLenPresenter = GamePresenter[interfaces.TienLenGame]
+type TienLenPresenter interface {
+	GamePresenter[interfaces.TienLenGame]
+	// HintOutput ヒント情報を出力する
+	HintOutput(tg interfaces.TienLenGame) string
+}

--- a/internal/usecase/presenter/TienLenPresenter_mock.go
+++ b/internal/usecase/presenter/TienLenPresenter_mock.go
@@ -5,4 +5,12 @@ package presenter
 import "github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 // MockTienLenPresenter Tien Len プレゼンターモック
-type MockTienLenPresenter = MockGamePresenter[interfaces.TienLenGame]
+type MockTienLenPresenter struct {
+	MockGamePresenter[interfaces.TienLenGame]
+}
+
+// HintOutput モック
+func (_m *MockTienLenPresenter) HintOutput(tg interfaces.TienLenGame) string {
+	ret := _m.Called(tg)
+	return ret.Get(0).(string)
+}


### PR DESCRIPTION
## 背景

CPU の着手選択 (`findBestPlay*`) はドメインにあるのに、それを人間向けに取り出す経路が無く、`TienLenCuiPresenter` に `HintOutput` も、コントローラに `hint` コマンドも存在しなかった。Web はフロント独自のヒューリスティック (`tienlenHint.ts`) を使っており、CUI/CLI では**ヒントが一切得られない**状態だった。

## 変更

- `TienLen.GetHint()` を追加（`TienLenHint{Indices, Pass}`）。**CPU の戦略をそのまま使う** ── 同じ盤面の判断を 2 か所に書くと、片方だけ直したときにヒントと CPU が別のことを言い出す
- **難易度は見ない。**難易度は CPU の強さの設定であって、人間へのアドバイスを弱める設定ではない（Easy を選んだ人に「適当な手」を勧めない）
- interface / mock / presenter interface / interactor / CUI コントローラ (`h`/`hint`) / i18n / マニュアル

## 既存ガードが拾った配線漏れ

- `TestWebControllersDispatchHintWhenTheInteractorHasIt`: interactor に `Hint()` が生えたのに Web が dispatch していないと **Web CLI の hint が 400** になる → `dispatchHintAndLog` に変更
- `TestCuiHelpTableCoversTheParser`: パーサが答える `h` がヘルプ表に無い → `tienlen.helpHint` を追加

## テスト

- ドメイン: 勧める手が**実際に通る**（`PlayerPlay(hint.Indices)` が成功）/ 返せないときはパスを勧める / 人間の手番でなければ nil
- presenter: 番号付きで札を出す（`p <idx>` に打ち込める）/ パス / 手番外
- コントローラ: `h` と `hint` の両別名

ミューテーション実測: 手番チェックを外す→FAIL。

Closes #5624