### PR TITLE
test(klaverjas): tie both strength tables to the domain

### DIFF
--- a/internal/domain/Klaverjas.go
+++ b/internal/domain/Klaverjas.go
@@ -386,6 +386,44 @@ func (g *Klaverjas) klaverjasRank(card *Card) int {
 	return klaverjasPlainStrength(card.GetValue())
 }
 
+// KlaverjasRankRow は強さ早見表の 1 行。
+type KlaverjasRankRow struct {
+	// Value はカードの値 (1=A, 11=J, 12=Q, 13=K)。
+	Value int
+	// Points はそのカードの得点。
+	Points int
+}
+
+// KlaverjasRankTable は強い順に並べた強さ早見表を返す。isTrump で切り札用と
+// 非切り札用を切り替える。
+//
+// **切り札 (J>9>A>10>K>Q>8>7) と非切り札 (A>10>K>Q>J>9>8>7) で順序も配点も
+// 別系統**という、このゲームでいちばん覚えにくいところ。Web は #4757 で 2 つの表を
+// 出したが値を TS 側に写しており、CUI には説明そのものが無かった (#5645)。
+// 3 つ目の写しを作らないよう、判定と同じ関数から表を組み立てて返す。
+func KlaverjasRankTable(isTrump bool) []KlaverjasRankRow {
+	// 実際の勝敗判定 (trumpStrength / klaverjasPlainStrength) と配点 (cardPoints)
+	// をそのまま使うので、片方だけ直しても表がずれない。
+	g := &Klaverjas{trumpSuit: CardDesignSpade}
+	design := CardDesignSpade
+	if !isTrump {
+		design = CardDesignHeart
+	}
+	values := []int{1, 7, 8, 9, 10, 11, 12, 13}
+	rows := make([]KlaverjasRankRow, 0, len(values))
+	for _, v := range values {
+		rows = append(rows, KlaverjasRankRow{Value: v, Points: g.cardPoints(NewCard(design, v, false))})
+	}
+	strength := func(v int) int {
+		if isTrump {
+			return g.trumpStrength(v)
+		}
+		return klaverjasPlainStrength(v)
+	}
+	sort.SliceStable(rows, func(i, j int) bool { return strength(rows[i].Value) > strength(rows[j].Value) })
+	return rows
+}
+
 // trumpStrength 切り札の強さ。J>9>A>10>K>Q>8>7。
 func (g *Klaverjas) trumpStrength(value int) int {
 	switch value {

--- a/internal/domain/Klaverjas_test.go
+++ b/internal/domain/Klaverjas_test.go
@@ -364,3 +364,57 @@ func TestKlaverjas_UnmarshalErrors(t *testing.T) {
 		t.Errorf("err = %v, want errKlaverjasOversized", err)
 	}
 }
+
+// #5645: 切り札と非切り札で強さも配点も別系統という、Klaverjas でいちばん
+// 覚えにくいところ。Web は #4757 で 2 つの表を出したが、その値は TS 側に
+// 手で写されている。CUI にも同じ説明を出すにあたり、**3 つ目の写しを作らない**
+// よう、順序と配点をドメインから問えるようにする。
+func TestKlaverjasRankTable(t *testing.T) {
+	trump := KlaverjasRankTable(true)
+	plain := KlaverjasRankTable(false)
+
+	wantTrump := []KlaverjasRankRow{
+		{Value: 11, Points: 20}, {Value: 9, Points: 14}, {Value: 1, Points: 11}, {Value: 10, Points: 10},
+		{Value: 13, Points: 4}, {Value: 12, Points: 3}, {Value: 8, Points: 0}, {Value: 7, Points: 0},
+	}
+	wantPlain := []KlaverjasRankRow{
+		{Value: 1, Points: 11}, {Value: 10, Points: 10}, {Value: 13, Points: 4}, {Value: 12, Points: 3},
+		{Value: 11, Points: 2}, {Value: 9, Points: 0}, {Value: 8, Points: 0}, {Value: 7, Points: 0},
+	}
+	for _, c := range []struct {
+		name string
+		got  []KlaverjasRankRow
+		want []KlaverjasRankRow
+	}{{"trump", trump, wantTrump}, {"plain", plain, wantPlain}} {
+		if len(c.got) != len(c.want) {
+			t.Fatalf("%s: len = %d, want %d", c.name, len(c.got), len(c.want))
+		}
+		for i := range c.want {
+			if c.got[i] != c.want[i] {
+				t.Errorf("%s[%d] = %+v, want %+v", c.name, i, c.got[i], c.want[i])
+			}
+		}
+	}
+}
+
+// 表は実際の勝敗判定と同じ順序でなければ意味がない。**強い順に並んでいること**を
+// 判定関数そのもので確かめる (表を手で書き写しただけでは、順序が逆でも通る)。
+func TestKlaverjasRankTableIsSortedByTheRealStrength(t *testing.T) {
+	g := newKlavGame(true)
+	g.SetTrumpSuit(CardDesignSpade)
+	for _, isTrump := range []bool{true, false} {
+		rows := KlaverjasRankTable(isTrump)
+		for i := 1; i < len(rows); i++ {
+			prev, cur := rows[i-1].Value, rows[i].Value
+			var ps, cs int
+			if isTrump {
+				ps, cs = g.trumpStrength(prev), g.trumpStrength(cur)
+			} else {
+				ps, cs = klaverjasPlainStrength(prev), klaverjasPlainStrength(cur)
+			}
+			if ps <= cs {
+				t.Errorf("trump=%v: %d は %d より強くない (%d <= %d)", isTrump, prev, cur, ps, cs)
+			}
+		}
+	}
+}

--- a/internal/infrastructure/games/klaverjas_rank_help_test.go
+++ b/internal/infrastructure/games/klaverjas_rank_help_test.go
@@ -1,0 +1,150 @@
+package games_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+)
+
+// klaverjasFaceOf は表示用の呼び名。A/J/Q/K は数字ではなく文字で書かれている。
+func klaverjasFaceOf(value int) string {
+	switch value {
+	case 1:
+		return "A"
+	case 11:
+		return "J"
+	case 12:
+		return "Q"
+	case 13:
+		return "K"
+	default:
+		return strconv.Itoa(value)
+	}
+}
+
+// TestKlaverjasRankHelpMatchesTheDomain guards the two strength tables that
+// exist in three places: the domain's own ordering and scoring, the CUI prompt
+// text (`internal/i18n/locales/*/klaverjas.json`, `rankHelp*`) and the Web
+// legend (`KLAVERJAS_TRUMP_ROWS` / `KLAVERJAS_PLAIN_ROWS` in
+// `frontend/src/pages/KlaverjasPage.tsx`).
+//
+// The CUI text landed in #5831 and the Web tables in #4757, both spelled out by
+// hand. Nothing checked either against the code that actually decides tricks, so
+// a change to `trumpStrength` or `cardPoints` would leave two screens confidently
+// teaching the wrong order (#5645).
+func TestKlaverjasRankHelpMatchesTheDomain(t *testing.T) {
+	root := filepath.Join("..", "..", "..")
+
+	for _, tc := range []struct {
+		name    string
+		isTrump bool
+		locKey  string
+		tsVar   string
+	}{
+		{"trump", true, "rankHelpTrump", "KLAVERJAS_TRUMP_ROWS"},
+		{"plain", false, "rankHelpPlain", "KLAVERJAS_PLAIN_ROWS"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rows := domain.KlaverjasRankTable(tc.isTrump)
+			if len(rows) != 8 {
+				t.Fatalf("rank table has %d rows, want 8", len(rows))
+			}
+
+			// --- CUI: 強い順の並びと、0 点でないカードの配点が本文にあること ---
+			for _, loc := range []string{"ja", "en"} {
+				path := filepath.Join(root, "internal", "i18n", "locales", loc, "klaverjas.json")
+				raw, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatalf("read %s: %v", path, err)
+				}
+				var d map[string]any
+				if err := json.Unmarshal(raw, &d); err != nil {
+					t.Fatalf("parse %s: %v", path, err)
+				}
+				line, ok := d[tc.locKey].(string)
+				if !ok {
+					t.Fatalf("%s %s missing", loc, tc.locKey)
+				}
+				// **並びの部分だけを見る。**行全体を順に走査すると、後半の配点欄
+				// (「9=14」など) の数字が並びの証拠として拾われ、順序を入れ替えても
+				// 通ってしまう (実際にこの書き方で誤って通した)。
+				order := klaverjasOrderSegment(t, line)
+				want := make([]string, len(rows))
+				for i, r := range rows {
+					want[i] = klaverjasFaceOf(r.Value)
+				}
+				if strings.Join(order, " > ") != strings.Join(want, " > ") {
+					t.Errorf("%s %s order = %v, want %v", loc, tc.locKey, order, want)
+				}
+				for _, r := range rows {
+					if r.Points == 0 {
+						continue
+					}
+					want := klaverjasFaceOf(r.Value) + "=" + strconv.Itoa(r.Points)
+					if !strings.Contains(line, want) {
+						t.Errorf("%s %s = %q, want it to state %q", loc, tc.locKey, line, want)
+					}
+				}
+			}
+
+			// --- Web: 同じ並びと配点が KlaverjasPage.tsx の表にあること ---
+			page := filepath.Join(root, "frontend", "src", "pages", "KlaverjasPage.tsx")
+			src, err := os.ReadFile(page)
+			if err != nil {
+				t.Fatalf("read %s: %v", page, err)
+			}
+			block := klaverjasRowsBlock(t, string(src), tc.tsVar)
+			got := regexp.MustCompile(`face: '([^']+)', points: (\d+)`).FindAllStringSubmatch(block, -1)
+			if len(got) != len(rows) {
+				t.Fatalf("%s has %d rows, want %d", tc.tsVar, len(got), len(rows))
+			}
+			for i, r := range rows {
+				if got[i][1] != klaverjasFaceOf(r.Value) || got[i][2] != strconv.Itoa(r.Points) {
+					t.Errorf("%s[%d] = %s/%s, want %s/%d",
+						tc.tsVar, i, got[i][1], got[i][2], klaverjasFaceOf(r.Value), r.Points)
+				}
+			}
+		})
+	}
+}
+
+// klaverjasOrderSegment は「切り札の強さ: J > 9 > ...」の並びだけを取り出す。
+// 配点欄 (全角/半角どちらの括弧でも) より前を、">" で切る。
+func klaverjasOrderSegment(t *testing.T, line string) []string {
+	t.Helper()
+	seg := line
+	if i := strings.IndexAny(seg, "（("); i >= 0 {
+		seg = seg[:i]
+	}
+	if i := strings.Index(seg, ":"); i >= 0 {
+		seg = seg[i+1:]
+	}
+	parts := strings.Split(seg, ">")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// klaverjasRowsBlock は const <name> ... ]; の中身を切り出す。
+func klaverjasRowsBlock(t *testing.T, src, name string) string {
+	t.Helper()
+	start := strings.Index(src, "const "+name)
+	if start < 0 {
+		t.Fatalf("%s not found in KlaverjasPage.tsx", name)
+	}
+	end := strings.Index(src[start:], "];")
+	if end < 0 {
+		t.Fatalf("%s is not terminated", name)
+	}
+	return src[start : start+end]
+}


### PR DESCRIPTION
## issue の前提について（1点訂正）

issue は「`KlaverjasCuiPresenter.go` に説明文が一切無い」としているが、**CUI の強さ順テキストは既に入っている** — `0ff1658db feat(klaverjas): show both strength orders in the CUI play prompt (#5831)`。受け入れ条件 1・3・4 は満たされている。

残っていたのは **条件 2「表示内容が Web の `klaverjas-strength-legend` の値と一致する」** で、これを確かめるものが何も無かった。

## 背景

切り札 (J>9>A>10>K>Q>8>7) と非切り札 (A>10>K>Q>J>9>8>7) で**順序も配点も別系統**という、このゲームでいちばん覚えにくい部分が **3 箇所に手で書き写されている**:

1. ドメインの `trumpStrength` / `klaverjasPlainStrength` / `cardPoints`（実際に勝敗を決める側）
2. CUI のロケール文字列 `rankHelpTrump` / `rankHelpPlain`（#5831）
3. Web の `KLAVERJAS_TRUMP_ROWS` / `KLAVERJAS_PLAIN_ROWS`（#4757）

トリックの勝ち負けを決める関数を変えても、**2 つの画面は古い順序を教え続ける**。

## 変更

- `domain.KlaverjasRankTable(isTrump)` を追加 — 判定と配点の関数そのものから表を組み立てて返す
- `TestKlaverjasRankHelpMatchesTheDomain` が、その表と **CUI ロケール（ja/en）** と **Web の 2 つの行配列** を突き合わせる

## ガードの実装で踏んだ落とし穴

最初の順序チェックは行全体を順に走査していたため、**順序を入れ替えても通った** — 後半の配点欄（`9=14` など）の数字が並びの証拠として拾われていた。配点欄より前の並び部分だけを見るよう修正済み。

## テスト計画

- [x] `TestKlaverjasRankTable` — 両系統の順序と配点
- [x] `TestKlaverjasRankTableIsSortedByTheRealStrength` — 表の並びを**判定関数そのもの**で検証（写しただけでは順序が逆でも通るため）
- [x] ミューテーション5件すべて検出: CUI の順序入れ替え / CUI の配点 1 桁変更 / Web の配点 1 桁変更 / **ドメインの配点変更（両画面が落ちる）** / **ドメインの強さ変更（順序が変わって落ちる）**
- [x] `go test -tags test ./internal/...`、`golangci-lint run ./internal/...`

Closes #5645