### PR TITLE
fix(anaconda,gofish): make the hint ring survive the inline box-shadow

### DIFF
--- a/frontend/src/pages/AnacondaPage.test.tsx
+++ b/frontend/src/pages/AnacondaPage.test.tsx
@@ -262,6 +262,11 @@ describe('AnacondaPage', () => {
     fireEvent.click(toggle);
 
     await waitFor(() => expect(document.querySelectorAll('[data-hint-card="true"]')).toHaveLength(2));
+    // **リングはインラインで置く。**手札には selectedCardStyle の
+    // `boxShadow: 'none'` が乗るので、Tailwind の ring-* (同じ box-shadow) は
+    // 未選択のあいだ潰される。印だけ見ていても気づけない。
+    const ringed = document.querySelector('[data-hint-card="true"]') as HTMLElement;
+    expect(ringed.style.outline).toContain('var(--color-ds-warning)');
   });
 
   it('rings nothing for a betting suggestion or while hints are off', async () => {

--- a/frontend/src/pages/AnacondaPage.tsx
+++ b/frontend/src/pages/AnacondaPage.tsx
@@ -28,7 +28,7 @@ import { useGameHint } from '../hooks/useGameHint';
 import { useGamePageSetup } from '../hooks/useGamePageSetup';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { btnDanger, btnPrimary, btnSecondary, btnSuccess, focusRingAccent } from '../styles/buttonStyles';
-import { selectedCardStyle } from '../styles/cardStyles';
+import { hintRingStyle, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { AnacondaResponse } from '../types/card';
@@ -462,7 +462,7 @@ function AnacondaPageContent() {
                         aria-pressed={isSelected}
                         disabled={!canSelectCards || loading}
                         onClick={() => toggle(i)}
-                        className={[focusRingAccent, 'rounded', isSuggested ? 'ring-2 ring-ds-warning' : ''].join(' ')}
+                        className={[focusRingAccent, 'rounded'].join(' ')}
                         data-hint-card={isSuggested ? 'true' : undefined}
                         style={{
                           background: 'none',
@@ -470,6 +470,10 @@ function AnacondaPageContent() {
                           cursor: canSelectCards ? 'pointer' : 'default',
                           borderRadius: 8,
                           ...selectedCardStyle(isSelected),
+                          // **ring-* では出ない。**上の selectedCardStyle が
+                          // 未選択時に `boxShadow: 'none'` をインラインで置くので、
+                          // 同じ box-shadow を使う Tailwind の ring は潰される。
+                          ...(isSuggested ? hintRingStyle() : {}),
                           boxSizing: 'border-box',
                         }}
                       >

--- a/frontend/src/pages/GoFishPage.test.tsx
+++ b/frontend/src/pages/GoFishPage.test.tsx
@@ -346,6 +346,11 @@ describe('GoFishPage', () => {
     expect(screen.getByRole('button', { name: '♠ 7' })).toHaveAttribute('data-hint-card', 'true');
     expect(screen.getByRole('button', { name: '♥ 7' })).toHaveAttribute('data-hint-card', 'true');
     expect(screen.getByRole('button', { name: '♦ 3' })).not.toHaveAttribute('data-hint-card');
+    // **リングはインラインで置く。**手札には selectedCardStyle の
+    // `boxShadow: 'none'` が乗るので、Tailwind の ring-* (同じ box-shadow) は
+    // 未選択のあいだ潰される。印だけ見ていても気づけない。
+    expect(screen.getByRole('button', { name: '♠ 7' }).style.outline).toContain('var(--color-ds-warning)');
+    expect(screen.getByRole('button', { name: '♦ 3' }).style.outline).toBe('');
     // ツールチップもランクを名指しする。
     expect(screen.getByTestId('hint-tooltip')).toHaveTextContent('7');
   });

--- a/frontend/src/pages/GoFishPage.tsx
+++ b/frontend/src/pages/GoFishPage.tsx
@@ -26,7 +26,7 @@ import { useGoFishGame } from '../hooks/useGoFishGame';
 import { useGoFishKnownRanks } from '../hooks/useGoFishKnownRanks';
 import { usePhaseNames } from '../hooks/usePhaseNames';
 import { btnPrimary } from '../styles/buttonStyles';
-import { focusRingCard, selectedCardStyle } from '../styles/cardStyles';
+import { focusRingCard, hintRingStyle, selectedCardStyle } from '../styles/cardStyles';
 import { lgCardAreaConstraint } from '../styles/gameStyles';
 import { gameTheme } from '../styles/gameTheme';
 import type { GoFishResponse } from '../types/card';
@@ -351,17 +351,17 @@ function GoFishPageContent() {
                       onClick={() => handleSelectRank(card.value)}
                       aria-label={cardAlt(card)}
                       aria-pressed={selectedRank === card.value}
-                      className={[
-                        'transition-transform',
-                        focusRingCard,
-                        isSuggested ? 'ring-2 ring-ds-warning' : '',
-                      ].join(' ')}
+                      className={['transition-transform', focusRingCard].join(' ')}
                       data-hint-card={isSuggested ? 'true' : undefined}
                       style={{
                         background: 'none',
                         padding: 0,
                         borderRadius: 8,
                         ...selectedCardStyle(selectedRank === card.value),
+                        // **ring-* では出ない。**上の selectedCardStyle が
+                        // 未選択時に `boxShadow: 'none'` をインラインで置くので、
+                        // 同じ box-shadow を使う Tailwind の ring は潰される。
+                        ...(isSuggested ? hintRingStyle() : {}),
                         boxSizing: 'border-box',
                       }}
                     >


### PR DESCRIPTION
PR #6172 のレビューが指摘した同型の不具合。**実測で本物だった。**

## 何が起きていたか

`AnacondaPage.tsx` と `GoFishPage.tsx` はヒントが指す札を Tailwind の `ring-2 ring-ds-warning` で囲っていた。ところが同じ要素の `style` に `...selectedCardStyle(isSelected)` を展開しており、これは

```ts
boxShadow: isSelected ? '0 4px 12px …' : 'none',
```

を**インラインで**置く（`cardStyles.ts:47`）。Tailwind の `ring-*` は box-shadow のカスタムプロパティで実装されているので、**未選択のあいだリングは常に潰される**。`data-hint-card` は付くのでテストは通り、画面には何も出ない、という形だった。

同じ形を他のページでも探したが、`data-hint-card` + `ring-ds-warning` + `selectedCardStyle` が揃うのはこの 2 ページだけだった。

## 変更点

#5990 (PR #6172) で追加した `hintRingStyle()`（`outline` ベースなので box-shadow と衝突しない）に置き換え。`trumpRingStyle` と同じ理由・同じ形。

## テスト

**先に落ちることを確認した（Red）**: 既存のテストは `data-hint-card` しか見ておらず、この不具合を 1 件も捕まえていなかった。`style.outline` の検証を足すと 2 本落ちる → 修正で通る。

- Anaconda: ヒントが指す 2 枚に `var(--color-ds-warning)` の outline が付く
- Go Fish: ヒントのランクの 2 枚に付き、**それ以外の札には付かない**（`style.outline` が空）

### ミューテーション確認

`...(isSuggested ? hintRingStyle() : {})` を落とす → Go Fish のテストが落ちる ✅

## 検証

- `bunx vitest run src/pages/AnacondaPage.test.tsx src/pages/GoFishPage.test.tsx` 51 passed
- `bun run check` / `bun run typecheck` clean