### PR TITLE
ci: stop restoring the golangci-lint cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,17 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           args: --build-tags test
+          # **キャッシュを復元した run だけ staticcheck が誤検知する。**
+          # 2026-08-20、触っていない PR が軒並み SA5011 (t.Fatal の直後の
+          # 参照を「nil 参照の可能性」と読む) 6 件で落ちた。同じ
+          # golangci-lint 2.12.2 / Go 1.26.5 をローカルで走らせると 0 件、
+          # CI もキャッシュを消した直後の run は 0 件、その run が保存した
+          # キャッシュを復元した次の run からまた 6 件になる、という再現性が
+          # あった (max-same-issues=3 の既定で毎回ちょうど 6 件に丸められ、
+          # 直すたびに別ファイルが出てくる)。
+          # lint は 5-6 分の job なので、キャッシュを捨てて毎回冷えた状態で
+          # 走らせるほうが、緑の意味が保てる。
+          skip-cache: true
 
   test-backend:
     name: Backend Tests


### PR DESCRIPTION
## 症状

2026-08-20、**触っていない PR が軒並み Backend Lint で落ちた**（#6105 / #6106 / #6107 / #6110 / #6111 / #6112）。内容は毎回 SA5011 6 件で、`t.Fatal` の直後の参照を「nil 参照の可能性」と読むもの。指摘されるファイルは run ごとに変わる（`Gaps_test.go` / `Guandan_test.go` → `Karnoffel_test.go` / `Omaha_hilo_test.go` / `OpenFaceChinese_test.go`）。

## 切り分け

- ローカル（golangci-lint **2.12.2**、Go **1.26.5**、同じ `.golangci.yml`、`--build-tags test`）: **0 件**。公式リリースのバイナリを落として、キャッシュを消して走らせても 0 件
- CI も **キャッシュを消した直後の run は 0 件**
- その run が保存したキャッシュを復元した**次の run から再び 6 件**
- 毎回ちょうど 6 件なのは `max-same-issues: 3` の既定（メッセージ 2 種 × 3）。つまり**実際にはもっと多く、直すたびに別ファイルが出てくる**

`skip-cache: true` で毎回冷えた状態にする。lint は 5-6 分の job なので、緑が意味を持つほうを取る。

## 補足

先に #6109 で `t.Fatal` の後に `return` を 3 箇所足した。あれ自体は無害な保険（`t.Fatal` は `runtime.Goexit()` するので挙動は変わらない）だが、**原因はコード側ではなくキャッシュだった**。同種の指摘が出ても、以後は追加の `return` を撒かずにこの PR の切り分けを見てほしい。

## 検証

- 汚染されたキャッシュ entry を `gh cache delete` で削除済み。次の run から冷えた状態で走る
- `bun run check` の `job-timeouts` ガードは引き続き OK