### PR TITLE
feat(watten): レイズ履歴を live region にする

### DIFF
--- a/frontend/src/pages/WattenPage.test.tsx
+++ b/frontend/src/pages/WattenPage.test.tsx
@@ -183,6 +183,23 @@ describe('WattenPage', () => {
     expect(screen.queryByRole('button', { name: /レイズ/ })).not.toBeInTheDocument();
   });
 
+  // #5701: スタークの吊り上げ (レイズ / hold / フォールドの応酬) がこのゲームの
+  // 核心なのに、履歴パネルは live region ではなく、スクリーンリーダー利用者には
+  // 賭け金が動いたことが一切伝わらなかった。
+  it('announces the stake history as a polite live region', async () => {
+    mockActionLog.mockResolvedValue({
+      entries: [logEntry(1, 'declare', 0), logEntry(2, 'raise', 1)],
+    });
+    renderWithProviders(<WattenPage />);
+
+    const panel = await screen.findByTestId('watten-stake-history');
+
+    expect(panel).toHaveAttribute('role', 'status');
+    expect(panel).toHaveAttribute('aria-live', 'polite');
+    // 読み上げ対象の中に、誰がいくらへ上げたかが入っていること。
+    expect(panel).toHaveTextContent('CPU 1 レイズ→3');
+  });
+
   it('renders the stake-escalation mini-history in order when the action log has raises', async () => {
     mockActionLog.mockResolvedValue({
       entries: [

--- a/frontend/src/pages/WattenPage.tsx
+++ b/frontend/src/pages/WattenPage.tsx
@@ -324,6 +324,10 @@ function WattenPageContent() {
                   <div
                     className="mb-2 p-2 rounded bg-black/30 text-ds-text-muted text-sm"
                     data-testid="watten-stake-history"
+                    // 賭け金の吊り上げはこのゲームの核心なので、履歴が伸びるたびに
+                    // 読み上げる。視覚レイアウトは変えない。
+                    role="status"
+                    aria-live="polite"
                   >
                     <div className="text-ds-text-primary mb-1">{t('stakeHistory.title')}</div>
                     <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">


### PR DESCRIPTION
## 背景

Watten の核心はスターク（賭け金）の吊り上げで、`watten-stake-history` パネルが
`buildWattenStakeHistory` の結果をミニ履歴として出している。ところがこの `<div>` には
live region が無く、**賭け金が動いたこと自体**がスクリーンリーダー利用者に伝わらなかった。

## 変更

- `watten-stake-history` に `role="status"` + `aria-live="polite"` を付与
- 視覚的なレイアウト・クラスは一切変更なし

## テスト

- `announces the stake history as a polite live region` — 属性と、読み上げ内容に
  「誰がいくらへ上げたか」が入っていることを検証
- ミューテーション1件で検出を確認: 2 属性を外す … FAIL
- 既存の 18 テスト（履歴の並び順・非表示条件など）はそのまま green
- `bun run typecheck` / `bun run check` green

Closes #5701