### PR TITLE
feat(tablanet): タブラ達成時の演出をBasraと同じ形で入れる

### DIFF
--- a/frontend/src/i18n/locales/en/tablanet.json
+++ b/frontend/src/i18n/locales/en/tablanet.json
@@ -39,6 +39,8 @@
   "tablaAnnounce": "{{player}} scored a tabla (cleared the table)",
   "tablaButton": "Tabla Capture!",
   "tablaReady": "Tabla!",
+  "tablaBadge": "Tabla! Table swept",
+  "tablaBadgeOwn": "Tabla! You swept it",
   "table": "Table",
   "tableCandidateAria": "{{card}}, capturable",
   "tableEmpty": "(empty)",

--- a/frontend/src/i18n/locales/ja/tablanet.json
+++ b/frontend/src/i18n/locales/ja/tablanet.json
@@ -39,6 +39,8 @@
   "tablaAnnounce": "{{player}} がタブラ（場を一掃）を達成しました",
   "tablaButton": "タブラ捕獲！",
   "tablaReady": "タブラ！",
+  "tablaBadge": "タブラ！場を一掃",
+  "tablaBadgeOwn": "タブラ！あなたが一掃",
   "table": "場",
   "tableCandidateAria": "{{card}}、キャプチャ可能",
   "tableEmpty": "（なし）",

--- a/frontend/src/pages/TablanetPage.test.tsx
+++ b/frontend/src/pages/TablanetPage.test.tsx
@@ -10,6 +10,17 @@ vi.mock('../api/gameApi', () => ({
   actionLogApi: { tablanet: vi.fn() },
 }));
 
+const mockPlaySound = vi.fn();
+const mockSoundValue = { playSound: mockPlaySound, muted: false, toggleMute: vi.fn() };
+/** 中央のタップ (useGameApi / GamePageShell) も同じ mock を通るので、名前で絞る。 */
+const soundCalls = (name: string) => mockPlaySound.mock.calls.filter((c) => c[0] === name).length;
+
+vi.mock('../providers/SoundProvider', () => ({
+  SoundProvider: ({ children }: { children: React.ReactNode }) => children,
+  useSound: () => mockSoundValue,
+  useOptionalSound: () => mockSoundValue,
+}));
+
 const mockExec = vi.mocked(tablanetApi.exec);
 
 const playPhaseState = makeTablanetState();
@@ -46,6 +57,7 @@ const tablaReadyState = makeTablanetState({
 beforeEach(() => {
   localStorage.clear();
   mockExec.mockReset();
+  mockPlaySound.mockClear();
   mockExec.mockResolvedValue(playPhaseState);
 });
 
@@ -218,5 +230,64 @@ describe('TablanetPage', () => {
     expect(first).toHaveAttribute('aria-pressed', 'false');
     fireEvent.click(first);
     await waitFor(() => expect(screen.getByTestId('table-card-0')).toHaveAttribute('aria-pressed', 'true'));
+  });
+
+  // #5695: タブラは Basra と同じ「自分の名を冠した一掃スコア」なのに、
+  // 達成の瞬間は sr-only のライブリージョンにしか出ておらず、晴眼のプレイヤーには
+  // 音もアニメーションも目立つバッジも無かった (Basra は #3626 で入れている)。
+  const withTabla = (seat: number) =>
+    makeTablanetState({
+      players: playPhaseState.players.map((p, i) => (i === seat ? { ...p, tablaCount: 1 } : p)),
+    });
+
+  const playInto = async (next: ReturnType<typeof makeTablanetState>) => {
+    const handCard = await screen.findByTestId('hand-card-0');
+    fireEvent.click(handCard);
+    fireEvent.click(screen.getByTestId('table-card-0'));
+    mockExec.mockResolvedValue(next);
+    fireEvent.click(screen.getByRole('button', { name: '捕獲' }));
+  };
+
+  it('shows no tabla celebration on a steady play state', async () => {
+    renderWithProviders(<TablanetPage />);
+    await screen.findByTestId('hand-card-0');
+
+    expect(screen.queryByTestId('tablanet-celebration')).not.toBeInTheDocument();
+    expect(screen.getByTestId('tablanet-tabla-count-1')).not.toHaveAttribute('data-emphasised');
+  });
+
+  it('celebrates the human tabla with a badge, a fanfare and the counter emphasised', async () => {
+    renderWithProviders(<TablanetPage />);
+    await playInto(withTabla(0));
+
+    const badge = await screen.findByTestId('tablanet-celebration');
+    expect(badge).toHaveAttribute('role', 'status');
+    expect(badge).toHaveTextContent('あなた');
+    expect(soundCalls('winFanfare')).toBe(1);
+    // 既存の sr-only アナウンスは残す。
+    expect(screen.getByTestId('tablanet-live-region')).toHaveTextContent('タブラ');
+  });
+
+  it('celebrates a CPU tabla with the neutral badge and emphasises that seat', async () => {
+    renderWithProviders(<TablanetPage />);
+    await playInto(withTabla(1));
+
+    const badge = await screen.findByTestId('tablanet-celebration');
+    expect(badge).toHaveTextContent('場を一掃');
+    expect(await screen.findByTestId('tablanet-tabla-count-1')).toHaveAttribute('data-emphasised', 'true');
+    expect(screen.getByTestId('tablanet-tabla-count-2')).not.toHaveAttribute('data-emphasised');
+  });
+
+  // リセットは tablaCount を 0 に戻すので、そこで演出が残ると次のゲームに漏れる。
+  it('clears the celebration when a reset drops the counts back to zero', async () => {
+    renderWithProviders(<TablanetPage />);
+    await playInto(withTabla(0));
+    await screen.findByTestId('tablanet-celebration');
+
+    mockExec.mockResolvedValue(playPhaseState);
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' })); // 確認ダイアログを開く
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+
+    await waitFor(() => expect(screen.queryByTestId('tablanet-celebration')).not.toBeInTheDocument());
   });
 });

