### PR TITLE
feat(anaconda): パス先のプレイヤー名をWebにも出す

### DIFF
--- a/frontend/src/i18n/locales/en/anaconda.json
+++ b/frontend/src/i18n/locales/en/anaconda.json
@@ -28,6 +28,7 @@
   "selectionOver": "Remove {{n}} card(s) ({{selected}}/{{required}})",
   "selectionReady": "Selection complete ({{selected}}/{{required}})",
   "passNotice": "Pass phase — choose {{count}} card(s) to pass left.",
+  "passNoticeTo": "Pass phase — choose {{count}} card(s) to pass to {{name}}.",
   "setNotice": "Set phase — keep your best 5 cards (discard 2).",
   "rollNotice": "Roll phase — {{revealed}}/5 revealed. Call, raise, or fold.",
   "badge": {

--- a/frontend/src/i18n/locales/ja/anaconda.json
+++ b/frontend/src/i18n/locales/ja/anaconda.json
@@ -28,6 +28,7 @@
   "selectionOver": "{{n}} 枚外してください（{{selected}}/{{required}}）",
   "selectionReady": "選択完了（{{selected}}/{{required}}）",
   "passNotice": "パスフェーズ — 左隣へ渡すカードを {{count}} 枚選んでください。",
+  "passNoticeTo": "パスフェーズ — {{name}} へ渡すカードを {{count}} 枚選んでください。",
   "setNotice": "セットフェーズ — 残す5枚を選んでください（2枚を捨てる）。",
   "rollNotice": "ロールフェーズ — {{revealed}}/5 公開。コール・レイズ・フォールドを選択。",
   "badge": {

--- a/frontend/src/pages/AnacondaPage.test.tsx
+++ b/frontend/src/pages/AnacondaPage.test.tsx
@@ -272,4 +272,33 @@ describe('AnacondaPage', () => {
     await waitFor(() => expect(mockExec).toHaveBeenCalled());
     expect(document.querySelectorAll('[data-hint-card="true"]')).toHaveLength(0);
   });
+
+  // #5703: 「左隣」は脱落者を飛ばすので席番号 +1 とは限らない。CUI は受取人を
+  // 名指ししていたのに、Web は「左隣へ」としか出しておらず、実際に誰へ渡るのかが
+  // 卓の状況次第で分からなかった。
+  it('names the seat that will receive the passed cards', async () => {
+    mockExec.mockResolvedValue(passState);
+    renderWithProviders(<AnacondaPage />);
+
+    const notice = await screen.findByTestId('anaconda-pass-notice');
+
+    expect(notice).toHaveTextContent('CPU 1');
+  });
+
+  it('skips eliminated seats when naming the recipient', async () => {
+    mockExec.mockResolvedValue(
+      makeAnacondaState({
+        phase: 0,
+        passCount: 3,
+        isHumanTurn: true,
+        players: passState.players.map((p) => (p.id === 1 ? { ...p, out: true } : p)),
+      }),
+    );
+    renderWithProviders(<AnacondaPage />);
+
+    const notice = await screen.findByTestId('anaconda-pass-notice');
+
+    expect(notice).toHaveTextContent('CPU 2');
+    expect(notice).not.toHaveTextContent('CPU 1');
+  });
 });

--- a/frontend/src/pages/AnacondaPage.tsx
+++ b/frontend/src/pages/AnacondaPage.tsx
@@ -34,6 +34,7 @@ import { gameTheme } from '../styles/gameTheme';
 import type { AnacondaResponse } from '../types/card';
 import { AnacondaPhase } from '../types/phases';
 import type { TutorialStep } from '../types/tutorial';
+import { anacondaPassRecipient } from '../utils/anacondaPass';
 import { ANACONDA_HELP, parseAnacondaCommand } from '../utils/cli/commands/anacondaCommands';
 import { formatAnacondaState } from '../utils/cli/formatters/anacondaFormatter';
 import type { CliGameConfig } from '../utils/cli/types';
