### PR TITLE
test(horse): 配り依存で落ちる round-trip テストを直す

### DIFF
--- a/internal/domain/HorseJSON_test.go
+++ b/internal/domain/HorseJSON_test.go
@@ -44,18 +44,27 @@ func TestHorseRoundTripJSON_MidHand(t *testing.T) {
 		beforeFold[i] = back.GetSeatChips(i)
 	}
 
-	horseFoldOutHand(t, &back)
-	require.Equal(t, HorsePhaseHandEnd, back.GetPhase())
-	assert.Equal(t, beforeChips, horseTotalChips(&back), "総量が変わっている")
-
+	// **1 ハンドでは足りない。**降りたぶんの掛け金がそのまま自分に戻る配りだと、
+	// 全席が打つ前と同じ残高で終わる。それを「回収が繋がっていない」と読むと
+	// 配りに依存して落ちる (#5869 で 3 回観測、いずれも Horse と無関係な PR)。
+	// 回収が本当に切れていれば**何ハンド打っても**動かないので、動くまで数ハンド
+	// 続ける形にする。
 	moved := false
-	for i := range beforeFold {
-		if back.GetSeatChips(i) != beforeFold[i] {
-			moved = true
-			break
+	for hand := 0; hand < 3 && !moved; hand++ {
+		if hand > 0 {
+			require.NoError(t, back.NextHand())
+		}
+		horseFoldOutHand(t, &back)
+		require.Equal(t, HorsePhaseHandEnd, back.GetPhase())
+		assert.Equal(t, beforeChips, horseTotalChips(&back), "総量が変わっている")
+		for i := range beforeFold {
+			if back.GetSeatChips(i) != beforeFold[i] {
+				moved = true
+				break
+			}
 		}
 	}
-	assert.True(t, moved, "ハンドを打ったのに残高が 1 席も動いていない (回収が繋がっていない)")
+	assert.True(t, moved, "3 ハンド打っても残高が 1 席も動いていない (回収が繋がっていない)")
 }
 
 func TestHorseRoundTripJSON_BetweenHands(t *testing.T) {


### PR DESCRIPTION
## 背景

`TestHorseRoundTripJSON_MidHand` が **CI で 3 回**落ちています（#5869 に記録、いずれも Horse と無関係な PR。今日は PR #5995 で**連続 2 回**）。

落ちるのは「1 ハンド打ったのに残高が 1 席も動いていない」というアサーション。これは**回収 (`harvest`) が繋がっているか**を見る番人ですが、降りたぶんの掛け金がそのまま自分に戻る配りだと、全席が打つ前と同じ残高でハンドが終わります。つまり**配り依存**でした。

## 変更

**動くまで最大 3 ハンド続ける。**回収が本当に切れていれば何ハンド打っても動かないので、番人の役目は変わりません。

## 検証

- 修正後、ローカルで 8 回連続 green
- **番人が効いていることを負のコントロールで確認**: `settleIfHandOver` の `harvest()` 呼び出しを外すと、修正後のテストは**落ちます**（=「常に通る」テストになっていない）

ローカルで再現しない類なので、CI での再発有無で最終確認します。

Refs #5869