--- a/frontend/src/pages/TablanetPage.test.tsx
+++ b/frontend/src/pages/TablanetPage.test.tsx
@@ -264,6 +264,8 @@ describe('TablanetPage', () => {
     expect(badge).toHaveAttribute('role', 'status');
     expect(badge).toHaveTextContent('あなた');
     expect(soundCalls('winFanfare')).toBe(1);
+    // 自分の席のタブラ数も CPU と同じく強調する (レビュー指摘: 自分だけ演出が薄かった)。
+    expect(screen.getByTestId('tablanet-tabla-count-0')).toHaveAttribute('data-emphasised', 'true');
     // 既存の sr-only アナウンスは残す。
     expect(screen.getByTestId('tablanet-live-region')).toHaveTextContent('タブラ');
   });

--- a/frontend/src/pages/TablanetPage.tsx
+++ b/frontend/src/pages/TablanetPage.tsx
@@ -188,8 +188,9 @@ function TablanetPageContent() {
 
   const winnerNames = state.winners.map((i) => (state.players[i]?.isHuman ? t('you') : t('cpu', { id: i }))).join(', ');
 
+  // タブラ数だけは強調の対象になるので、文字列に混ぜず個別の要素で出す。
   const humanStats = human
-    ? `${t('cards', { count: human.cardCount })} · ${t('captured', { count: human.capturedCount })} · ${t('tabla', { count: human.tablaCount })}`
+    ? `${t('cards', { count: human.cardCount })} · ${t('captured', { count: human.capturedCount })}`
     : '';
 
   // 直近の一掃を祝っているあいだ、その席のタブラ数を強調する。
@@ -322,6 +323,18 @@ function TablanetPageContent() {
             <div className="text-center" data-tutorial="tablanet-player-hand">
               <div className="text-xs text-ds-text-muted mb-1">
                 {t('you')} — {humanStats}
+                {human && (
+                  <>
+                    {' · '}
+                    <span
+                      className={tablaCelebration?.seat === human.id ? tablaEmphasisClass : undefined}
+                      data-testid={`tablanet-tabla-count-${human.id}`}
+                      data-emphasised={tablaCelebration?.seat === human.id || undefined}
+                    >
+                      {t('tabla', { count: human.tablaCount })}
+                    </span>
+                  </>
+                )}
               </div>
               <div className="flex flex-wrap justify-center gap-2">
                 {human?.cards.map((c, i) => (

--- a/frontend/src/pages/TablanetPage.tsx
+++ b/frontend/src/pages/TablanetPage.tsx
@@ -19,6 +19,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { CPU_DIFFICULTY_OPTIONS, useTablanetGame } from '../hooks/useTablanetGame';
+import { useSound } from '../providers/SoundProvider';
 import { btnPrimary, btnSuccess } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { TablanetResponse } from '../types/card';
@@ -105,6 +106,11 @@ function TablanetPageContent() {
   const prevPerPlayerRef = useRef<{ captured: number; tabla: number }[] | null>(null);
   const [captureAnnounce, setCaptureAnnounce] = useState('');
   const [announceNonce, setAnnounceNonce] = useState(0);
+  // タブラは Basra の basraCount と同じ「自分の名を冠した一掃スコア」で、CPU の
+  // 速い手番の中では見逃しやすい。sr-only のアナウンスだけでなく、Basra と同じ
+  // バッジ + リング + winFanfare でも知らせる (#5695 / Basra は #3626)。
+  const [tablaCelebration, setTablaCelebration] = useState<{ key: number; own: boolean; seat: number } | null>(null);
+  const { playSound } = useSound();
   // biome-ignore lint/correctness/useExhaustiveDependencies: react to each state update; reads the t snapshot deliberately.
   useEffect(() => {
     if (!state) return;
@@ -123,6 +129,13 @@ function TablanetPageContent() {
     if (tablaPlayers.length > 0) {
       setCaptureAnnounce(t('tablaAnnounce', { player: tablaPlayers.map(nameOf).join(t('listSeparator')) }));
       setAnnounceNonce((n) => n + 1);
+      const seat = tablaPlayers[tablaPlayers.length - 1];
+      setTablaCelebration((c) => ({ key: (c?.key ?? 0) + 1, own: state.players[seat]?.isHuman ?? false, seat }));
+      playSound('winFanfare', { pitchVariation: 0.05 });
+    } else if (cur.some((c, i) => c.tabla < (prev[i]?.tabla ?? c.tabla))) {
+      // リセット / 次ゲームは tablaCount を 0 に戻す。古いバッジをここで消さないと
+      // 次のゲームへ演出が漏れる。
+      setTablaCelebration(null);
     } else if (capturePlayers.length > 0) {
       setCaptureAnnounce(t('captureAnnounce', { player: capturePlayers.map(nameOf).join(t('listSeparator')) }));
       setAnnounceNonce((n) => n + 1);
@@ -179,6 +192,10 @@ function TablanetPageContent() {
     ? `${t('cards', { count: human.cardCount })} · ${t('captured', { count: human.capturedCount })} · ${t('tabla', { count: human.tablaCount })}`
     : '';
 
+  // 直近の一掃を祝っているあいだ、その席のタブラ数を強調する。
+  const tablaEmphasisClass =
+    'inline-block rounded px-1 ring-2 ring-ds-accent text-ds-accent font-bold motion-safe:animate-pulse';
+
   return (
     <GamePageShell
       title={tc('nav.tablanet')}
@@ -212,7 +229,13 @@ function TablanetPageContent() {
                   <div key={p.id} className="text-center">
                     <div className="text-xs text-ds-text-muted mb-1">
                       {t('cpu', { id: p.id })} — {t('captured', { count: p.capturedCount })} ·{' '}
-                      {t('tabla', { count: p.tablaCount })}
+                      <span
+                        className={tablaCelebration?.seat === p.id ? tablaEmphasisClass : undefined}
+                        data-testid={`tablanet-tabla-count-${p.id}`}
+                        data-emphasised={tablaCelebration?.seat === p.id || undefined}
+                      >
+                        {t('tabla', { count: p.tablaCount })}
+                      </span>
                     </div>
                     <div className="flex gap-0.5 justify-center">
                       {Array.from({ length: Math.min(p.cardCount, 8) }, (_, i) => (
@@ -225,12 +248,25 @@ function TablanetPageContent() {
 
             {/* Table cards */}
             <div
-              className={`py-3 rounded-lg transition-all ${
+              className={`relative py-3 rounded-lg transition-all ${
                 tablaPossible ? 'bg-ds-success/20 ring-2 ring-ds-success motion-safe:animate-pulse' : 'bg-black/20'
               }`}
               data-tutorial="tablanet-table-cards"
               data-tabla-ready={tablaPossible || undefined}
             >
+              {tablaCelebration && (
+                <div
+                  key={tablaCelebration.key}
+                  className="absolute inset-x-0 -top-3 z-10 flex justify-center motion-safe:animate-bounce pointer-events-none"
+                  role="status"
+                  aria-live="polite"
+                  data-testid="tablanet-celebration"
+                >
+                  <span className="rounded-full px-3 py-1 text-sm font-bold shadow-lg bg-ds-accent text-ds-text-on-accent ring-2 ring-ds-accent">
+                    {tablaCelebration.own ? t('tablaBadgeOwn') : t('tablaBadge')}
+                  </span>
+                </div>
+              )}
               <div className="text-center text-xs text-ds-text-muted mb-2">
                 {t('table')}
                 {tablaPossible && (


### PR DESCRIPTION
## 背景

姉妹ゲーム Basra は「盤面を1枚で一掃する」達成時に演出（リング + バッジ +
`playSound('winFanfare')` + バウンス）を #3626 で入れている。理由も「CPU の速い
ターンの中で見逃しやすい」と明記されている。Tablanet の `tablaCount` は
`basraCount` と全く同じ位置づけの一掃スコアなのに、あるのは達成**前**の予告バッジ
(`tablaReady`) と、達成後の `sr-only` ライブリージョンだけで、**晴眼のプレイヤーは
達成の瞬間を知らされない**状態だった。

## 変更

- `tablaBadge` / `tablaBadgeOwn` を ja/en に追加（Basra の `basraBadge` に対応）
- 既存の per-player 差分エフェクトに相乗りして（新しい ref を増やさない）、
  `tablaCount` が上がった席に:
  - 中央バッジ `tablanet-celebration`（`role="status"`、`key` で毎回再生）
  - その席のタブラ数にリング強調（`data-emphasised`）
  - `playSound('winFanfare', { pitchVariation: 0.05 })`
- `tablaCount` が**下がった**とき（リセット / 次ゲーム）はバッジを消す
- 既存の `captureAnnounce` / `tablaAnnounce` の sr-only アナウンスはそのまま

## テスト

- 平常時は出ない / 自分のタブラ（自分向けバッジ + fanfare 1回 + sr-only は維持）/
  CPU のタブラ（中立バッジ + その席だけ強調）/ **リセットで消える**（確認ダイアログまで押す）
- ミューテーション3件で検出を確認:
  - `playSound('winFanfare')` を削除 … FAIL
  - リセット時のクリア分岐を無効化 … FAIL
  - `own` を常に false … FAIL
- `bun run typecheck` green、`bun run check` green、`TablanetPage.test.tsx` 19 tests green

Closes #5695