@@ -174,6 +175,9 @@ function AnacondaPageContent() {
   const humanTurn = state.isHumanTurn && !isGameEnd;
   const humanWonMatch = state.matchWinnerIdx >= 0 && (state.players[state.matchWinnerIdx]?.isHuman ?? false);
 
+  // 受取人は「左隣」ではなく「脱落者を飛ばした次の現存プレイヤー」。
+  const passRecipient = anacondaPassRecipient(state.players);
+
   const canSelectCards = (isPassPhase || isSetPhase) && humanTurn;
   const passReady = isPassPhase && humanTurn && selected.length === state.passCount;
   const keepReady = isSetPhase && humanTurn && selected.length === KEEP_SIZE;
@@ -304,8 +308,18 @@ function AnacondaPageContent() {
             </div>
 
             {isPassPhase && humanTurn && (
-              <div className="text-ds-text-muted text-center mb-2 text-sm font-semibold">
-                {t('passNotice', { count: state.passCount })}
+              <div
+                className="text-ds-text-muted text-center mb-2 text-sm font-semibold"
+                data-testid="anaconda-pass-notice"
+              >
+                {/* 「左隣」は脱落者を飛ばすので席番号 +1 とは限らない。CUI は
+                    受取人を名指ししているので、Web でも同じ相手を出す。 */}
+                {passRecipient >= 0
+                  ? t('passNoticeTo', {
+                      count: state.passCount,
+                      name: playerLabel(passRecipient, state.players[passRecipient]?.isHuman ?? false),
+                    })
+                  : t('passNotice', { count: state.passCount })}
               </div>
             )}
             {isSetPhase && humanTurn && (

--- a/frontend/src/utils/__fixtures__/anacondaPassRecipient.golden.json
+++ b/frontend/src/utils/__fixtures__/anacondaPassRecipient.golden.json
@@ -1,0 +1,55 @@
+{
+  "_comment": "Golden vectors for the Anaconda pass recipient. Two implementations read this file: internal/adapter/presenter/AnacondaCuiPresenter_test.go (anacondaPassRecipient) and frontend/src/utils/anacondaPass.test.ts (anacondaPassRecipient). Seats are listed in table order; `human` marks the human seat and `out` marks eliminated seats. `recipient` is the seat index the human passes to, or -1 when nobody can receive.",
+  "cases": [
+    {
+      "name": "four seats, nobody out: the human passes to the next seat",
+      "seats": [
+        { "human": true, "out": false },
+        { "human": false, "out": false },
+        { "human": false, "out": false },
+        { "human": false, "out": false }
+      ],
+      "recipient": 1
+    },
+    {
+      "name": "the seat on the left is out, so the pass skips to the one beyond it",
+      "seats": [
+        { "human": true, "out": false },
+        { "human": false, "out": true },
+        { "human": false, "out": false },
+        { "human": false, "out": false }
+      ],
+      "recipient": 2
+    },
+    {
+      "name": "every other seat but one is out",
+      "seats": [
+        { "human": true, "out": false },
+        { "human": false, "out": true },
+        { "human": false, "out": true },
+        { "human": false, "out": false }
+      ],
+      "recipient": 3
+    },
+    {
+      "name": "the human is the last seat and wraps around to the first survivor",
+      "seats": [
+        { "human": false, "out": true },
+        { "human": false, "out": false },
+        { "human": false, "out": false },
+        { "human": true, "out": false }
+      ],
+      "recipient": 1
+    },
+    {
+      "name": "the human is the only survivor: nobody to pass to",
+      "seats": [{ "human": true, "out": false }, { "human": false, "out": true }, { "human": false, "out": true }],
+      "recipient": -1
+    },
+    {
+      "name": "the human is out: nothing to pass",
+      "seats": [{ "human": true, "out": true }, { "human": false, "out": false }, { "human": false, "out": false }],
+      "recipient": -1
+    }
+  ]
+}

--- a/frontend/src/utils/anacondaPass.test.ts
+++ b/frontend/src/utils/anacondaPass.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import golden from './__fixtures__/anacondaPassRecipient.golden.json';
+import { anacondaPassRecipient } from './anacondaPass';
+
+describe('anacondaPassRecipient golden vectors (shared with the CUI presenter)', () => {
+  it('has vectors to check', () => {
+    expect(golden.cases.length).toBeGreaterThan(0);
+  });
+
+  it.each(golden.cases)('$name', (c) => {
+    const seats = c.seats.map((s) => ({ isHuman: s.human, out: s.out }));
+
+    expect(anacondaPassRecipient(seats)).toBe(c.recipient);
+  });
+});

--- a/frontend/src/utils/anacondaPass.ts
+++ b/frontend/src/utils/anacondaPass.ts
@@ -1,0 +1,31 @@
+/** The minimum a seat must expose for {@link anacondaPassRecipient}. */
+export interface AnacondaPassSeat {
+  /** Whether this seat is the human player. */
+  isHuman: boolean;
+  /** Whether this seat is out of the round (eliminated or folded). */
+  out: boolean;
+}
+
+/**
+ * Seat index the human passes their cards to.
+ *
+ * Anaconda passes to the left, but **skips seats that are out**, so with
+ * eliminations "left" is not simply `id + 1`. Mirrors `anacondaPassRecipient` in
+ * `internal/adapter/presenter/AnacondaCuiPresenter.go`; the two are held together
+ * by `frontend/src/utils/__fixtures__/anacondaPassRecipient.golden.json`, which
+ * both test suites assert against.
+ *
+ * @param seats - Every seat at the table, in table order.
+ * @returns The receiving seat index, or -1 when the human is out or alone.
+ */
+export function anacondaPassRecipient(seats: readonly AnacondaPassSeat[]): number {
+  let humanPos = -1;
+  const participants: number[] = [];
+  seats.forEach((seat, index) => {
+    if (seat.out) return;
+    if (seat.isHuman) humanPos = participants.length;
+    participants.push(index);
+  });
+  if (humanPos < 0 || participants.length < 2) return -1;
+  return participants[(humanPos + 1) % participants.length];
+}

--- a/internal/adapter/presenter/anaconda_pass_golden_test.go
+++ b/internal/adapter/presenter/anaconda_pass_golden_test.go
@@ -1,0 +1,65 @@
+//go:build test && (!js || !wasm || extra)
+
+package presenter
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+)
+
+// anacondaGolden mirrors frontend/src/utils/__fixtures__/anacondaPassRecipient.golden.json.
+type anacondaGolden struct {
+	Cases []struct {
+		Name  string `json:"name"`
+		Seats []struct {
+			Human bool `json:"human"`
+			Out   bool `json:"out"`
+		} `json:"seats"`
+		Recipient int `json:"recipient"`
+	} `json:"cases"`
+}
+
+// #5703: 「左隣」は脱落者を飛ばすので、席番号 +1 ではない。Web は受取人を
+// 名指しできるよう同じ判定を TypeScript に持つことになったので、両者を同じ
+// golden vector で縛る。
+func TestAnacondaPassRecipient_GoldenVectors(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join(
+		"..", "..", "..", "frontend", "src", "utils", "__fixtures__", "anacondaPassRecipient.golden.json"))
+	require.NoError(t, err)
+	var golden anacondaGolden
+	require.NoError(t, json.Unmarshal(raw, &golden))
+	require.NotEmpty(t, golden.Cases)
+
+	sawSkip, sawNone := false, false
+	for _, c := range golden.Cases {
+		t.Run(c.Name, func(t *testing.T) {
+			players := make([]*domain.AnacondaPlayer, 0, len(c.Seats))
+			for _, s := range c.Seats {
+				pl := domain.NewAnacondaPlayer(s.Human, 100)
+				pl.SetOut(s.Out)
+				players = append(players, pl)
+			}
+			g := domain.NewAnaconda(domain.NewTrumpCards(0), players, domain.DefaultAnacondaConfig())
+
+			assert.Equal(t, c.Recipient, anacondaPassRecipient(g))
+		})
+		if c.Recipient < 0 {
+			sawNone = true
+		}
+		for i, s := range c.Seats {
+			if s.Out && c.Recipient >= 0 && i < c.Recipient {
+				sawSkip = true
+			}
+		}
+	}
+	// 負のコントロール: 脱落者を飛ばす case と受取人不在の case が要る。
+	assert.True(t, sawSkip, "the golden vectors must include a skipped seat")
+	assert.True(t, sawNone, "the golden vectors must include a table with no recipient")
+}


### PR DESCRIPTION
## 背景

Anaconda のパスは**脱落者を飛ばして**次の現存プレイヤーへ渡るので、「左隣」は
席番号 +1 とは限らない。CUI (`anacondaPassRecipient`) は受取人を名指ししているのに、
Web の `passNotice` は「左隣へ渡すカードを N 枚選んでください」だけで、実際に誰へ渡るのかが
卓の状況次第で分からなかった。

## 変更

- `frontend/src/utils/anacondaPass.ts` に `anacondaPassRecipient(seats)` を追加（CUI と同じ判定）
- `passNoticeTo` を ja/en に追加し、受取人がいるときは名前入りの文言に切り替え
  （受取人がいない＝1人だけ残った場合は従来の文言）
- **CUI と一致することを golden vector で縛る**:
  `frontend/src/utils/__fixtures__/anacondaPassRecipient.golden.json` を
  `TestAnacondaPassRecipient_GoldenVectors`（Go, presenter パッケージ内）と
  `anacondaPass.test.ts`（TS）の両方が検証。**脱落者を飛ばす case と受取人不在の case を
  含んでいること**を負のコントロールとして assert しています

## テスト

- `AnacondaPage.test.tsx` — 通常時は CPU 1、CPU 1 が脱落しているときは CPU 2 と出ること
- golden 6 ケース（隣接 / 1人飛ばし / 2人飛ばし / 折り返し / 受取人なし / 人間が脱落）
- ミューテーション2件で検出を確認:
  - Go 側の `GetOut()` スキップを外す … golden + 既存テスト FAIL
  - TS 側の `seat.out` スキップを外す … 6 tests FAIL
- `golangci-lint run ./internal/...` 0 issues、`bun run check` / `typecheck` green

Closes #5703