### PR TITLE
fix(letitride): drop a pending pull on reset

### DIFF
--- a/internal/adapter/controller/LetItRideCuiController.go
+++ b/internal/adapter/controller/LetItRideCuiController.go
@@ -31,7 +31,13 @@ func NewLetItRideCuiController(ci usecase.LetItRideInteractorIF) *LetItRideCuiCo
 func (lc *LetItRideCuiController) Exec(command string) string {
 	return execCuiCommand(
 		command,
-		func(_ []string) string { return lc.ci.Reset() },
+		func(_ []string) string {
+			// **r / reset は gameHandler を通らない** (execCuiCommand が先に拾う)。
+			// ここで消さないと、リセット直後の "y" が配り直した卓に Pull を
+			// 走らせる (#6076)。
+			lc.pullPending = false
+			return lc.ci.Reset()
+		},
 		[]string{"b", "bet", "p", "pull", "y", "yes", "l", "letitride", "log"},
 		func(cmd string, args []string) (string, bool) {
 			// **確認待ちは "y" 以外のどのコマンドでも取り消す。**残したままだと、
@@ -53,7 +59,8 @@ func (lc *LetItRideCuiController) Exec(command string) string {
 				return lc.ci.PullConfirm(), true
 			case "y", "yes":
 				if !pending {
-					return "Nothing to confirm.", true
+					// **日本語モードでも英語で返っていた。**
+					return invalidArg("letitride.nothingToConfirm"), true
 				}
 				lc.pullPending = false
 				return lc.ci.Pull(), true

--- a/internal/adapter/controller/LetItRideCuiController_test.go
+++ b/internal/adapter/controller/LetItRideCuiController_test.go
@@ -105,7 +105,20 @@ func TestLetItRideCuiController_Pull_AnyOtherCommandCancels(t *testing.T) {
 
 	c.Exec("p")
 	assert.Equal(t, "letitride result", c.Exec("l"))
-	assert.Equal(t, "Nothing to confirm.", c.Exec("y"))
+	assert.Contains(t, c.Exec("y"), msgStem("letitride.nothingToConfirm"))
+	m.AssertNotCalled(t, "Pull")
+}
+
+// **リセットも確認待ちを消す** (#6076)。r / reset は execCuiCommand が
+// gameHandler より先に拾うので、gameHandler 側のクリアだけでは待ちが残り、
+// 配り直した卓に Pull が走っていた。
+func TestLetItRideCuiController_Pull_ResetCancels(t *testing.T) {
+	m := newMockLetItRideInteractor()
+	c := controller.NewLetItRideCuiController(m)
+
+	c.Exec("p")
+	assert.Equal(t, "reset result", c.Exec("r"))
+	assert.Contains(t, c.Exec("y"), msgStem("letitride.nothingToConfirm"))
 	m.AssertNotCalled(t, "Pull")
 }
 
@@ -113,7 +126,7 @@ func TestLetItRideCuiController_Confirm_WithoutPendingPull(t *testing.T) {
 	m := newMockLetItRideInteractor()
 	c := controller.NewLetItRideCuiController(m)
 
-	assert.Equal(t, "Nothing to confirm.", c.Exec("y"))
+	assert.Contains(t, c.Exec("y"), msgStem("letitride.nothingToConfirm"))
 	m.AssertNotCalled(t, "Pull")
 }
 

--- a/internal/i18n/locales/en/letitride.json
+++ b/internal/i18n/locales/en/letitride.json
@@ -24,5 +24,6 @@
   "pullConfirmPrompt": "Enter y to go ahead (any other command cancels).",
   "pullUnavailable": "You cannot pull right now.",
   "helpExampleBet": "  b 100                bet 100 chips",
-  "totalRiskLine": "At risk right now: {{risk}}"
+  "totalRiskLine": "At risk right now: {{risk}}",
+  "nothingToConfirm": "There is no pull waiting for confirmation."
 }

--- a/internal/i18n/locales/ja/letitride.json
+++ b/internal/i18n/locales/ja/letitride.json
@@ -24,5 +24,6 @@
   "pullConfirmPrompt": "実行するには y を入力してください (他のコマンドで取り消し)。",
   "pullUnavailable": "いまは引き下げられません。",
   "helpExampleBet": "  b 100              100 チップを賭ける",
-  "totalRiskLine": "いまのリスク総額: {{risk}}"
+  "totalRiskLine": "いまのリスク総額: {{risk}}",
+  "nothingToConfirm": "確認待ちの Pull はありません。"
 }


### PR DESCRIPTION
Closes #6076

## 原因

`LetItRideCuiController.pullPending` は `gameHandler` の中でしかクリアされないが、`execCuiCommand` は `r` / `reset` を **`gameHandler` に渡る前に**処理する（`cui_controller_helper.go:60-68`）。そのため `p` → `r` → `y` で、**配り直した卓に対して `Pull()` が走っていた**。コード上のコメント（「確認待ちは "y" 以外のどのコマンドでも取り消す」）と挙動が食い違っていた。

#5733（リテラチャーの claim 確認、PR #6070）のレビューで指摘された既存の穴。

## 変更点

- `resetFn` クロージャで `pullPending = false` にする
- あわせて `"Nothing to confirm."` を i18n 化。日本語モードでも英語のまま返っていた

## テスト

- `TestLetItRideCuiController_Pull_ResetCancels` を追加（`p` → `r` → `y` が何も確定させない）
- 既存の 2 箇所の文字列断言を `msgStem("letitride.nothingToConfirm")` に置き換え

### ミューテーション確認

- `resetFn` のクリアを外す → 新テストが落ちる ✅

## 検証

- `go test -tags test ./internal/...` 全通過
- `golangci-lint run ./...` 0 issues