### PR TITLE
test(guards): require a digit boundary when matching point values

### DIFF
--- a/internal/infrastructure/games/baccarat_payout_test.go
+++ b/internal/infrastructure/games/baccarat_payout_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -50,7 +49,10 @@ func TestBaccaratWebPayoutRefMatchesTheDomain(t *testing.T) {
 				t.Errorf("%s payoutRef.%s missing", loc, key)
 				continue
 			}
-			if !strings.Contains(line, fragment) {
+			// **数字の境界まで見る** (#6009)。括弧付きなので今の文言では
+			// 部分一致の穴は無いが、"(18:1)" のような文言に変わった日に
+			// "(8:1)" が通ってしまう形は残さない。
+			if !statesText(line, fragment) {
 				t.Errorf("%s payoutRef.%s should state %s (from the domain constants), got %q",
 					loc, key, fragment, line)
 			}

--- a/internal/infrastructure/games/number_match_test.go
+++ b/internal/infrastructure/games/number_match_test.go
@@ -1,0 +1,80 @@
+//go:build test
+
+package games_test
+
+import (
+	"regexp"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+// statesNumber reports whether s states n as a number in its own right.
+//
+// **部分一致では通っても何も保証しない。** `strings.Contains(line, "0")` は
+// `"10点"` の 0 でも通るので、期待値を 1 桁変えても落ちないガードになる
+// (#6009)。数字の前後が別の数字でないことまで見る。
+func statesNumber(s string, n int) bool {
+	return numberPattern(strconv.Itoa(n)).MatchString(s)
+}
+
+// statesText reports whether s states the given numeric text (e.g. "0.95") in
+// its own right. Same rule as statesNumber, for values that are not plain ints.
+func statesText(s, num string) bool {
+	return numberPattern(num).MatchString(s)
+}
+
+var (
+	numberPatternMu    sync.Mutex
+	numberPatternCache = map[string]*regexp.Regexp{}
+)
+
+// numberPattern は「前後が数字でない」ことを要求する正規表現を返す。
+//
+// 小数点を含む値 (0.95) もそのまま扱えるよう、区切りの判定は数字だけで行い、
+// 小数点は数値の一部として扱う。
+func numberPattern(num string) *regexp.Regexp {
+	numberPatternMu.Lock()
+	defer numberPatternMu.Unlock()
+	if re, ok := numberPatternCache[num]; ok {
+		return re
+	}
+	re := regexp.MustCompile(`(?:^|[^0-9.])` + regexp.QuoteMeta(num) + `(?:[^0-9.]|$)`)
+	numberPatternCache[num] = re
+	return re
+}
+
+// **ガード自身のガード。** 桁の一部で通ってしまう形に戻したら、ここが落ちる。
+func TestStatesNumberRequiresADigitBoundary(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		n    int
+		want bool
+	}{
+		{"exact", "0点", 0, true},
+		{"inside a longer number", "10点", 0, false},
+		{"leading digit", "120点", 12, false},
+		{"trailing digit", "612点", 12, false},
+		{"among other text", "合計 120 点のうち 61 点で勝ち", 61, true},
+		{"decimal is not a boundary", "0.95:1", 0, false},
+		{"the whole decimal matches", "0.95:1", 95, false},
+		{"at the start", "61 点", 61, true},
+		{"at the end", "勝利ラインは 61", 61, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := statesNumber(tc.text, tc.n); got != tc.want {
+				t.Errorf("statesNumber(%q, %d) = %v, want %v", tc.text, tc.n, got, tc.want)
+			}
+		})
+	}
+
+	// 小数はそのまま照合できる。
+	if !statesText("バンカー勝ち (0.95:1)", "0.95") {
+		t.Error(`statesText("… (0.95:1)", "0.95") = false, want true`)
+	}
+	if statesText("バンカー勝ち (10.95:1)", "0.95") {
+		t.Error(`statesText("… (10.95:1)", "0.95") = true, want false`)
+	}
+}

