### PR TITLE
test(cinch): ビッド強度のGo/TS二重実装をgolden vectorで縛る

### DIFF
--- a/frontend/src/utils/__fixtures__/cinchBidStrength.golden.json
+++ b/frontend/src/utils/__fixtures__/cinchBidStrength.golden.json
@@ -50,11 +50,7 @@
     },
     {
       "name": "the 5 of hearts is the Left Pedro in diamonds, making diamonds the best suit",
-      "cards": [
-        { "suit": 3, "value": 5 },
-        { "suit": 4, "value": 13 },
-        { "suit": 4, "value": 10 }
-      ],
+      "cards": [{ "suit": 3, "value": 5 }, { "suit": 4, "value": 13 }, { "suit": 4, "value": 10 }],
       "pointsBySuit": [0, 0, 0, 5, 7],
       "bestSuit": 4,
       "maxPoints": 7,

--- a/frontend/src/utils/cinchBidStrength.golden.test.ts
+++ b/frontend/src/utils/cinchBidStrength.golden.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { Card } from '../types/card';
+import { estimateCinchBidStrength } from './cinchBidStrength';
+
+/**
+ * The Cinch point rules live twice: `internal/domain/Cinch.go`
+ * (`CinchHandPointsBySuit`, which the CUI calls directly) and this module. The
+ * shared golden vectors below are also asserted by
+ * `TestCinchBidStrength_GoldenVectors` in `internal/domain/Cinch_test.go`, so
+ * changing the rules on one side alone fails that side, and regenerating the
+ * vectors to fix it fails the other.
+ */
+// vitest runs with the repo's `frontend/` directory as the cwd.
+const GOLDEN_PATH = resolve(process.cwd(), '../internal/domain/testdata/cinch_bid_strength.json');
+
+interface GoldenCase {
+  name: string;
+  cards: { suit: number; value: number }[];
+  /** Indexed by suit; index 0 is unused. */
+  pointsBySuit: number[];
+  bestSuit: number;
+  maxPoints: number;
+  minPoints: number;
+}
+
+const DESIGNS: Card['design'][] = ['JOKER', 'SPADE', 'CLOVER', 'HEART', 'DIAMOND'];
+
+const golden = JSON.parse(readFileSync(GOLDEN_PATH, 'utf8')) as { cases: GoldenCase[] };
+
+describe('estimateCinchBidStrength golden vectors (shared with the Go domain)', () => {
+  it('has vectors to check', () => {
+    expect(golden.cases.length).toBeGreaterThan(0);
+  });
+
+  it.each(golden.cases)('$name', (c) => {
+    const cards: Card[] = c.cards.map((cd) => ({ design: DESIGNS[cd.suit], value: cd.value }));
+
+    const got = estimateCinchBidStrength(cards);
+
+    expect([0, got.pointsBySuit[1], got.pointsBySuit[2], got.pointsBySuit[3], got.pointsBySuit[4]]).toEqual(
+      c.pointsBySuit,
+    );
+    expect(got.bestSuit).toBe(c.bestSuit);
+    expect(got.maxPoints).toBe(c.maxPoints);
+    expect(got.minPoints).toBe(c.minPoints);
+  });
+});

--- a/frontend/src/utils/cinchBidStrength.golden.test.ts
+++ b/frontend/src/utils/cinchBidStrength.golden.test.ts
@@ -1,33 +1,16 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import type { Card } from '../types/card';
+import golden from './__fixtures__/cinchBidStrength.golden.json';
 import { estimateCinchBidStrength } from './cinchBidStrength';
 
 /**
  * The Cinch point rules live twice: `internal/domain/Cinch.go`
- * (`CinchHandPointsBySuit`, which the CUI calls directly) and this module. The
- * shared golden vectors below are also asserted by
- * `TestCinchBidStrength_GoldenVectors` in `internal/domain/Cinch_test.go`, so
- * changing the rules on one side alone fails that side, and regenerating the
- * vectors to fix it fails the other.
+ * (`CinchHandPointsBySuit`, which the CUI calls directly) and this module. These
+ * golden vectors are also asserted by `TestCinchBidStrength_GoldenVectors` in
+ * `internal/domain/Cinch_test.go`, so changing the rules on one side alone fails
+ * that side, and regenerating the vectors to fix it fails the other.
  */
-// vitest runs with the repo's `frontend/` directory as the cwd.
-const GOLDEN_PATH = resolve(process.cwd(), '../internal/domain/testdata/cinch_bid_strength.json');
-
-interface GoldenCase {
-  name: string;
-  cards: { suit: number; value: number }[];
-  /** Indexed by suit; index 0 is unused. */
-  pointsBySuit: number[];
-  bestSuit: number;
-  maxPoints: number;
-  minPoints: number;
-}
-
 const DESIGNS: Card['design'][] = ['JOKER', 'SPADE', 'CLOVER', 'HEART', 'DIAMOND'];
-
-const golden = JSON.parse(readFileSync(GOLDEN_PATH, 'utf8')) as { cases: GoldenCase[] };
 
 describe('estimateCinchBidStrength golden vectors (shared with the Go domain)', () => {
   it('has vectors to check', () => {

--- a/frontend/src/utils/cinchBidStrength.ts
+++ b/frontend/src/utils/cinchBidStrength.ts
@@ -14,7 +14,7 @@ export const CINCH_TRUMP_SUITS = [1, 2, 3, 4] as const;
  *
  * Mirrors `cinchPointValue` in `internal/domain/Cinch.go`, and the two are held
  * together by the shared golden vectors in
- * `internal/domain/testdata/cinch_bid_strength.json` (asserted here by
+ * `frontend/src/utils/__fixtures__/cinchBidStrength.golden.json` (asserted here by
  * `cinchBidStrength.golden.test.ts` and there by `Cinch_test.go`): the trump A/K/10/J
  * are worth 1 each ("High"/"King"/"Ten (Game)"/"Jack"), the Right Pedro (5 of
  * trump) is worth 5, and the Left Pedro (5 of the same-color off-suit) is worth

--- a/frontend/src/utils/cinchBidStrength.ts
+++ b/frontend/src/utils/cinchBidStrength.ts
@@ -12,7 +12,10 @@ export const CINCH_TRUMP_SUITS = [1, 2, 3, 4] as const;
 /**
  * Point value a card contributes toward the 14 deal points when `suit` is trump.
  *
- * Mirrors `cinchPointValue` in `internal/domain/Cinch.go`: the trump A/K/10/J
+ * Mirrors `cinchPointValue` in `internal/domain/Cinch.go`, and the two are held
+ * together by the shared golden vectors in
+ * `internal/domain/testdata/cinch_bid_strength.json` (asserted here by
+ * `cinchBidStrength.golden.test.ts` and there by `Cinch_test.go`): the trump A/K/10/J
  * are worth 1 each ("High"/"King"/"Ten (Game)"/"Jack"), the Right Pedro (5 of
  * trump) is worth 5, and the Left Pedro (5 of the same-color off-suit) is worth
  * 5. Every other card is worth 0.

--- a/internal/domain/Cinch.go
+++ b/internal/domain/Cinch.go
@@ -258,7 +258,7 @@ func cinchPointValue(c *Card, trumpSuit int) int {
 //
 // The Web GUI re-implements this in TypeScript (frontend/src/utils/cinchBidStrength.ts);
 // the two are held together by the golden vectors in
-// testdata/cinch_bid_strength.json, which both test suites assert against.
+// frontend/src/utils/__fixtures__/cinchBidStrength.golden.json, which both test suites assert against.
 //
 // Holding a point card is not the same as capturing it, so this is a bidding
 // guide, not a promise. The Web GUI has shown the same table since the game

--- a/internal/domain/Cinch.go
+++ b/internal/domain/Cinch.go
@@ -256,6 +256,10 @@ func cinchPointValue(c *Card, trumpSuit int) int {
 // the CardDesign constants), how many of the 14 deal points the hand already
 // holds. Index 0 is unused.
 //
+// The Web GUI re-implements this in TypeScript (frontend/src/utils/cinchBidStrength.ts);
+// the two are held together by the golden vectors in
+// testdata/cinch_bid_strength.json, which both test suites assert against.
+//
 // Holding a point card is not the same as capturing it, so this is a bidding
 // guide, not a promise. The Web GUI has shown the same table since the game
 // shipped; the CUI showed only the current high bid (#4845).

--- a/internal/domain/Cinch_test.go
+++ b/internal/domain/Cinch_test.go
@@ -683,7 +683,9 @@ type cinchGolden struct {
 // domain を呼んで一致を保証しているのに、Web 側は同じ規則を独自実装しており、
 // 片方だけ直せば黙ってずれる。同じ golden vector を両方から検証してそれを防ぐ。
 func TestCinchBidStrength_GoldenVectors(t *testing.T) {
-	raw, err := os.ReadFile(filepath.Join("testdata", "cinch_bid_strength.json"))
+	// TS 側は import で読むので、fixture は frontend 側に置く (guandanCombo.golden の前例)。
+	raw, err := os.ReadFile(filepath.Join(
+		"..", "..", "frontend", "src", "utils", "__fixtures__", "cinchBidStrength.golden.json"))
 	require.NoError(t, err)
 	var golden cinchGolden
 	require.NoError(t, json.Unmarshal(raw, &golden))

--- a/internal/domain/Cinch_test.go
+++ b/internal/domain/Cinch_test.go
@@ -714,16 +714,16 @@ func TestCinchBidStrength_GoldenVectors(t *testing.T) {
 			assert.Equal(t, c.MaxPoints, maxPts)
 			assert.Equal(t, c.MinPoints, minPts)
 		})
-		// 負のコントロール: Left Pedro (同色オフスートの 5) を含む case が
-		// 1 件も無ければ、この golden は肝心の規則を守っていない。
+		// 負のコントロール: Left Pedro (**同色**オフスートの 5) を実際に点にしている
+		// case が 1 件も無ければ、この golden は肝心の規則を守っていない。
+		// 「どこか別のスートが 5 点」では、Right Pedro でも満たせてしまう。
+		sameColor := map[int]int{
+			domain.CardDesignSpade: domain.CardDesignClover, domain.CardDesignClover: domain.CardDesignSpade,
+			domain.CardDesignHeart: domain.CardDesignDiamond, domain.CardDesignDiamond: domain.CardDesignHeart,
+		}
 		for _, cd := range c.Cards {
-			if cd.Value != 5 {
-				continue
-			}
-			for suit := domain.CardDesignSpade; suit <= domain.CardDesignDiamond; suit++ {
-				if suit != cd.Suit && c.PointsBySuit[suit] >= 5 {
-					leftPedroCovered = true
-				}
+			if cd.Value == 5 && c.PointsBySuit[sameColor[cd.Suit]] >= 5 {
+				leftPedroCovered = true
 			}
 		}
 	}

--- a/internal/domain/Cinch_test.go
+++ b/internal/domain/Cinch_test.go
@@ -4,6 +4,8 @@ package domain_test
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -662,4 +664,66 @@ func TestCinchHandPointsBySuit(t *testing.T) {
 	empty := domain.CinchHandPointsBySuit(nil)
 	assert.Equal(t, 0, empty[domain.CardDesignSpade])
 	assert.Equal(t, domain.CardDesignSpade, domain.CinchBestTrumpSuit(empty))
+}
+
+// cinchGolden mirrors internal/domain/testdata/cinch_bid_strength.json.
+type cinchGolden struct {
+	Cases []struct {
+		Name         string `json:"name"`
+		Cards        []struct{ Suit, Value int }
+		PointsBySuit [domain.CardDesignDiamond + 1]int `json:"pointsBySuit"`
+		BestSuit     int                               `json:"bestSuit"`
+		MaxPoints    int                               `json:"maxPoints"`
+		MinPoints    int                               `json:"minPoints"`
+	} `json:"cases"`
+}
+
+// #5692: ビッド強度の点数計算は Go (CinchHandPointsBySuit) と TypeScript
+// (frontend/src/utils/cinchBidStrength.ts) の 2 か所にある。CUI 側はわざわざ
+// domain を呼んで一致を保証しているのに、Web 側は同じ規則を独自実装しており、
+// 片方だけ直せば黙ってずれる。同じ golden vector を両方から検証してそれを防ぐ。
+func TestCinchBidStrength_GoldenVectors(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("testdata", "cinch_bid_strength.json"))
+	require.NoError(t, err)
+	var golden cinchGolden
+	require.NoError(t, json.Unmarshal(raw, &golden))
+	require.NotEmpty(t, golden.Cases)
+
+	leftPedroCovered := false
+	for _, c := range golden.Cases {
+		t.Run(c.Name, func(t *testing.T) {
+			cards := make([]*domain.Card, 0, len(c.Cards))
+			for _, cd := range c.Cards {
+				cards = append(cards, domain.NewCard(cd.Suit, cd.Value, false))
+			}
+			points := domain.CinchHandPointsBySuit(cards)
+			assert.Equal(t, c.PointsBySuit, points)
+			assert.Equal(t, c.BestSuit, domain.CinchBestTrumpSuit(points))
+
+			maxPts, minPts := points[domain.CardDesignSpade], points[domain.CardDesignSpade]
+			for suit := domain.CardDesignSpade; suit <= domain.CardDesignDiamond; suit++ {
+				if points[suit] > maxPts {
+					maxPts = points[suit]
+				}
+				if points[suit] < minPts {
+					minPts = points[suit]
+				}
+			}
+			assert.Equal(t, c.MaxPoints, maxPts)
+			assert.Equal(t, c.MinPoints, minPts)
+		})
+		// 負のコントロール: Left Pedro (同色オフスートの 5) を含む case が
+		// 1 件も無ければ、この golden は肝心の規則を守っていない。
+		for _, cd := range c.Cards {
+			if cd.Value != 5 {
+				continue
+			}
+			for suit := domain.CardDesignSpade; suit <= domain.CardDesignDiamond; suit++ {
+				if suit != cd.Suit && c.PointsBySuit[suit] >= 5 {
+					leftPedroCovered = true
+				}
+			}
+		}
+	}
+	assert.True(t, leftPedroCovered, "the golden vectors must exercise the Left Pedro")
 }

--- a/internal/domain/testdata/cinch_bid_strength.json
+++ b/internal/domain/testdata/cinch_bid_strength.json
@@ -1,0 +1,64 @@
+{
+  "_comment": "Golden vectors for the Cinch bid-strength estimate. Two implementations read this file: internal/domain/Cinch_test.go (CinchHandPointsBySuit / CinchBestTrumpSuit) and frontend/src/utils/cinchBidStrength.golden.test.ts (estimateCinchBidStrength). Changing the point rules on one side alone fails that side's test; regenerating these numbers to fix it fails the other side. suit: 1=Spade 2=Clover 3=Heart 4=Diamond. pointsBySuit is indexed by suit, index 0 unused.",
+  "cases": [
+    {
+      "name": "empty hand holds nothing and falls back to the lowest suit",
+      "cards": [],
+      "pointsBySuit": [0, 0, 0, 0, 0],
+      "bestSuit": 1,
+      "maxPoints": 0,
+      "minPoints": 0
+    },
+    {
+      "name": "no point cards at all",
+      "cards": [{ "suit": 3, "value": 9 }, { "suit": 4, "value": 2 }],
+      "pointsBySuit": [0, 0, 0, 0, 0],
+      "bestSuit": 1,
+      "maxPoints": 0,
+      "minPoints": 0
+    },
+    {
+      "name": "a lone 5 of diamonds is the Right Pedro in diamonds and the Left Pedro in hearts",
+      "cards": [{ "suit": 4, "value": 5 }],
+      "pointsBySuit": [0, 0, 0, 5, 5],
+      "bestSuit": 3,
+      "maxPoints": 5,
+      "minPoints": 0
+    },
+    {
+      "name": "all fourteen points in spades, the 5 of clubs still counting as the Left Pedro in clubs",
+      "cards": [
+        { "suit": 1, "value": 1 },
+        { "suit": 1, "value": 13 },
+        { "suit": 1, "value": 10 },
+        { "suit": 1, "value": 11 },
+        { "suit": 1, "value": 5 },
+        { "suit": 2, "value": 5 }
+      ],
+      "pointsBySuit": [0, 14, 10, 0, 0],
+      "bestSuit": 1,
+      "maxPoints": 14,
+      "minPoints": 0
+    },
+    {
+      "name": "a tie between spades and clubs goes to the lower suit index",
+      "cards": [{ "suit": 1, "value": 1 }, { "suit": 2, "value": 1 }],
+      "pointsBySuit": [0, 1, 1, 0, 0],
+      "bestSuit": 1,
+      "maxPoints": 1,
+      "minPoints": 0
+    },
+    {
+      "name": "the 5 of hearts is the Left Pedro in diamonds, making diamonds the best suit",
+      "cards": [
+        { "suit": 3, "value": 5 },
+        { "suit": 4, "value": 13 },
+        { "suit": 4, "value": 10 }
+      ],
+      "pointsBySuit": [0, 0, 0, 5, 7],
+      "bestSuit": 4,
+      "maxPoints": 7,
+      "minPoints": 0
+    }
+  ]
+}


### PR DESCRIPTION
## 背景

`CinchCuiPresenter.go` の `cinchBidStrengthLine` は「計算はドメインに置いた。ここで
書き直すと Left Pedro（同色スートの5）の扱いが Web と食い違う」と明記して
`domain.CinchHandPointsBySuit` を直接呼んでいる。ところが Web 側
(`frontend/src/utils/cinchBidStrength.ts`) は**同じ規則を TypeScript で独自実装**していて、
CUI 側が避けたはずの乖離リスクをそのまま抱えていた。点数ルールが変われば、
2 箇所を同時に直さない限り黙ってずれる。

## 変更（本番コードの挙動は変えていません）

- `internal/domain/testdata/cinch_bid_strength.json` に共有 golden vector を追加
  （空手札 / 点札なし / 単独の5 / ♠14点満貫 / 同点の tie-break / Left Pedro で♦が最強）
- Go: `TestCinchBidStrength_GoldenVectors` が `CinchHandPointsBySuit` +
  `CinchBestTrumpSuit` + max/min を検証。**負のコントロール**として、golden が
  Left Pedro を 1 件も含まなければテスト自体が落ちる
- TS: `cinchBidStrength.golden.test.ts` が同じファイルを読んで
  `estimateCinchBidStrength` を検証（vitest が自動収集、CI で実行される）
- 両実装の doc コメントから golden ファイルを相互参照

**片方だけ直すと直した側が落ち、golden を書き換えて直すともう片方が落ちる**のが要点です。

## テスト（ミューテーション3方向で確認）

| 変更 | 結果 |
|---|---|
| Go の Left Pedro を 5 → 1 点 | Go golden test FAIL |
| TS の Left Pedro を 5 → 1 点 | vitest 3 cases FAIL |
| golden の期待値を 10 → 9 に | **Go / TS 両方 FAIL** |

- `go test -tags test ./internal/domain/ -run Cinch` green
- `bunx vitest run src/utils/` 9421 tests green（新規テストが自動収集されていることを確認）
- `golangci-lint run ./internal/domain/...` 0 issues

Closes #5692