### PR TITLE
ci: bound the playwright apt steps so a hang cannot eat the whole job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,15 +335,31 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
 
+      # --with-deps も apt を叩くので、キャッシュミス側も同じ理由で有界にする
+      # (#6002)。ブラウザ本体のダウンロードを含むぶん上限は長め。ここで失敗したら
+      # ブラウザが無くテストは動かないので、continue-on-error は付けない。
       - name: Install Playwright browsers
         working-directory: frontend
+        timeout-minutes: 10
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: bunx playwright install --with-deps chromium
         if: steps.pw-cache.outputs.cache-hit != 'true'
 
       # --with-deps installs OS packages outside the cached directory, so a
       # cache hit still needs them.
+      #
+      # **このステップが2本のPRで連続してジョブの20分を食い潰した** (#6002):
+      # apt がロック待ちや対話プロンプトで固まると、テストが1本も走らないまま
+      # ジョブ全体が timeout で cancel される。3分で切り上げ、非対話で走らせる。
+      # 本当にライブラリが足りなければ後続の playwright test が落ちるので、
+      # ここで失敗しても止めない。
       - name: Install Playwright OS dependencies
         working-directory: frontend
+        timeout-minutes: 3
+        continue-on-error: true
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: bunx playwright install-deps chromium
         if: steps.pw-cache.outputs.cache-hit == 'true'
 

--- a/frontend/scripts/check-job-timeouts.mjs
+++ b/frontend/scripts/check-job-timeouts.mjs
@@ -64,6 +64,39 @@ export function jobsWithoutTimeout(src) {
   );
 }
 
