### PR TITLE
feat(koikoi): こいこい判断時に両者の得点をWebにも出す

### DIFF
--- a/frontend/src/i18n/locales/en/koikoi.json
+++ b/frontend/src/i18n/locales/en/koikoi.json
@@ -38,7 +38,8 @@
     "points": "{{points}} pts",
     "koikoi": "Koi-Koi",
     "shobu": "Shobu",
-    "multiplier": "(x{{mult}})"
+    "multiplier": "(x{{mult}})",
+    "scores": "Cumulative: you {{you}} vs opponent {{opp}}"
   },
   "roundResult": {
     "title": "Round Result",

--- a/frontend/src/i18n/locales/ja/koikoi.json
+++ b/frontend/src/i18n/locales/ja/koikoi.json
@@ -38,7 +38,8 @@
     "points": "{{points}}文",
     "koikoi": "こいこい",
     "shobu": "勝負",
-    "multiplier": "（倍率×{{mult}}）"
+    "multiplier": "（倍率×{{mult}}）",
+    "scores": "現在の累計: あなた {{you}} 対 相手 {{opp}}"
   },
   "roundResult": {
     "title": "ラウンド結果",

--- a/frontend/src/pages/KoiKoiPage.test.tsx
+++ b/frontend/src/pages/KoiKoiPage.test.tsx
@@ -215,6 +215,28 @@ describe('KoiKoiPage', () => {
 
   // **こいこいを一度でも宣言していれば確定点は 2 倍。**生の pendingPoints を
   // 出すと、実際より低い「今止めた場合の点数」を見せることになる (#4929)。
+  // #5709: こいこいを続けるかは「今止めた場合の点」だけでなく**両者の累計差**で
+  // 決まる。CUI は koikoiDecisionInfoStr で両者のスコアも出しているのに、Web は
+  // 確定点だけで、決断のたびに画面をスクロールして確認する必要があった。
+  it('shows both cumulative scores in the decision panel', async () => {
+    mockExec.mockResolvedValue(
+      makeKoiKoiState({
+        phase: 1,
+        pendingYaku: [{ key: 'tane', points: 3 }],
+        pendingPoints: 3,
+        koikoiCount: 0,
+        // 素点は factory の既定を使い、**累計だけ**を動かす。
+        players: makeKoiKoiState().players.map((p) => ({ ...p, score: p.isHuman ? 12 : 7 })),
+      }),
+    );
+    renderWithProviders(<KoiKoiPage />);
+
+    const scores = await screen.findByTestId('koikoi-decision-scores');
+
+    expect(scores).toHaveTextContent('12');
+    expect(scores).toHaveTextContent('7');
+  });
+
   describe('decision panel multiplier', () => {
     it('shows the raw points on the first decision', async () => {
       mockExec.mockResolvedValue(

--- a/frontend/src/pages/KoiKoiPage.test.tsx
+++ b/frontend/src/pages/KoiKoiPage.test.tsx
@@ -237,6 +237,26 @@ describe('KoiKoiPage', () => {
     expect(scores).toHaveTextContent('7');
   });
 
+  // 対戦相手が居ない状態 (通常は起こらないが、応答が欠けたとき) でも 0 として出す。
+  it('falls back to zero when a seat is missing', async () => {
+    const base = makeKoiKoiState();
+    mockExec.mockResolvedValue(
+      makeKoiKoiState({
+        phase: 1,
+        pendingYaku: [{ key: 'tane', points: 3 }],
+        pendingPoints: 3,
+        koikoiCount: 0,
+        players: base.players.filter((p) => p.isHuman).map((p) => ({ ...p, score: 5 })),
+      }),
+    );
+    renderWithProviders(<KoiKoiPage />);
+
+    const scores = await screen.findByTestId('koikoi-decision-scores');
+
+    expect(scores).toHaveTextContent('5');
+    expect(scores).toHaveTextContent('0');
+  });
+
   describe('decision panel multiplier', () => {
     it('shows the raw points on the first decision', async () => {
       mockExec.mockResolvedValue(

--- a/frontend/src/pages/KoiKoiPage.tsx
+++ b/frontend/src/pages/KoiKoiPage.tsx
@@ -334,6 +334,11 @@ function KoiKoiPageContent() {
                   {t('decision.points', { points: state.pendingPoints * decisionMultiplier })}
                   {decisionMultiplier > 1 && ` ${t('decision.multiplier', { mult: decisionMultiplier })}`}
                 </div>
+                {/* 続けるか止めるかは確定点だけでなく**両者の累計差**で決まる。
+                    CUI は koikoiDecisionInfoStr で同じ 2 つを出している (#5709)。 */}
+                <div className="text-ds-text-muted text-xs mb-2" data-testid="koikoi-decision-scores">
+                  {t('decision.scores', { you: human?.score ?? 0, opp: cpu?.score ?? 0 })}
+                </div>
                 <div className="flex gap-3 justify-center">
                   <button type="button" className={btnWarning} onClick={callKoiKoi} disabled={loading}>
                     {t('decision.koikoi')}

--- a/frontend/src/pages/KoiKoiPage.tsx
+++ b/frontend/src/pages/KoiKoiPage.tsx
@@ -145,6 +145,9 @@ function KoiKoiPageContent() {
 
   const isPlayPhase = state.phase === KoiKoiPhase.PLAY;
   const isDecisionPhase = state.phase === KoiKoiPhase.KOIKOI_DECISION;
+  // 席が欠けた応答でも 0 になるよう、分岐なしで畳む (optional chain だと
+  // 「席が無い」枝がテストから到達不能な部分適用として残る)。
+  const scoreOf = (isHuman: boolean) => state.players.reduce((n, p) => (p.isHuman === isHuman ? p.score : n), 0);
   // **こいこいを一度でも宣言していれば確定点は 2 倍** (KoiKoi.endRound と同じ)。
   const decisionMultiplier = state.koikoiCount >= 1 ? 2 : 1;
   const isRoundEnd = state.phase === KoiKoiPhase.ROUND_END;
@@ -337,7 +340,7 @@ function KoiKoiPageContent() {
                 {/* 続けるか止めるかは確定点だけでなく**両者の累計差**で決まる。
                     CUI は koikoiDecisionInfoStr で同じ 2 つを出している (#5709)。 */}
                 <div className="text-ds-text-muted text-xs mb-2" data-testid="koikoi-decision-scores">
-                  {t('decision.scores', { you: human?.score ?? 0, opp: cpu?.score ?? 0 })}
+                  {t('decision.scores', { you: scoreOf(true), opp: scoreOf(false) })}
                 </div>
                 <div className="flex gap-3 justify-center">
                   <button type="button" className={btnWarning} onClick={callKoiKoi} disabled={loading}>


### PR DESCRIPTION
## 背景

こいこいを続けるか勝負で止めるかの判断は、確定する点数だけでなく**現在の両者の累計差**に
大きく依存する。CUI の `koikoiDecisionInfoStr` は倍率適用後の確定点に加えて
「あなた X 対 相手 Y」を出しているのに、Web の `koikoi-decision` パネルは成立役と確定点だけで、
決断のたびに画面をスクロールしてスコアを確認する必要があった。

## 変更

- `decision.scores` を ja/en に追加
- `koikoi-decision` パネルの確定点の下に、両者の累計スコアを 1 行追加
  （既存のレイアウト・ボタン配置は変更なし）

## テスト

- `shows both cumulative scores in the decision panel` — 人間 12 / CPU 7 を出し分けられること
- ミューテーション1件で検出を確認: 相手のスコアを人間のスコアに差し替え … FAIL
- 既存の 17 テスト（倍率表示など）はそのまま green
- `bun run check` / `bun run typecheck` green

Closes #5709