### PR TITLE
feat(osmosis): 配置不可の理由を支援技術にも伝える

### DIFF
--- a/frontend/src/pages/OsmosisPage.test.tsx
+++ b/frontend/src/pages/OsmosisPage.test.tsx
@@ -354,3 +354,32 @@ describe('OsmosisPage', () => {
     });
   });
 });
+
+// #5625: 置けない段は赤枠と `title` だけで示していた。`title` は支援技術が
+// 読み上げる保証が無いので、キーボード/スクリーンリーダー利用者には**理由が
+// どこにも無い**状態だった。
+describe('OsmosisPage blocked foundation rows', () => {
+  it('puts the reason in the accessible name of the rows that reject the card', async () => {
+    renderWithProviders(<OsmosisPage />);
+    await waitFor(() => expect(screen.getByTestId('os-allowed-0')).toBeInTheDocument());
+
+    // ♥4 を選ぶ。ベース段 (♠) にも、まだ何も入っていない下の段にも置けない。
+    fireEvent.click(screen.getByRole('button', { name: 'ウェイスト' }));
+
+    // 名前は状態で変えず、理由は説明として結びつける。
+    const row0 = await screen.findByRole('button', { name: '組札 0' });
+    await waitFor(() => expect(row0).toHaveAttribute('aria-describedby'));
+    const id = row0.getAttribute('aria-describedby') as string;
+    expect(document.getElementById(id)).toHaveTextContent('この段には置けません');
+    // 視覚 (赤枠) と支援技術が同じ段を指す。
+    expect(row0.className).toContain('border-ds-error');
+  });
+
+  it('leaves the accessible name alone when nothing is selected', async () => {
+    renderWithProviders(<OsmosisPage />);
+    await waitFor(() => expect(screen.getByTestId('os-allowed-0')).toBeInTheDocument());
+
+    expect(screen.getByRole('button', { name: '組札 0' })).not.toHaveAttribute('aria-describedby');
+    expect(screen.queryByText('この段には置けません')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/OsmosisPage.tsx
+++ b/frontend/src/pages/OsmosisPage.tsx
@@ -282,6 +282,11 @@ function OsmosisPageContent() {
                       onClick={() => handleFoundationClick(i)}
                       disabled={!isPlaying || !selected || loading}
                       aria-label={`${t('foundation')} ${i}`}
+                      // **理由は読み上げに乗せる。**`title` は支援技術が読み上げる
+                      // 保証が無く、赤枠も見えない人には届かない (#5625)。名前
+                      // 自体は状態で変えない ── 同じ段が選択のたびに別名で呼ばれると
+                      // どれを触っているのか分からなくなる。
+                      aria-describedby={blocked ? `os-foundation-blocked-${i.toString()}` : undefined}
                       title={blocked ? t('cannotPlaceHere') : undefined}
                       className={
                         blocked
@@ -311,6 +316,11 @@ function OsmosisPageContent() {
                             : allowed.map((r) => RANK_LABELS[r]).join(' ')}
                       </span>
                     </button>
+                    {blocked && (
+                      <span id={`os-foundation-blocked-${i.toString()}`} className="sr-only">
+                        {t('cannotPlaceHere')}
+                      </span>
+                    )}
                   </DropZone>
                 );
               })}


### PR DESCRIPTION
## 背景

置けない段は `title={blocked ? t('cannotPlaceHere') : undefined}` の**ネイティブツールチップだけ**で示していた。`title` はスクリーンリーダーが読み上げる保証が無く、`aria-label` は `組札 N` 固定で blocked 状態を含んでいない。赤枠も見えない人には届かないので、**理由がどこにも無い**状態だった。

## 変更

`aria-describedby` で理由（`cannotPlaceHere`）を結びつける。sr-only の説明要素は blocked のときだけ描画。

**名前 (`aria-label`) は状態で変えない。**最初は名前に理由を足したが、同じ段が選択のたびに別名で呼ばれることになり、既存のテスト 3 本も落ちた ── 支援技術の利用者にとっても「さっき触った段」が別物に見えるので、説明として渡すのが正しい。

## テスト

- blocked のとき `aria-describedby` が指す要素に理由が入る／同じ段が赤枠にもなる（視覚と支援技術が同じ段を指す）
- 何も選んでいなければ `aria-describedby` は付かず、説明要素も DOM に無い

ミューテーション実測: `aria-describedby` を外す→1 failed、常に付ける→1 failed。

Closes #5625