### PR TITLE
fix(test): return after t.Fatal so staticcheck sees the nil guard

### DIFF
--- a/internal/domain/Gaps_test.go
+++ b/internal/domain/Gaps_test.go
@@ -464,6 +464,7 @@ func TestGetHint_FindsAnchorMove(t *testing.T) {
 	h := g.GetHint()
 	if h == nil {
 		t.Fatal("expected a hint")
+		return
 	}
 	// Anchor move: any 2 → (0,0). 2S is at (0,1) actually — no, grid[0] = 2S,3S,... and we punched
 	// grid[0][0] to nil. So grid[0][1]=3S. The 2 of Spade lives... actually with our

--- a/internal/domain/Guandan_test.go
+++ b/internal/domain/Guandan_test.go
@@ -822,6 +822,7 @@ func TestGuandanHandEndsWhenThreeAreOut(t *testing.T) {
 	res := g.GetLastResult()
 	if res == nil {
 		t.Fatal("the hand must settle")
+		return
 	}
 	// 残り 1 人が最下位に入る。
 	if res.Order[3] != 3 {
@@ -879,6 +880,7 @@ func TestGuandanCpuDrivesAFullHand(t *testing.T) {
 		res := g.GetLastResult()
 		if res == nil {
 			t.Fatalf("attempt %d: no settlement", attempt)
+			return
 		}
 		// **全席が順位に現れる。**
 		seen := map[int]bool{}


### PR DESCRIPTION
## 背景

2026-08-20 の途中から **触っていない PR まで Backend Lint が落ちる**ようになった（#6105 / #6106 / #6107 で同一の 6 件）。

```
internal/domain/Gaps_test.go:465:5: SA5011(related information): this check suggests that the pointer can be nil
internal/domain/Gaps_test.go:472:7: SA5011: possible nil pointer dereference
internal/domain/Guandan_test.go:823,827 / 880,885: 同上
```

golangci-lint は CI もローカルも **2.12.2**、Go も同じ **1.26.5**。ローカルではキャッシュを消しても 0 issues なので、CI 側の解析キャッシュが（#6103 の `go.mod` 変更で）失効し、**冷えた状態で初めて出た潜在指摘**とみるのが自然。いずれにせよ全 PR を止めるので直す。

## 変更点

`t.Fatal` / `t.Fatalf` の直後に `return` を足しただけ（3 箇所）。解析器が「ここで止まる」を読めていないので、制御フローを明示する。**実行時の挙動は変わらない。**

## 検証

- `go test -tags test ./internal/domain/` 通過
- `golangci-lint run --build-tags test ./internal/domain/` 0 issues