### PR TITLE
test(solitaire): pin the empty-foundation ring in three pages

### DIFF
--- a/frontend/src/pages/AmericanToadPage.test.tsx
+++ b/frontend/src/pages/AmericanToadPage.test.tsx
@@ -335,6 +335,26 @@ describe('AmericanToadPage keyboard shortcuts', () => {
 describe('AmericanToadPage destination highlight', () => {
   const targets = () => document.querySelectorAll('[data-legal-target]');
 
+  // **空の組札の唯一の受け手は基準ランクの札。**そこが光らないと、置き先が
+  // 無いように見える (#5958)。リングは組札を包む要素側にあるので closest で辿る。
+  it('rings the empty foundations of the matching suit for a base-rank card', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      reserve: [],
+      tableau: makeTableau([[{ card: card('SPADE', 5), faceUp: true }]]),
+    });
+    renderWithProviders(<AmericanToadPage />);
+    fireEvent.click(await screen.findByRole('button', { name: /♠ 5/ }));
+
+    await waitFor(() =>
+      expect(
+        screen.getAllByRole('button', { name: /^空の組札\d+ \(♠\)$/ })[0]?.closest('[data-legal-target="true"]'),
+      ).not.toBeNull(),
+    );
+    // ♠ の組札は 2 つ (2 デッキ)。他スートの 6 つは光らない。
+    expect(targets()).toHaveLength(2);
+  });
+
   it('rings the legal column once a card is selected', async () => {
     // ♠8 を選ぶと ♠9 の上には置けない (降順なので ♠7 が要る) が、
     // 別の列の ♣4 の上でもない。合法な列だけが光ること。

--- a/frontend/src/pages/BakersDozenPage.test.tsx
+++ b/frontend/src/pages/BakersDozenPage.test.tsx
@@ -46,8 +46,6 @@ function makeTableau(cols: BakersDozenTableauCard[][]): BakersDozenTableauCard[]
 
 const card = (design: CardDesign, value: number): Card => ({ design, value });
 
-const emptyColumns = (n: number) => Array.from({ length: n }, () => []);
-
 const playingState: BakersDozenResponse = {
   tableau: makeTableau([
     [
@@ -359,7 +357,7 @@ describe('BakersDozenPage legal targets', () => {
   it('rings the empty foundations when an ace is selected', async () => {
     mockExec.mockResolvedValue({
       ...playingState,
-      tableau: makeTableau([[{ card: card('SPADE', 1), faceUp: true }], ...emptyColumns(12)]),
+      tableau: makeTableau([[{ card: card('SPADE', 1), faceUp: true }]]),
     });
     renderWithProviders(<BakersDozenPage />);
     fireEvent.click(await screen.findByRole('button', { name: '♠ A' }));

--- a/frontend/src/pages/BakersDozenPage.test.tsx
+++ b/frontend/src/pages/BakersDozenPage.test.tsx
@@ -46,6 +46,8 @@ function makeTableau(cols: BakersDozenTableauCard[][]): BakersDozenTableauCard[]
 
 const card = (design: CardDesign, value: number): Card => ({ design, value });
 
+const emptyColumns = (n: number) => Array.from({ length: n }, () => []);
+
 const playingState: BakersDozenResponse = {
   tableau: makeTableau([
     [
@@ -349,6 +351,24 @@ describe('BakersDozenPage legal targets', () => {
   it('never rings an empty column', async () => {
     await selectSpadeFive();
     await waitFor(() => expect(document.querySelectorAll('[data-legal-target="true"]').length).toBe(1));
+  });
+
+  // **A の唯一の行き先は空の組札。**そこが光らないと「置ける先が無い」と
+  // 読めてしまう (#5958)。リングは組札を包む要素側に付いているので、空札の
+  // ボタンからは closest で辿る。
+  it('rings the empty foundations when an ace is selected', async () => {
+    mockExec.mockResolvedValue({
+      ...playingState,
+      tableau: makeTableau([[{ card: card('SPADE', 1), faceUp: true }], ...emptyColumns(12)]),
+    });
+    renderWithProviders(<BakersDozenPage />);
+    fireEvent.click(await screen.findByRole('button', { name: '♠ A' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: '空の組札 (♠)' }).closest('[data-legal-target="true"]')).not.toBeNull(),
+    );
+    // A はどの組札にも置ける。4 つとも光る。
+    expect(document.querySelectorAll('[data-legal-target="true"]').length).toBe(4);
   });
 
   it('rings nothing before a card is selected', async () => {

--- a/frontend/src/pages/BeleagueredCastlePage.test.tsx
+++ b/frontend/src/pages/BeleagueredCastlePage.test.tsx
@@ -227,6 +227,26 @@ describe('BeleagueredCastlePage', () => {
       expect(markedColumns().sort()).toEqual(['#1', '#2', '#3', '#4', '#5', '#6', '#7']);
     });
 
+    // **空の組札の唯一の受け手は A。**そこが光らないと、A にとって置き先が
+    // 無いように見える (#5958)。リングは組札を包む要素側にあるので closest で辿る。
+    it('marks the empty foundations when an ace is selected', async () => {
+      mockExec.mockResolvedValue({
+        ...playingState,
+        tableau: makeTableau([[{ card: card('SPADE', 1), faceUp: true }]]),
+        foundation: [[], [], [], []],
+      });
+      renderWithProviders(<BeleagueredCastlePage />);
+      fireEvent.click(await screen.findByRole('button', { name: '♠ A' }));
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: '空の組札 (♠)' }).closest('[data-legal-target="true"]'),
+        ).not.toBeNull(),
+      );
+      // 組札 4 つ + 空き列 7 つ。組札側が 0 なら 7 で止まる。
+      expect(document.querySelectorAll('[data-legal-target="true"]')).toHaveLength(11);
+    });
+
     // ファンデーションは A の上に同スートの 2 だけ。♠5 では光らない。
     it('marks a foundation only for the card that continues it', async () => {
       mockExec.mockResolvedValue(playingState);


### PR DESCRIPTION
Closes #5958

## 前提の検証（issue の指摘は当たっていなかった）

issue は AmericanToad / BeleagueredCastle / BakersDozen の空の組札が `data-target-candidate` もリングも読まない、と書いている。実際に読むと **この 3 ページは KingAlbert と DOM の作りが違う**:

- KingAlbert はリングを**組札のボタンごと**に付けていて、`pile.length === 0` の枝が配線漏れになっていた（それが #5598 / PR #5957）
- この 3 ページはリングを**組札を包む `div` 側**に付けている（`AmericanToadPage.tsx:365`, `BeleagueredCastlePage.tsx:343`, `BakersDozenPage.tsx:280`）。中身が札でも空札プレースホルダでも同じ要素なので、**空の組札も既に光る**

移動先ユーティリティ側も空札を正しく含んでいる（`bakersDozenLegalTargets` は A、`beleagueredCastleLegalTargets` は A、`americanToadLegalTargets` は `baseRank`）。なので**プロダクションコードは変更していない**。

## それでも直したこと

守っているテストが無かった。既存は負の側（「♠5 では空の組札は光らない」）だけで、**空札の枝をユーティリティから落としても BakersDozen / BeleagueredCastle は 1 件も落ちなかった**。受け入れ条件の 3 番目・4 番目がまさにそこなので、正の側を 3 ページに足した。

- BakersDozen: ♠A を選ぶ → 空の組札 4 つが光る
- BeleagueredCastle: ♠A を選ぶ → 空の組札 4 つ + 空き列 7 つ = 11
- AmericanToad: 基準ランク (♠5) を選ぶ → **同スートの** 組札 2 つだけ（他スート 6 つは光らない）

### ミューテーション確認

各ユーティリティから `if (pile.length === 0) { … }` を落とす:

| ページ | 落ちたテスト |
|---|---|
| BakersDozen | 1 failed（**新しいテストだけ**。以前は 0 failed） |
| BeleagueredCastle | 1 failed（**新しいテストだけ**。以前は 0 failed） |
| AmericanToad | 11 failed（基準ランク札を使うテストが多く、元から一部は落ちていた） |

## 検証

- 3 ページ 95 tests passed
- `bun run check` / `bun run typecheck` clean