### PR TITLE
test(baseballpoker): draw a fresh table when the buy-in never comes up

### DIFF
--- a/internal/domain/BaseballPoker_test.go
+++ b/internal/domain/BaseballPoker_test.go
@@ -228,29 +228,43 @@ func TestBaseballPoker_FaceUpThreeAsksToBuyThePot(t *testing.T) {
 	require.Positive(t, saw, "30 局で表の 3 が一度も出なかった")
 }
 
+// baseballAdvanceToBuyIn は買い増しの場面まで進める。
+//
+// **表の 3 が出るかどうかは配り次第。** 1 卓を 200 手回すだけだと、たまたま
+// 出ない配りを引いた回に「到達しなかった」で落ちる (CI で実際に 1 度落ちた)。
+// 卓ごと引き直す外側のループを持つことで、確率の低い配りに当たっても
+// テストの結論が変わらないようにする。
+func baseballAdvanceToBuyIn(t *testing.T) *BaseballPoker {
+	t.Helper()
+	for attempt := range 50 {
+		g := newBaseballForTest(t)
+		for range 200 {
+			if g.GetPhase() == BaseballPhaseBuyIn {
+				return g
+			}
+			if g.GetPhase() == BaseballPhaseShowdown || g.GetGameEndFlag() {
+				if err := g.NextHand(); err != nil {
+					break // この卓はもう続けられない。引き直す。
+				}
+				continue
+			}
+			if g.IsHumanTurn() {
+				if err := g.PlayerAction(BaseballActionCheck, 0); err != nil {
+					require.NoError(t, g.PlayerAction(BaseballActionCall, 0))
+				}
+				continue
+			}
+			g.CpuPlay()
+		}
+		_ = attempt
+	}
+	t.Fatal("買い増しの場面まで到達しなかった (50 卓 × 200 手)")
+	return nil
+}
+
 // **買い増しの返事はポットとチップに正しく効く。**
 func TestBaseballPoker_BuyInMovesChips(t *testing.T) {
-	g := newBaseballForTest(t)
-	// 買い増しの場面に当たるまで進める。
-	found := false
-	for range 200 {
-		if g.GetPhase() == BaseballPhaseBuyIn {
-			found = true
-			break
-		}
-		if g.GetPhase() == BaseballPhaseShowdown || g.GetGameEndFlag() {
-			require.NoError(t, g.NextHand())
-			continue
-		}
-		if g.IsHumanTurn() {
-			if err := g.PlayerAction(BaseballActionCheck, 0); err != nil {
-				require.NoError(t, g.PlayerAction(BaseballActionCall, 0))
-			}
-			continue
-		}
-		g.CpuPlay()
-	}
-	require.True(t, found, "買い増しの場面まで到達しなかった")
+	g := baseballAdvanceToBuyIn(t)
 
 	buyer := g.GetBuyerSeat()
 	p := g.GetPlayers()[buyer]
@@ -264,26 +278,7 @@ func TestBaseballPoker_BuyInMovesChips(t *testing.T) {
 
 // **降りる返事はその席を降ろす。** 両方向を踏む。
 func TestBaseballPoker_BuyInFoldDropsTheSeat(t *testing.T) {
-	g := newBaseballForTest(t)
-	found := false
-	for range 200 {
-		if g.GetPhase() == BaseballPhaseBuyIn {
-			found = true
-			break
-		}
-		if g.GetPhase() == BaseballPhaseShowdown || g.GetGameEndFlag() {
-			require.NoError(t, g.NextHand())
-			continue
-		}
-		if g.IsHumanTurn() {
-			if err := g.PlayerAction(BaseballActionCheck, 0); err != nil {
-				require.NoError(t, g.PlayerAction(BaseballActionCall, 0))
-			}
-			continue
-		}
-		g.CpuPlay()
-	}
-	require.True(t, found, "買い増しの場面まで到達しなかった")
+	g := baseballAdvanceToBuyIn(t)
 
 	buyer := g.GetBuyerSeat()
 	p := g.GetPlayers()[buyer]


### PR DESCRIPTION
## 症状

PR #6134（スポイル・ファイブ、**この test には無関係**）の Backend Tests で

```
--- FAIL: TestBaseballPoker_BuyInFoldDropsTheSeat (0.21s)
    BaseballPoker_test.go:286: Should be true  ("買い増しの場面まで到達しなかった")
```

## 原因

買い増しは**表向きの 3 が配られた席**にだけ起きる。テストは 1 卓を 200 手回して待つだけなので、**その配りで 3 が表に出なければ落ちる**。ローカルでは同じテストを 5 回、パッケージ全体を 3 回走らせても再現しないので、確率の低い配りを CI が引いた形。

（flake-ledger に 1 件目として記録済み。ただし「再実行して通った」で済ませず、テストの側を配りに依らない形へ直す。）

## 変更点

- `baseballAdvanceToBuyIn` を追加し、**卓ごと引き直す外側のループ**（50 卓 × 200 手）を持たせる
- 卓が続けられなくなった場合（`NextHand` がエラー）も引き直しに回す
- 買い増しの 2 つのテスト（払う / 降りる）が同じヘルパーを使う

## 検証

- `go test -tags test ./internal/domain/ -run TestBaseballPoker_BuyIn` を 5 回、いずれも通過
- `golangci-lint run --build-tags test ./internal/domain/` 0 issues