### PR TITLE
feat(sedma): announce the match score to screen readers

### DIFF
--- a/frontend/src/pages/SedmaPage.test.tsx
+++ b/frontend/src/pages/SedmaPage.test.tsx
@@ -84,6 +84,28 @@ describe('SedmaPage', () => {
     expect(panel).toHaveTextContent('チームBのカード点: 20');
   });
 
+  // #5648: ラウンド中のカード点は role="status" で読み上げられるのに、その上の
+  // チーム通算得点には role も aria-live も無く、ラウンドが確定して点が動いても
+  // スクリーンリーダー利用者には何も伝わらなかった。
+  it('announces the match score so a round settling is heard', async () => {
+    mockExec.mockResolvedValue(makeSedmaState({ teamScores: [3, 1] }));
+    renderWithProviders(<SedmaPage />);
+
+    const panel = await screen.findByTestId('sedma-team-scores');
+    expect(panel).toHaveAttribute('role', 'status');
+    expect(panel).toHaveAttribute('aria-live', 'polite');
+    expect(panel).toHaveTextContent('チームA: 3');
+    expect(panel).toHaveTextContent('チームB: 1');
+  });
+
+  // 読み上げ対象が2つに増えても、既存のカード点パネルはそのまま。
+  it('leaves the round-points panel announcing on its own', async () => {
+    mockExec.mockResolvedValue(makeSedmaState({ roundCardPoints: [40, 20] }));
+    renderWithProviders(<SedmaPage />);
+
+    expect(await screen.findByTestId('sedma-round-points')).toHaveAttribute('role', 'status');
+  });
+
   it('hides the live captured card points once the round ends', async () => {
     mockExec.mockResolvedValue(roundEndState);
     renderWithProviders(<SedmaPage />);

--- a/frontend/src/pages/SedmaPage.tsx
+++ b/frontend/src/pages/SedmaPage.tsx
@@ -242,8 +242,14 @@ function SedmaPageContent() {
 
               {/* Right: info sidebar */}
               <div data-tutorial="sedma-info">
-                {/* Team match scores */}
-                <div className="mb-2 p-2 rounded bg-black/30 text-ds-text-muted text-sm">
+                {/* Team match scores. ラウンドが確定すると増える値なので、カード点
+                    パネルと同じく読み上げ対象にする (#5648)。 */}
+                <div
+                  className="mb-2 p-2 rounded bg-black/30 text-ds-text-muted text-sm"
+                  data-testid="sedma-team-scores"
+                  role="status"
+                  aria-live="polite"
+                >
                   <div>{t('teamScore', { team: t('team.a'), score: state.teamScores[0] ?? 0 })}</div>
                   <div>{t('teamScore', { team: t('team.b'), score: state.teamScores[1] ?? 0 })}</div>
                   <div className="mt-1">


### PR DESCRIPTION
## 背景

`SedmaPage.tsx` のサイドバーには得点ブロックが2つある。

- ラウンド中のカード点 (`sedma-round-points`) … `role="status"` が付いていて更新が読み上げられる
- **その上のチーム通算得点** … `role` も `aria-live` も無い

ラウンドが確定して `teamScores` が動くのは**勝敗を決める側の数字**なのに、スクリーンリーダー利用者には何も伝わらなかった。

## 変更

- チーム通算得点ブロックに `data-testid="sedma-team-scores"` と `role="status"` / `aria-live="polite"` を付与（下のパネルと同じパターン。ロジック変更なし）

## テスト計画

- [x] 通算得点ブロックが `role="status"` / `aria-live="polite"` を持ち、両チームの点を含む
- [x] **既存の `sedma-round-points` の `role="status"` はそのまま**（負のコントロール）
- [x] ミューテーション2件とも検出: 追加した属性を外す / 既存パネルの `role` を外す
- [x] `bun run check`、`bun run typecheck`、`bunx vitest run src/pages/SedmaPage.test.tsx`

Closes #5648