--- a/internal/infrastructure/games/number_match_test.go
+++ b/internal/infrastructure/games/number_match_test.go
@@ -5,7 +5,6 @@ package games_test
 import (
 	"regexp"
 	"strconv"
-	"sync"
 	"testing"
 )
 
@@ -24,24 +23,12 @@ func statesText(s, num string) bool {
 	return numberPattern(num).MatchString(s)
 }
 
-var (
-	numberPatternMu    sync.Mutex
-	numberPatternCache = map[string]*regexp.Regexp{}
-)
-
 // numberPattern は「前後が数字でない」ことを要求する正規表現を返す。
 //
 // 小数点を含む値 (0.95) もそのまま扱えるよう、区切りの判定は数字だけで行い、
 // 小数点は数値の一部として扱う。
 func numberPattern(num string) *regexp.Regexp {
-	numberPatternMu.Lock()
-	defer numberPatternMu.Unlock()
-	if re, ok := numberPatternCache[num]; ok {
-		return re
-	}
-	re := regexp.MustCompile(`(?:^|[^0-9.])` + regexp.QuoteMeta(num) + `(?:[^0-9.]|$)`)
-	numberPatternCache[num] = re
-	return re
+	return regexp.MustCompile(`(?:^|[^0-9.])` + regexp.QuoteMeta(num) + `(?:[^0-9.]|$)`)
 }
 
 // **ガード自身のガード。** 桁の一部で通ってしまう形に戻したら、ここが落ちる。

--- a/internal/infrastructure/games/sueca_point_legend_test.go
+++ b/internal/infrastructure/games/sueca_point_legend_test.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -62,7 +60,9 @@ func TestSuecaWebPointLegendMatchesTheDomain(t *testing.T) {
 				t.Errorf("%s pointLegend.%s missing", loc, key)
 				continue
 			}
-			if !strings.Contains(line, strconv.Itoa(pts)) {
+			// **部分一致では通っても何も保証しない** (#6009)。0 は "10点" の
+			// 0 でも通ってしまうので、桁の境界まで見る。
+			if !statesNumber(line, pts) {
 				t.Errorf("%s pointLegend.%s = %q, want it to state %d", loc, key, line, pts)
 			}
 		}
@@ -72,7 +72,7 @@ func TestSuecaWebPointLegendMatchesTheDomain(t *testing.T) {
 		}
 		// 合計 120 点と勝利ライン 61 点も本文に書いてある。数字だけずれても気づけない。
 		for _, n := range []int{total, domain.SuecaWinPoints} {
-			if !strings.Contains(note, strconv.Itoa(n)) {
+			if !statesNumber(note, n) {
 				t.Errorf("%s pointLegend.note = %q, want it to state %d", loc, note, n)
 			}
 		}


### PR DESCRIPTION
Closes #6009

## 背景

配点をロケール文字列と突き合わせるガードが `strings.Contains(line, strconv.Itoa(pts))` で数字を探していた。**桁の一部が一致しただけで通る**ので、`othersValue`（0 点）は `"10点"` でも満たされる。いまの文言では誤検知しないが、**通っても何も保証しない形**であること自体が問題で、文言が変わった瞬間に静かに空振りする。

## 変更点

- `statesNumber` / `statesText`（`internal/infrastructure/games/number_match_test.go`）: **前後が数字でも小数点でもない**ことを要求する照合
- Sueca の配点表ガードと Baccarat の配当ガードの両方をこれに乗せ換え（受け入れ条件3）
- ヘルパー自身に境界のテストを付ける（`10点` は `0` を満たさない / `120点` は `12` を満たさない / 小数 `0.95` はそのまま照合できる）

## テスト

- `TestStatesNumberRequiresADigitBoundary`: 9 ケース（一致・桁の内側・先頭/末尾の桁・小数）
- **ミューテーション**: `sueca.json` の `othersValue` を `"0点"` → `"10点"` に変えると Sueca のガードが落ちる ✅（**これが issue の指す穴そのもの**で、変更前は通っていた）

## 検証

- `go test -tags test ./internal/...` 全通過 / `golangci-lint run --build-tags test ./...` 0 issues