### PR TITLE
test(cui): ヒントの返事を拒否と読まないようにする

### DIFF
--- a/internal/infrastructure/ui/help_example_exec_test.go
+++ b/internal/infrastructure/ui/help_example_exec_test.go
@@ -213,6 +213,15 @@ func TestCuiHelpExamplesAreNotQuietlyRefused(t *testing.T) {
 			if cmd == "" {
 				continue
 			}
+			// **ヒントの返事は拒否ではない。**「フォローできないので低い札を捨てる」
+			// のような助言は、拒否を探す語 (cannot / できません / no ... to) を
+			// 普通に含む。実測でヒント文字列 307 個がこの正規表現に当たり、
+			// acesup の `h` は「配りが手詰まりのときだけ」その文を返すので、
+			// **配り依存で 1/3 ほど落ちる**フレークになっていた (#5620)。
+			// コマンドがヒントなら返事は定義上ヒントなので、ここでは測らない。
+			if cmd == "h" || cmd == "hint" {
+				continue
+			}
 			checked++
 			out := ctrl.Exec(cmd)
 			if _, isErr := i18n.StripErrorPrefix(out); isErr {


### PR DESCRIPTION
## 背景

`TestCuiHelpExamplesAreNotQuietlyRefused` が **フルパッケージ実行の 1/3 ほどで落ちる**状態でした（実測）。

```
examples the game turns down without marking it (1 of 404):
  acesup: `h` -> Hint: deal a card to each column
Why: no move is available, so deal one card from the stock to each column.
```

原因は私が #5620 で足した英文です。ガードは `cannot` / `できません` / `no ... to` といった**拒否の語**で判定しますが、助言は普通にその語を含みます。実測でロケール中の**ヒント文字列 307 個**が同じ正規表現に当たります。これまで表面化しなかったのは、その文を返すのが「配りが手詰まりのとき」だけだったからで、配り依存のフレークになっていました。

## 変更

**ヒントコマンドの返事は定義上ヒントなので測らない。**`h`/`hint` をスキップします。

- 文言を書き換えて逃げる案は採りませんでした。307 個が同じ地雷を踏み得るので、次に誰かが助言に「cannot」と書いた瞬間に同じフレークが戻ります
- `checked == 0` の床はそのまま。ヒント以外の例は従来どおり全部測ります（実測 404 → ヒント分だけ減）

## 検証

- フルパッケージ実行を **6 回連続 green**（修正前は 1/3 で赤）
- flake-ledger に記録済み

Fixes the flake introduced by #5620.