### PR TITLE
fix(e2e): ナチュラルBJの配りで blackjack.spec が落ちるのを直す

### DIFF
--- a/frontend/e2e/blackjack.spec.ts
+++ b/frontend/e2e/blackjack.spec.ts
@@ -19,14 +19,20 @@ test.describe('BlackJack E2E', () => {
       await waitForLoaded(page);
     }
 
-    // ACTION phase: click スタンド
+    // A natural blackjack (dealer's, or every player hand) settles the round in
+    // checkNaturalBlackJack without ever entering the ACTION phase, so スタンド
+    // never appears on those deals -- wait for either state rather than assuming
+    // one (#6063).
     const standButton = page.getByRole('button', { name: 'スタンド' });
-    await expect(standButton).toBeVisible({ timeout: 5_000 });
-    await standButton.click();
-    await waitForLoaded(page);
-
-    // END phase: 次のゲーム button should be visible
     const resetButton = page.getByRole('button', { name: '次のゲーム' });
+    await expect(standButton.or(resetButton).first()).toBeVisible({ timeout: 5_000 });
+
+    if (await standButton.isVisible()) {
+      await standButton.click();
+      await waitForLoaded(page);
+    }
+
+    // END phase: 次のゲーム button should be visible either way
     await expect(resetButton).toBeVisible({ timeout: 10_000 });
   });
 });


### PR DESCRIPTION
## 背景

`blackjack.spec.ts:24` が `element(s) not found` で落ちるのを**無関係な差分の PR で 2 回**観測しました
（2 回目は**ドキュメント 1 行だけ**の PR #6058 なので、差分が原因ではありえません）。flake ledger で
CONFIRMED になったため、原因を調べて直します。

## 原因（配り依存）

`internal/domain/BlackJackEval.go:224` の `checkNaturalBlackJack` は

- ディーラーがナチュラル BJ → 即 `endGame()`
- プレイヤー側が全ハンド BJ → 同じく即決着

します。つまり **ACTION フェーズに入らない配りが存在する**（合わせておよそ 9%）ため、
「スタンド」ボタンが出ません。spec はそれを無条件に待っていました。

**タイムアウトを伸ばす修正では直りません**（待っても出ないボタンなので）。

## 変更

`crazyeights.spec.ts` と同じく、スタンド／次のゲームの**どちらが出ても進める**形にしました。
通常の配りでは従来どおりスタンドを押し、ナチュラルの配りではそのまま決着を確認します。

## テスト

E2E はローカルで走らせていません（この配りは CI の乱数依存で、ローカルで狙って再現できないため）。
ロジック上、従来通る配りでは同じ経路を通り、落ちていた配りでは決着側の assert に進みます。

Closes #6063