+/**
+ * OS パッケージを入れるステップのうち、ステップ単位の上限が無いものを返す。
+ *
+ * apt はロック待ちや対話プロンプトで固まる。ジョブ側の上限しか無いと、
+ * **テストが 1 本も走らないままジョブの予算を丸ごと使い切って cancel** される
+ * (#6002 で 2 本の PR が連続で踏んだ)。ステップ側で先に切り上げれば、残りの
+ * 予算はテストに残る。
+ *
+ * @param {string} src - ci.yml の中身。
+ * @returns {string[]} 上限の無い apt ステップ名 (無名なら run 行)。
+ */
+export function aptStepsWithoutTimeout(src) {
+  const steps = src.split(/^ {6}- /m).slice(1);
+  return (
+    steps
+      // **コメント行は見ない。**次のステップに付けた説明コメントは前のステップの
+      // 塊に入るので、素の全文検索だと「apt と書いてある解説」で隣のステップを
+      // 誤検知する (実際に一度誤検知した)。
+      .filter((step) =>
+        step
+          .split('\n')
+          .filter((line) => !/^\s*#/.test(line))
+          .some((line) => /(?:apt-get|apt |install-deps|--with-deps)/.test(line)),
+      )
+      .filter((step) => !/^ {8}timeout-minutes: *\d+ *$/m.test(step))
+      .map((step) => {
+        const named = /^name: (.+)$/m.exec(step);
+        const run = /^ *run: (.+)$/m.exec(step);
+        return named?.[1] ?? run?.[1] ?? '(unnamed step)';
+      })
+  );
+}
+
 const src = await readFile(CI, 'utf8');
 const jobs = splitJobs(src);
 // **0 件で成功と読ませない。**`jobs:` の切り出しが壊れれば「違反 0 件」になり、
@@ -76,4 +109,10 @@ if (missing.length > 0) {
   console.error('  ハングしても既定の 6 時間止まりません。実測 max のおよそ 2 倍を目安に付けてください。');
   process.exit(1);
 }
-console.log(`job-timeouts: OK (${jobs.length.toString()} jobs, all bounded).`);
+const unboundedApt = aptStepsWithoutTimeout(src);
+if (unboundedApt.length > 0) {
+  console.error(`check-job-timeouts: ステップ単位の timeout-minutes が無い apt ステップ: ${unboundedApt.join(', ')}`);
+  console.error('  apt が固まるとジョブの予算を丸ごと使い切り、テストが 1 本も走らずに cancel されます (#6002)。');
+  process.exit(1);
+}
+console.log(`job-timeouts: OK (${jobs.length.toString()} jobs bounded, apt steps bounded).`);

--- a/frontend/scripts/check-job-timeouts.test.mjs
+++ b/frontend/scripts/check-job-timeouts.test.mjs
@@ -145,6 +145,33 @@ describe('check-job-timeouts', () => {
     expect(r.status).toBe(0);
   });
 
+  // 実装中に一度これで誤検知した: 次のステップ向けに書いた解説コメントは
+  // **前のステップの塊に入る**ので、素の全文検索だと apt と無関係なステップが
+  // 上限なしとして報告される。コメント除去そのものを固定しておく。
+  it('does not blame the previous step for a comment that describes the next one', () => {
+    const ci = CI_BOUNDED.replace(
+      `  test-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - run: echo hi`,
+      `  test-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Build something
+        run: echo build
+
+      # apt がロック待ちで固まるので次のステップは有界にしてある
+      - name: Install Playwright OS dependencies
+        timeout-minutes: 3
+        run: bunx playwright install-deps chromium`,
+    );
+    const r = runGuard(ci);
+    expect(r.status).toBe(0);
+    expect(r.stderr).not.toContain('Build something');
+  });
+
   it('passes against the real ci.yml', () => {
     const r = spawnSync('bun', [GUARD], { encoding: 'utf8' });
     expect(r.status).toBe(0);

--- a/frontend/scripts/check-job-timeouts.test.mjs
+++ b/frontend/scripts/check-job-timeouts.test.mjs
@@ -104,6 +104,47 @@ describe('check-job-timeouts', () => {
   });
 
   // 本番の ci.yml でも通ること。フィクスチャだけ緑では意味がない。
+  // #6002: apt を叩くステップが2本のPRで連続してジョブの20分を食い潰し、
+  // テストが1本も走らないまま cancel された。ジョブ側の上限は「6時間止まる」しか
+  // 防げないので、apt ステップ自体にも上限が要る。
+  it('fails when an apt-installing step has no step-level timeout', () => {
+    const ci = CI_BOUNDED.replace(
+      `  test-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - run: echo hi`,
+      `  test-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Install Playwright OS dependencies
+        run: bunx playwright install-deps chromium`,
+    );
+    const r = runGuard(ci);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('Install Playwright OS dependencies');
+  });
+
+  it('accepts an apt-installing step that bounds itself', () => {
+    const ci = CI_BOUNDED.replace(
+      `  test-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - run: echo hi`,
+      `  test-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Install Playwright OS dependencies
+        timeout-minutes: 3
+        run: bunx playwright install-deps chromium`,
+    );
+    const r = runGuard(ci);
+    expect(r.status).toBe(0);
+  });
+
   it('passes against the real ci.yml', () => {
     const r = spawnSync('bun', [GUARD], { encoding: 'utf8' });
     expect(r.status).toBe(0);


### PR DESCRIPTION
## 背景

**2本のPRで連続して E2E シャードが1本も走らずに死んだ。**

| PR | run | ジョブ | 止まった場所 |
|----|-----|--------|--------------|
| #5999 | [32161631303](https://github.com/yuta-yoshinaga/go_trumpcards/actions/runs/32161631303) | E2E Tests (2/3) | `Install Playwright OS dependencies` |
| #6000 | [32162393021](https://github.com/yuta-yoshinaga/go_trumpcards/actions/runs/32162393021) | E2E Tests (3/3) | **同じステップ** |

どちらも他の2シャードは約10分で success。apt がロック待ちか対話プロンプトで固まり、#5967 で入れたジョブ単位の 20 分 timeout がジョブごと cancel していた。**「6時間止まる」は防げているが、テストを1本も走らせないまま20分を捨てる**状態が残っていた。

## 変更

- `Install Playwright OS dependencies` (キャッシュヒット側) … `timeout-minutes: 3` + `DEBIAN_FRONTEND=noninteractive` + `continue-on-error: true`（本当にライブラリが足りなければ直後の `playwright test` が落ちる）
- `Install Playwright browsers` (キャッシュミス側、`--with-deps` で同じく apt を叩く) … `timeout-minutes: 10` + 非対話。**こちらは continue-on-error を付けない**（ブラウザが無ければテストは動かない）
- `check-job-timeouts.mjs` に「OS パッケージを入れるステップはステップ単位の timeout を持つ」検査を追加

## ガードの実装で踏んだ落とし穴

最初の実装はステップの塊を素の全文検索していたため、**隣のステップに書いた解説コメントの「apt」で `Install Playwright browsers` を誤検知**した（次のステップ用のコメントは前のステップの塊に入る）。コメント行を除いた行だけを見るように修正済み。

## テスト計画

- [x] `fails when an apt-installing step has no step-level timeout` — 新規
- [x] `accepts an apt-installing step that bounds itself` — 負のコントロール
- [x] ミューテーション: フィルタを常に false にすると新テストが落ちる / 実際の ci.yml から `timeout-minutes: 3` を消すとガードが落ちる
- [x] `bun run check`（`job-timeouts: OK (7 jobs bounded, apt steps bounded).`）
- [x] `bunx vitest run scripts/check-job-timeouts.test.mjs` — 8 passed

Closes #6002