### PR TITLE
test(zwanzigerrufen): stop assuming the CPUs stopped bidding at Rufer

### DIFF
--- a/internal/domain/Zwanzigerrufen_test.go
+++ b/internal/domain/Zwanzigerrufen_test.go
@@ -202,15 +202,27 @@ func TestZwanzigerrufenBid_RejectsUndeclarableAndLowBids(t *testing.T) {
 	assert.ErrorContains(t, err, "cannot be declared")
 	assert.Error(t, g.PlayerBid(ZwanzigerrufenBidPass))
 
-	// **上回らない入札は通らない。** CPU が既に Rufer を宣言していれば Solo しか残らない。
-	if g.GetHighestBid() >= ZwanzigerrufenBidRufer {
-		assert.Error(t, g.PlayerBid(ZwanzigerrufenBidRufer), "同額の入札が通っている")
-		require.NoError(t, g.PlayerBid(ZwanzigerrufenBidSolo))
-		assert.Equal(t, ZwanzigerrufenBidSolo, g.GetHighestBid())
+	// **上回らない入札は通らない。**現在の最高入札と同額は必ず弾かれる。
+	//
+	// 配り次第で CPU は Rufer までしか出さないことも Solo まで出すこともある。
+	// 「Rufer が立っているなら Solo が通る」と決め打つと、CPU が既に Solo を
+	// 宣言していた配りでは Solo も同額で弾かれて落ちる。上回れる段があるとき
+	// だけ、上回れることを確かめる。
+	high := g.GetHighestBid()
+	if high >= ZwanzigerrufenBidTrischaken {
+		assert.Error(t, g.PlayerBid(high), "同額の入札が通っている")
+	}
+	if high >= ZwanzigerrufenBidSolo {
+		// 最高段まで出ている配り。上回れる段がもう無い。
 		return
 	}
-	require.NoError(t, g.PlayerBid(ZwanzigerrufenBidRufer))
-	assert.Equal(t, ZwanzigerrufenBidRufer, g.GetHighestBid())
+	next := high + 1
+	if next < ZwanzigerrufenBidRufer {
+		// Trischaken は宣言できないので、打てるのは Rufer から。
+		next = ZwanzigerrufenBidRufer
+	}
+	require.NoError(t, g.PlayerBid(next))
+	assert.Equal(t, next, g.GetHighestBid())
 }
 
 func TestZwanzigerrufenBid_Errors(t *testing.T) {


### PR DESCRIPTION
Closes #6074

## 原因

`TestZwanzigerrufenBid_RejectsUndeclarableAndLowBids` は「Rufer 以上が立っている ⇒ Solo はまだ空いている」と決め打っていた。CPU は配り次第で **Solo（最高段）まで出す**ので、その配りでは `PlayerBid(Solo)` も `bid 3 does not beat the current bid 3` で弾かれる。プロダクション側は正しく、テストの前提が配りに依存していた。

## 修正

最高入札の実値を見て

- 同額の入札は必ず弾かれること
- 上回れる段が残っているなら、その段は通ること（Trischaken は宣言できないので下限は Rufer）
- 最高段まで出ている配りでは、上回れる段が無いのでそこで打ち切る

を確かめる形にした。

## 検証

- 修正前: `go test -count=40 -tags test ./internal/domain/ -run TestZwanzigerrufen` で再現（パッケージ全体の 1 回流しでも観測）
- 修正後: 同じコマンドを 5 回（計 200 反復）流して全て green