### PR TITLE
test(loba): redeal instead of failing when a hand cannot be driven

### DIFF
--- a/internal/domain/Loba_test.go
+++ b/internal/domain/Loba_test.go
@@ -394,6 +394,27 @@ func TestLoba_RejectsIllegalRequests(t *testing.T) {
 }
 
 // lbPlayRound drives one round with CPU decisions. Returns false if it stalls.
+// lbFreshRoundPlayed は「1 ラウンド打ち切れる配り」を引くまで卓を配り直し、
+// 打ち切れた卓を返す。
+//
+// **打ち切れるかどうかは配り次第。** CPU の駆動が捨て札を選べない配りや、
+// 2000 手で終わらない配りが混ざると、単発の require.True は無関係な PR の
+// CI で落ちる (#5869)。**どの配りでも打ち切れないなら本当の詰まり**なので、
+// そのときは落とす。
+func lbFreshRoundPlayed(t *testing.T) *Loba {
+	t.Helper()
+	for attempt := range 20 {
+		l := NewDefaultLoba()
+		l.Reset()
+		if lbPlayRound(t, l) {
+			return l
+		}
+		t.Logf("配り %d は打ち切れなかった。引き直す", attempt)
+	}
+	t.Fatal("20 卓すべてでラウンドを打ち切れなかった (駆動ではなく規則側の詰まり)")
+	return nil
+}
+
 func lbPlayRound(t *testing.T, l *Loba) bool {
 	t.Helper()
 	for range 2000 {
@@ -420,26 +441,37 @@ func lbPlayRound(t *testing.T, l *Loba) bool {
 }
 
 func TestLoba_ARoundPlaysOutToSomebodyGoingOut(t *testing.T) {
-	l := NewDefaultLoba()
-	l.Reset()
-	require.True(t, lbPlayRound(t, l))
+	l := lbFreshRoundPlayed(t)
 	assert.GreaterOrEqual(t, l.GetRoundWinner(), 0)
 	assert.Zero(t, l.GetPlayer(l.GetRoundWinner()).GetCardsSize())
 	assert.Equal(t, 1, l.GetRoundNumber())
 }
 
 func TestLoba_TheGameRunsUntilOnePlayerIsLeft(t *testing.T) {
-	l := NewDefaultLoba()
-	l.Reset()
-	for range 200 {
-		if l.GetGameEndFlag() {
+	// **打ち切れない配りに当たったら卓ごと引き直す** (#5869)。途中のラウンドだけ
+	// 配り直すことはできないので、リトライは 1 局まるごとの単位になる。
+	var l *Loba
+	for attempt := 0; ; attempt++ {
+		require.Less(t, attempt, 20, "20 局すべてでラウンドを打ち切れなかった")
+		l = NewDefaultLoba()
+		l.Reset()
+		stuck := false
+		for range 200 {
+			if l.GetGameEndFlag() {
+				break
+			}
+			if !lbPlayRound(t, l) {
+				stuck = true
+				break
+			}
+			if l.GetGameEndFlag() {
+				break
+			}
+			require.NoError(t, l.NextRound())
+		}
+		if !stuck && l.GetGameEndFlag() {
 			break
 		}
-		require.True(t, lbPlayRound(t, l))
-		if l.GetGameEndFlag() {
-			break
-		}
-		require.NoError(t, l.NextRound())
 	}
 	require.True(t, l.GetGameEndFlag())
 
@@ -454,9 +486,7 @@ func TestLoba_TheGameRunsUntilOnePlayerIsLeft(t *testing.T) {
 }
 
 func TestLoba_SurvivesAKVRoundTrip(t *testing.T) {
-	l := NewDefaultLoba()
-	l.Reset()
-	require.True(t, lbPlayRound(t, l))
+	l := lbFreshRoundPlayed(t)
 
 	data, err := json.Marshal(l)
 	require.NoError(t, err)


### PR DESCRIPTION
Closes #5869

## 背景

`internal/domain` のフルパッケージ実行でだけ落ちる配り依存テストの記録が #5869 にあります。issue に挙がった 8 件のうち Horse / Sakura / Durak / Shelem はバッチ中に個別対応済みで、**残っていたのが Loba の 2 本**（`lbPlayRound` を単発で `require.True` する形）でした。

## 変更点

- `lbFreshRoundPlayed`: 1 ラウンド打ち切れる配りを引くまで卓を配り直すヘルパー。**20 卓すべてで打ち切れないときだけ落とす**（それは駆動ではなく規則側の詰まり）
- `TestLoba_ARoundPlaysOutToSomebodyGoingOut` / `TestLoba_SurvivesAKVRoundTrip` はそのヘルパーを使う
- `TestLoba_TheGameRunsUntilOnePlayerIsLeft` は途中のラウンドだけ配り直せないので、**1 局まるごとを単位にリトライ**する

## 検証（このバッチでの実測）

- `go test -tags test ./internal/domain/` フルパッケージを **本日 7 回**（この PR の前 3 回 + 後 4 回）走らせ、いずれも通過
- 名前の挙がった 6 テストを **40 回連続**で実行して通過
- Mushi にも同じ形（`mushiPlayRound` の単発 require）がありますが、**25 回走らせても落ちない**うえ #5869 の記録にも無いので、証拠のないまま触るのはやめました
- **ミューテーション**: 駆動が常に打ち切れないようにすると、Loba の 3 本とも落ちる ✅（リトライが詰まりを飲み込んでいないことの確認）

## 補足

issue が挙げている残りの 2 項目について:

- **`shuffle-determinism-auditor` の一括適用**: 同じ形を `require.True(t, ...PlayRound...)` で grep したところ Loba と Mushi の 2 箇所だけでした（前者はこの PR で対応、後者は上記の理由で据え置き）
- **RNG の明示シード**: `TrumpCards.Shuffle` がグローバル `rand` を直に使っているため、テスト側からシードを固定するには本体の API 変更が要ります。この PR の範囲を超えるので別途