### PR TITLE
refactor(rook): アクションボタンを共通デザイントークンに揃える

### DIFF
--- a/frontend/src/pages/RookPage.test.tsx
+++ b/frontend/src/pages/RookPage.test.tsx
@@ -85,6 +85,24 @@ describe('RookPage', () => {
     expect(screen.getByTestId('bid-button')).toBeEnabled();
   });
 
+  // #5708: 他ページは buttonStyles.ts の共通トークンを使うのに、Rook だけ生の
+  // Tailwind クラスを直書きしていた。共通トークンには 44px の最小タップ領域と
+  // フォーカスリングが入っており、直書きの側にはそれが無かった。
+  it('styles its action buttons with the shared button tokens', async () => {
+    renderWithProviders(<RookPage />);
+
+    const bid = await screen.findByTestId('bid-button');
+    const pass = screen.getByTestId('pass-button');
+
+    for (const button of [bid, pass]) {
+      expect(button.className).toContain('min-h-[44px]'); // 共通トークンの最小タップ領域
+      expect(button.className).toContain('focus-visible:ring-ds-accent');
+      expect(button.className).not.toContain('bg-ds-info'); // 直書きの色は残さない
+    }
+    expect(bid.className).toContain('bg-ds-accent');
+    expect(pass.className).toContain('bg-ds-warning');
+  });
+
   it('shows a visible label associated with the bid selector', async () => {
     renderWithProviders(<RookPage />);
     const label = await screen.findByTestId('rook-bid-label');

--- a/frontend/src/pages/RookPage.tsx
+++ b/frontend/src/pages/RookPage.tsx
@@ -18,6 +18,7 @@ import { useCliMode } from '../hooks/useCliMode';
 import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { useRookGame } from '../hooks/useRookGame';
+import { btnPrimary, btnWarning } from '../styles/buttonStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { RookResponse } from '../types/card';
 import { RookPhase } from '../types/phases';
@@ -439,7 +440,7 @@ function RookPageContent() {
                     onClick={() => bid(effectiveBid)}
                     disabled={loading || bidOptions.length === 0}
                     data-testid="bid-button"
-                    className="px-4 py-2 rounded-lg bg-ds-info text-white text-sm disabled:opacity-40"
+                    className={btnPrimary}
                   >
                     {t('bidButton')}
                   </button>
@@ -447,7 +448,7 @@ function RookPageContent() {
                     type="button"
                     onClick={pass}
                     disabled={loading}
-                    className="px-4 py-2 rounded-lg bg-ds-warning text-white text-sm disabled:opacity-40"
+                    className={btnWarning}
                     data-testid="pass-button"
                   >
                     {t('passButton')}
@@ -481,7 +482,7 @@ function RookPageContent() {
                     type="button"
                     onClick={handleExchange}
                     disabled={loading || selectedCardIndices.length !== ROOK_DISCARD_COUNT || trumpChoice === null}
-                    className="px-4 py-2 rounded-lg bg-ds-info text-white text-sm disabled:opacity-40"
+                    className={btnPrimary}
                     data-testid="exchange-button"
                   >
                     {t('exchangeButton', { count: selectedCardIndices.length })}
@@ -494,7 +495,7 @@ function RookPageContent() {
                   type="button"
                   onClick={handlePlay}
                   disabled={loading || selectedCardIndices[0] === undefined}
-                  className="px-4 py-2 rounded-lg bg-ds-info text-white text-sm disabled:opacity-40"
+                  className={btnPrimary}
                   data-testid="play-button"
                 >
                   {t('playButton')}
@@ -506,7 +507,7 @@ function RookPageContent() {
                   type="button"
                   onClick={nextTrick}
                   disabled={loading}
-                  className="px-4 py-2 rounded-lg bg-ds-info text-white text-sm disabled:opacity-40"
+                  className={btnPrimary}
                   data-testid="next-button"
                 >
                   {t('nextTrickButton')}
@@ -518,7 +519,7 @@ function RookPageContent() {
                   type="button"
                   onClick={nextRound}
                   disabled={loading}
-                  className="px-4 py-2 rounded-lg bg-ds-info text-white text-sm disabled:opacity-40"
+                  className={btnPrimary}
                   data-testid="nextround-button"
                 >
                   {t('nextRoundButton')}


### PR DESCRIPTION
## 背景

このグループの他ページ（Watten / Carioca / Samba / Machiavelli / Pan / Wizard …）は
`frontend/src/styles/buttonStyles.ts` の共通トークンを使っているのに、`RookPage.tsx` だけ
`bg-ds-info text-white text-sm disabled:opacity-40` のような生の Tailwind クラスを
6 か所に直書きしていた。

**見た目の統一だけの話ではありません**: 共通トークンの `base` には
`min-h-[44px]`（タップ領域）と `focus-visible:ring-ds-accent`（キーボードフォーカス）が
入っており、直書きの側にはどちらも無かった。

## 変更

- bid / exchange / play / nextTrick / nextRound → `btnPrimary`
- pass → `btnWarning`（元の警告色のトーンを維持）
- 生の `bg-ds-info` / `bg-ds-warning` ボタンクラスは残っていません

## テスト

- `styles its action buttons with the shared button tokens` — 44px の最小タップ領域と
  フォーカスリングが入ったこと、直書きの色が消えたこと、bid=accent / pass=warning
- ミューテーション1件で検出を確認: pass を `btnPrimary` に変える … FAIL
- 既存の 20 テスト（`data-testid` ベース）はそのまま green
- `bun run check` / `bun run typecheck` green

Closes #5708