### PR TITLE
fix(e2e): let kille tolerate a human eliminated before its turn

### DIFF
--- a/frontend/e2e/kille.spec.ts
+++ b/frontend/e2e/kille.spec.ts
@@ -19,10 +19,19 @@ test.describe('Kille E2E', () => {
 
     // Either action is legal on the human's turn; the dealer's exchange button
     // reads differently because it swaps with the stock.
+    //
+    // **The human does not always get a turn.** Reset makes seat 0 the dealer,
+    // so the human acts LAST, and a CPU that exchanges into the human's Pig
+    // knocks the original holder out before then (internal/domain/Kille.go).
+    // An eliminated seat renders no action buttons, so waiting longer would
+    // never help -- wait for the turn OR for the round to have moved on (#6071).
     const stand = page.getByRole('button', { name: '交換しない' });
-    await expect(stand).toBeVisible({ timeout: TIMEOUT_GAME_LOOP });
-    await stand.click();
-    await waitForLoaded(page);
+    const roundOver = page.getByTestId('kille-showdown').or(page.getByRole('button', { name: '次のラウンドへ' }));
+    await expect(stand.or(roundOver).first()).toBeVisible({ timeout: TIMEOUT_GAME_LOOP });
+    if (await stand.isVisible()) {
+      await stand.click();
+      await waitForLoaded(page);
+    }
 
     // The turn resolves to a showdown or to another seat's turn -- either way
     // the round advances rather than hanging.


### PR DESCRIPTION
Closes #6071

## 原因

`frontend/e2e/kille.spec.ts:23` は `交換しない` ボタンを無条件で待っていた。しかし

- `Kille.Reset` は `dealerIdx = 0`、つまり**初回ラウンドは人間がディーラー＝最後の手番**（`internal/domain/Kille.go:111,154`）
- その前に CPU が人間の **Pig** に交換を仕掛けると `exchangeWithNeighbour` が巻き戻して**元の持ち主（人間）を脱落**させる（`Kille.go:240-250`）
- 脱落すると `KillePage.tsx:173` の `isHumanTurn` が false になり、**ボタンは描画されない**

ので、待ち時間を伸ばしても来ないフェーズを待っていた。PR #6067（フロント無変更）の E2E で `241 passed / 1 failed` として顕在化。

## 修正

`交換しない` **または** ラウンドが進んだ印（showdown / 次のラウンドへ）を待ち、ボタンが出たときだけクリックする。#6064 で blackjack に入れたのと同じ `.or().first()` の形（`frontend/CLAUDE.md` の「`.or()` チェーンには `.first()`」規約に従う）。後半の「ラウンドが進んだこと」の確認はそのまま残るので、脱落した場合も何も検証しないままにはならない。

## 検証

- `bunx playwright test kille.spec.ts --repeat-each=8` → 16 passed
- `biome check` clean