### PR TITLE
fix(cui): translate the action log and name its seats like the rest

### DIFF
--- a/internal/adapter/presenter/AllFoursCuiPresenter.go
+++ b/internal/adapter/presenter/AllFoursCuiPresenter.go
@@ -191,5 +191,5 @@ var allFoursHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *AllFoursCuiPresenter) ActionLogOutput(s interfaces.AllFoursGame) string {
-	return actionLogOutputText(s)
+	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/AllFoursCuiPresenter.go
+++ b/internal/adapter/presenter/AllFoursCuiPresenter.go
@@ -191,5 +191,5 @@ var allFoursHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *AllFoursCuiPresenter) ActionLogOutput(s interfaces.AllFoursGame) string {
-	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.AllFoursPlayer](s)
 }

--- a/internal/adapter/presenter/AllFoursCuiPresenter_test.go
+++ b/internal/adapter/presenter/AllFoursCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -150,6 +151,8 @@ func TestAllFoursCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "stand", Detail: "You stand"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewAllFoursPlayer(true)).Maybe()
 	out := p.ActionLogOutput(m)
 	assert.Contains(t, out, "You stand")
 }

--- a/internal/adapter/presenter/AluetteCuiPresenter.go
+++ b/internal/adapter/presenter/AluetteCuiPresenter.go
@@ -209,5 +209,5 @@ var aluetteHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *AluetteCuiPresenter) ActionLogOutput(g interfaces.AluetteGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/AluetteCuiPresenter.go
+++ b/internal/adapter/presenter/AluetteCuiPresenter.go
@@ -209,5 +209,5 @@ var aluetteHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *AluetteCuiPresenter) ActionLogOutput(g interfaces.AluetteGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.AluettePlayer](g)
 }

--- a/internal/adapter/presenter/AluetteCuiPresenter_test.go
+++ b/internal/adapter/presenter/AluetteCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -198,6 +199,8 @@ func TestAluetteCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "Monsieur"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewAluettePlayer(true)).Maybe()
 	assert.Contains(t, p.ActionLogOutput(m), "play")
 }
 

--- a/internal/adapter/presenter/AnacondaCuiPresenter.go
+++ b/internal/adapter/presenter/AnacondaCuiPresenter.go
@@ -204,5 +204,5 @@ var anacondaHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *AnacondaCuiPresenter) ActionLogOutput(g interfaces.AnacondaGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.AnacondaPlayer](g)
 }

--- a/internal/adapter/presenter/BadugiCuiPresenter.go
+++ b/internal/adapter/presenter/BadugiCuiPresenter.go
@@ -169,7 +169,7 @@ func (bcp *BadugiCuiPresenter) Output(g interfaces.BadugiGame, lastErr error) st
 
 // ActionLogOutput renders the action log as plain text.
 func (bcp *BadugiCuiPresenter) ActionLogOutput(g interfaces.BadugiGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeatList(g, g.GetPlayers())
 }
 
 // HintOutput emits a draw-phase recommendation: which cards form the current

--- a/internal/adapter/presenter/BalootCuiPresenter.go
+++ b/internal/adapter/presenter/BalootCuiPresenter.go
@@ -182,5 +182,5 @@ var balootHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BalootCuiPresenter) ActionLogOutput(b interfaces.BalootGame) string {
-	return actionLogOutputText(b)
+	return actionLogOutputTextWithNames(b, func(idx int) string { return cuiPlayerName(b.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/BalootCuiPresenter.go
+++ b/internal/adapter/presenter/BalootCuiPresenter.go
@@ -182,5 +182,5 @@ var balootHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BalootCuiPresenter) ActionLogOutput(b interfaces.BalootGame) string {
-	return actionLogOutputTextWithNames(b, func(idx int) string { return cuiPlayerName(b.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.BalootPlayer](b)
 }

--- a/internal/adapter/presenter/BarbuCuiPresenter.go
+++ b/internal/adapter/presenter/BarbuCuiPresenter.go
@@ -242,5 +242,5 @@ func (p *BarbuCuiPresenter) HintOutput(bg interfaces.BarbuGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BarbuCuiPresenter) ActionLogOutput(bg interfaces.BarbuGame) string {
-	return actionLogOutputText(bg)
+	return actionLogOutputTextForSeats[*domain.BarbuPlayer](bg)
 }

--- a/internal/adapter/presenter/BasraCuiPresenter.go
+++ b/internal/adapter/presenter/BasraCuiPresenter.go
@@ -130,5 +130,5 @@ var basraHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BasraCuiPresenter) ActionLogOutput(g interfaces.BasraGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.BasraPlayer](g)
 }

--- a/internal/adapter/presenter/BeggarMyNeighbourCuiPresenter.go
+++ b/internal/adapter/presenter/BeggarMyNeighbourCuiPresenter.go
@@ -92,5 +92,5 @@ func (p *BeggarMyNeighbourCuiPresenter) Output(g interfaces.BeggarMyNeighbourGam
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BeggarMyNeighbourCuiPresenter) ActionLogOutput(g interfaces.BeggarMyNeighbourGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.BeggarMyNeighbourPlayer](g)
 }

--- a/internal/adapter/presenter/BeloteCuiPresenter.go
+++ b/internal/adapter/presenter/BeloteCuiPresenter.go
@@ -154,5 +154,5 @@ func (p *BeloteCuiPresenter) HintOutput(b interfaces.BeloteGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BeloteCuiPresenter) ActionLogOutput(b interfaces.BeloteGame) string {
-	return actionLogOutputTextWithNames(b, func(idx int) string { return cuiPlayerName(b.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.BelotePlayer](b)
 }

--- a/internal/adapter/presenter/BeloteCuiPresenter.go
+++ b/internal/adapter/presenter/BeloteCuiPresenter.go
@@ -154,5 +154,5 @@ func (p *BeloteCuiPresenter) HintOutput(b interfaces.BeloteGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BeloteCuiPresenter) ActionLogOutput(b interfaces.BeloteGame) string {
-	return actionLogOutputText(b)
+	return actionLogOutputTextWithNames(b, func(idx int) string { return cuiPlayerName(b.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/BeziqueCuiPresenter.go
+++ b/internal/adapter/presenter/BeziqueCuiPresenter.go
@@ -206,5 +206,5 @@ var beziqueHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BeziqueCuiPresenter) ActionLogOutput(b interfaces.BeziqueGame) string {
-	return actionLogOutputText(b)
+	return actionLogOutputTextWithNames(b, func(idx int) string { return cuiPlayerName(b.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/BeziqueCuiPresenter.go
+++ b/internal/adapter/presenter/BeziqueCuiPresenter.go
@@ -206,5 +206,5 @@ var beziqueHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BeziqueCuiPresenter) ActionLogOutput(b interfaces.BeziqueGame) string {
-	return actionLogOutputTextWithNames(b, func(idx int) string { return cuiPlayerName(b.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.BeziquePlayer](b)
 }

--- a/internal/adapter/presenter/BhabhiCuiPresenter.go
+++ b/internal/adapter/presenter/BhabhiCuiPresenter.go
@@ -144,5 +144,5 @@ var bhabhiHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BhabhiCuiPresenter) ActionLogOutput(b interfaces.BhabhiGame) string {
-	return actionLogOutputTextWithNames(b, func(idx int) string { return cuiPlayerName(b.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.BhabhiPlayer](b)
 }

--- a/internal/adapter/presenter/BhabhiCuiPresenter.go
+++ b/internal/adapter/presenter/BhabhiCuiPresenter.go
@@ -144,5 +144,5 @@ var bhabhiHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BhabhiCuiPresenter) ActionLogOutput(b interfaces.BhabhiGame) string {
-	return actionLogOutputText(b)
+	return actionLogOutputTextWithNames(b, func(idx int) string { return cuiPlayerName(b.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/BidEuchreCuiPresenter.go
+++ b/internal/adapter/presenter/BidEuchreCuiPresenter.go
@@ -188,7 +188,7 @@ func bidEuchreTrumpMenuLine() string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BidEuchreCuiPresenter) ActionLogOutput(g interfaces.BidEuchreGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.BidEuchrePlayer](g)
 }
 
 // bidEuchreHumanIdx は人間の席を返す (居なければ -1)。

--- a/internal/adapter/presenter/BidWhistCuiPresenter.go
+++ b/internal/adapter/presenter/BidWhistCuiPresenter.go
@@ -190,5 +190,5 @@ func (p *BidWhistCuiPresenter) HintOutput(g interfaces.BidWhistGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BidWhistCuiPresenter) ActionLogOutput(g interfaces.BidWhistGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.BidWhistPlayer](g)
 }

--- a/internal/adapter/presenter/BidWhistCuiPresenter.go
+++ b/internal/adapter/presenter/BidWhistCuiPresenter.go
@@ -190,5 +190,5 @@ func (p *BidWhistCuiPresenter) HintOutput(g interfaces.BidWhistGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BidWhistCuiPresenter) ActionLogOutput(g interfaces.BidWhistGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/BigTwoCuiPresenter.go
+++ b/internal/adapter/presenter/BigTwoCuiPresenter.go
@@ -108,5 +108,5 @@ func (p *BigTwoCuiPresenter) Output(bg interfaces.BigTwoGame, lastErr error) str
 
 // ActionLogOutput 棋譜を出力
 func (p *BigTwoCuiPresenter) ActionLogOutput(bg interfaces.BigTwoGame) string {
-	return actionLogOutputText(bg)
+	return actionLogOutputTextForSeats[*domain.BigTwoPlayer](bg)
 }

--- a/internal/adapter/presenter/BostonCuiPresenter.go
+++ b/internal/adapter/presenter/BostonCuiPresenter.go
@@ -172,5 +172,5 @@ func bostonLadderLine() string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BostonCuiPresenter) ActionLogOutput(g interfaces.BostonGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.BostonPlayer](g)
 }

--- a/internal/adapter/presenter/BouillotteCuiPresenter.go
+++ b/internal/adapter/presenter/BouillotteCuiPresenter.go
@@ -163,5 +163,5 @@ func (p *BouillotteCuiPresenter) HintOutput(g interfaces.BouillotteGame) string 
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BouillotteCuiPresenter) ActionLogOutput(g interfaces.BouillotteGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.BouillottePlayer](g)
 }

--- a/internal/adapter/presenter/BourreCuiPresenter.go
+++ b/internal/adapter/presenter/BourreCuiPresenter.go
@@ -78,7 +78,7 @@ func (p *BourreCuiPresenter) Output(bg interfaces.BourreGame, lastErr error) str
 
 // ActionLogOutput 棋譜をCUI出力
 func (p *BourreCuiPresenter) ActionLogOutput(bg interfaces.BourreGame) string {
-	return actionLogOutputText(bg)
+	return actionLogOutputTextForSeats[*domain.BourrePlayer](bg)
 }
 
 func bourrePlayerStr(bg interfaces.BourreGame, player *domain.BourrePlayer, idx int) string {

--- a/internal/adapter/presenter/BridgeCuiPresenter.go
+++ b/internal/adapter/presenter/BridgeCuiPresenter.go
@@ -261,5 +261,5 @@ var bridgeHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BridgeCuiPresenter) ActionLogOutput(b interfaces.BridgeGame) string {
-	return actionLogOutputText(b)
+	return actionLogOutputTextWithNames(b, func(idx int) string { return cuiPlayerName(b.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/BridgeCuiPresenter.go
+++ b/internal/adapter/presenter/BridgeCuiPresenter.go
@@ -261,5 +261,5 @@ var bridgeHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BridgeCuiPresenter) ActionLogOutput(b interfaces.BridgeGame) string {
-	return actionLogOutputTextWithNames(b, func(idx int) string { return cuiPlayerName(b.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.BridgePlayer](b)
 }

--- a/internal/adapter/presenter/BridgeCuiPresenter_test.go
+++ b/internal/adapter/presenter/BridgeCuiPresenter_test.go
@@ -350,10 +350,13 @@ func TestBridgeCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewBridgePlayer(true, 0)).Maybe()
 
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜")
 		assert.Contains(t, result, "play")
+		assert.Contains(t, result, "あなた", "棋譜の座席名が他の行と揃っていない")
 		assert.Contains(t, result, "played SPADE 5")
 		m.AssertExpectations(t)
 	})

--- a/internal/adapter/presenter/BriscolaCuiPresenter.go
+++ b/internal/adapter/presenter/BriscolaCuiPresenter.go
@@ -116,5 +116,5 @@ var briscolaHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BriscolaCuiPresenter) ActionLogOutput(b interfaces.BriscolaGame) string {
-	return actionLogOutputText(b)
+	return actionLogOutputTextWithNames(b, func(idx int) string { return cuiPlayerName(b.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/BriscolaCuiPresenter.go
+++ b/internal/adapter/presenter/BriscolaCuiPresenter.go
@@ -116,5 +116,5 @@ var briscolaHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BriscolaCuiPresenter) ActionLogOutput(b interfaces.BriscolaGame) string {
-	return actionLogOutputTextWithNames(b, func(idx int) string { return cuiPlayerName(b.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.BriscolaPlayer](b)
 }

--- a/internal/adapter/presenter/BuraCuiPresenter.go
+++ b/internal/adapter/presenter/BuraCuiPresenter.go
@@ -132,5 +132,5 @@ var buraHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BuraCuiPresenter) ActionLogOutput(b interfaces.BuraGame) string {
-	return actionLogOutputText(b)
+	return actionLogOutputTextForSeats[*domain.BuraPlayer](b)
 }

--- a/internal/adapter/presenter/BurracoCuiPresenter.go
+++ b/internal/adapter/presenter/BurracoCuiPresenter.go
@@ -184,5 +184,5 @@ func burracoJoinInts(xs []int) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *BurracoCuiPresenter) ActionLogOutput(g interfaces.BurracoGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.CanastaPlayer](g)
 }

--- a/internal/adapter/presenter/BurracoCuiPresenter_test.go
+++ b/internal/adapter/presenter/BurracoCuiPresenter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -270,6 +271,7 @@ func TestBurracoCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(entries)
+		m.On("GetPlayer", mock.Anything).Return(domain.NewCanastaPlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "draw_stock")

--- a/internal/adapter/presenter/CalabresellaCuiPresenter.go
+++ b/internal/adapter/presenter/CalabresellaCuiPresenter.go
@@ -209,5 +209,5 @@ var calabresellaHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *CalabresellaCuiPresenter) ActionLogOutput(g interfaces.CalabresellaGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.CalabresellaPlayer](g)
 }

--- a/internal/adapter/presenter/CalabresellaCuiPresenter.go
+++ b/internal/adapter/presenter/CalabresellaCuiPresenter.go
@@ -209,5 +209,5 @@ var calabresellaHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *CalabresellaCuiPresenter) ActionLogOutput(g interfaces.CalabresellaGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/CalabresellaCuiPresenter_test.go
+++ b/internal/adapter/presenter/CalabresellaCuiPresenter_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -205,6 +206,8 @@ func TestCalabresellaCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "You plays ♠K"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewCalabresellaPlayer(true)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "play")
 }

--- a/internal/adapter/presenter/CallBreakCuiPresenter.go
+++ b/internal/adapter/presenter/CallBreakCuiPresenter.go
@@ -136,5 +136,5 @@ var callBreakHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *CallBreakCuiPresenter) ActionLogOutput(cb interfaces.CallBreakGame) string {
-	return actionLogOutputTextWithNames(cb, func(idx int) string { return cuiPlayerName(cb.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.CallBreakPlayer](cb)
 }

--- a/internal/adapter/presenter/CallBreakCuiPresenter.go
+++ b/internal/adapter/presenter/CallBreakCuiPresenter.go
@@ -136,5 +136,5 @@ var callBreakHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *CallBreakCuiPresenter) ActionLogOutput(cb interfaces.CallBreakGame) string {
-	return actionLogOutputText(cb)
+	return actionLogOutputTextWithNames(cb, func(idx int) string { return cuiPlayerName(cb.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/CallBreakCuiPresenter_test.go
+++ b/internal/adapter/presenter/CallBreakCuiPresenter_test.go
@@ -172,9 +172,12 @@ func TestCallBreakCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewCallBreakPlayer(true)).Maybe()
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜")
 		assert.Contains(t, result, "play")
+		assert.Contains(t, result, "あなた", "棋譜の座席名が他の行と揃っていない")
 	})
 
 	t.Run("game not ended yields placeholder", func(t *testing.T) {

--- a/internal/adapter/presenter/CanastaCuiPresenter.go
+++ b/internal/adapter/presenter/CanastaCuiPresenter.go
@@ -157,5 +157,5 @@ func (p *CanastaCuiPresenter) Output(g interfaces.CanastaGame, lastErr error) st
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *CanastaCuiPresenter) ActionLogOutput(g interfaces.CanastaGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.CanastaPlayer](g)
 }

--- a/internal/adapter/presenter/CanastaCuiPresenter_test.go
+++ b/internal/adapter/presenter/CanastaCuiPresenter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -327,6 +328,8 @@ func TestCanastaCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewCanastaPlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "draw_stock")

--- a/internal/adapter/presenter/CariocaCuiPresenter.go
+++ b/internal/adapter/presenter/CariocaCuiPresenter.go
@@ -138,5 +138,5 @@ func (p *CariocaCuiPresenter) Output(g interfaces.CariocaGame, lastErr error) st
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *CariocaCuiPresenter) ActionLogOutput(g interfaces.CariocaGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.CariocaPlayer](g)
 }

--- a/internal/adapter/presenter/CassinoCuiPresenter.go
+++ b/internal/adapter/presenter/CassinoCuiPresenter.go
@@ -178,5 +178,5 @@ func cassinoJoinIdxs(idxs []int) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *CassinoCuiPresenter) ActionLogOutput(cg interfaces.CassinoGame) string {
-	return actionLogOutputText(cg)
+	return actionLogOutputTextForSeats[*domain.CassinoPlayer](cg)
 }

--- a/internal/adapter/presenter/CatchTenCuiPresenter.go
+++ b/internal/adapter/presenter/CatchTenCuiPresenter.go
@@ -106,5 +106,5 @@ var catchTenHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *CatchTenCuiPresenter) ActionLogOutput(g interfaces.CatchTenGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.CatchTenPlayer](g)
 }

--- a/internal/adapter/presenter/CatchTenCuiPresenter.go
+++ b/internal/adapter/presenter/CatchTenCuiPresenter.go
@@ -106,5 +106,5 @@ var catchTenHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *CatchTenCuiPresenter) ActionLogOutput(g interfaces.CatchTenGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/CegoCuiPresenter.go
+++ b/internal/adapter/presenter/CegoCuiPresenter.go
@@ -254,5 +254,5 @@ var cegoHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *CegoCuiPresenter) ActionLogOutput(g interfaces.CegoGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.CegoPlayer](g)
 }

--- a/internal/adapter/presenter/CegoCuiPresenter.go
+++ b/internal/adapter/presenter/CegoCuiPresenter.go
@@ -254,5 +254,5 @@ var cegoHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *CegoCuiPresenter) ActionLogOutput(g interfaces.CegoGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/ChinchonCuiPresenter.go
+++ b/internal/adapter/presenter/ChinchonCuiPresenter.go
@@ -215,5 +215,5 @@ func (p *ChinchonCuiPresenter) Output(g interfaces.ChinchonGame, lastErr error) 
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ChinchonCuiPresenter) ActionLogOutput(g interfaces.ChinchonGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.ChinchonPlayer](g)
 }

--- a/internal/adapter/presenter/ChineseTenCuiPresenter.go
+++ b/internal/adapter/presenter/ChineseTenCuiPresenter.go
@@ -129,5 +129,5 @@ var chineseTenHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ChineseTenCuiPresenter) ActionLogOutput(c interfaces.ChineseTenGame) string {
-	return actionLogOutputText(c)
+	return actionLogOutputTextForSeats[*domain.ChineseTenPlayer](c)
 }

--- a/internal/adapter/presenter/CinchCuiPresenter.go
+++ b/internal/adapter/presenter/CinchCuiPresenter.go
@@ -196,5 +196,5 @@ var cinchHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *CinchCuiPresenter) ActionLogOutput(g interfaces.CinchGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/CinchCuiPresenter.go
+++ b/internal/adapter/presenter/CinchCuiPresenter.go
@@ -196,5 +196,5 @@ var cinchHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *CinchCuiPresenter) ActionLogOutput(g interfaces.CinchGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.CinchPlayer](g)
 }

--- a/internal/adapter/presenter/ConquianCuiPresenter.go
+++ b/internal/adapter/presenter/ConquianCuiPresenter.go
@@ -102,5 +102,5 @@ func (p *ConquianCuiPresenter) Output(g interfaces.ConquianGame, lastErr error) 
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ConquianCuiPresenter) ActionLogOutput(g interfaces.ConquianGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.ConquianPlayer](g)
 }

--- a/internal/adapter/presenter/ContractRummyCuiPresenter.go
+++ b/internal/adapter/presenter/ContractRummyCuiPresenter.go
@@ -122,5 +122,5 @@ func (p *ContractRummyCuiPresenter) Output(g interfaces.ContractRummyGame, lastE
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ContractRummyCuiPresenter) ActionLogOutput(g interfaces.ContractRummyGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.ContractRummyPlayer](g)
 }

--- a/internal/adapter/presenter/CourtPieceCuiPresenter.go
+++ b/internal/adapter/presenter/CourtPieceCuiPresenter.go
@@ -166,5 +166,5 @@ var courtPieceHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *CourtPieceCuiPresenter) ActionLogOutput(t interfaces.CourtPieceGame) string {
-	return actionLogOutputText(t)
+	return actionLogOutputTextWithNames(t, func(idx int) string { return cuiPlayerName(t.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/CourtPieceCuiPresenter.go
+++ b/internal/adapter/presenter/CourtPieceCuiPresenter.go
@@ -166,5 +166,5 @@ var courtPieceHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *CourtPieceCuiPresenter) ActionLogOutput(t interfaces.CourtPieceGame) string {
-	return actionLogOutputTextWithNames(t, func(idx int) string { return cuiPlayerName(t.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.CourtPiecePlayer](t)
 }

--- a/internal/adapter/presenter/CrazyEightsCuiPresenter.go
+++ b/internal/adapter/presenter/CrazyEightsCuiPresenter.go
@@ -119,7 +119,7 @@ func (p *CrazyEightsCuiPresenter) Output(g interfaces.CrazyEightsGame, lastErr e
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *CrazyEightsCuiPresenter) ActionLogOutput(g interfaces.CrazyEightsGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.CrazyEightsPlayer](g)
 }
 
 // suitDisplayName returns the suit display string.

--- a/internal/adapter/presenter/CrazyEightsCuiPresenter_test.go
+++ b/internal/adapter/presenter/CrazyEightsCuiPresenter_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -275,6 +276,8 @@ func TestCrazyEightsCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewCrazyEightsPlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜")
@@ -287,6 +290,8 @@ func TestCrazyEightsCuiPresenter_ActionLogOutput(t *testing.T) {
 		m := new(interfaces.MockCrazyEightsGame)
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewCrazyEightsPlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜はありません")

--- a/internal/adapter/presenter/CribbageCuiPresenter.go
+++ b/internal/adapter/presenter/CribbageCuiPresenter.go
@@ -172,7 +172,7 @@ func (p *CribbageCuiPresenter) writeShowDetails(b *strings.Builder, g interfaces
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *CribbageCuiPresenter) ActionLogOutput(g interfaces.CribbageGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.CribbagePlayer](g)
 }
 
 // HintOutput ヒントを出力（ディスカード推奨2枚 or ペギング推奨1枚）

--- a/internal/adapter/presenter/CribbageCuiPresenter_test.go
+++ b/internal/adapter/presenter/CribbageCuiPresenter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -271,6 +272,8 @@ func TestCribbageCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewCribbagePlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜")
@@ -283,6 +286,8 @@ func TestCribbageCuiPresenter_ActionLogOutput(t *testing.T) {
 		m := new(interfaces.MockCribbageGame)
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewCribbagePlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜はありません")

--- a/internal/adapter/presenter/CuarentaCuiPresenter.go
+++ b/internal/adapter/presenter/CuarentaCuiPresenter.go
@@ -150,5 +150,5 @@ func cuarentaCardShort(c *domain.Card) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *CuarentaCuiPresenter) ActionLogOutput(cg interfaces.CuarentaGame) string {
-	return actionLogOutputText(cg)
+	return actionLogOutputTextForSeats[*domain.CuarentaPlayer](cg)
 }

--- a/internal/adapter/presenter/CuckooCuiPresenter.go
+++ b/internal/adapter/presenter/CuckooCuiPresenter.go
@@ -94,5 +94,5 @@ func (p *CuckooCuiPresenter) Output(g interfaces.CuckooGame, lastErr error) stri
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *CuckooCuiPresenter) ActionLogOutput(g interfaces.CuckooGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.CuckooPlayer](g)
 }

--- a/internal/adapter/presenter/CuckooCuiPresenter_test.go
+++ b/internal/adapter/presenter/CuckooCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -120,5 +121,7 @@ func TestCuckooCuiPresenter_ActionLogOutput(t *testing.T) {
 	}
 	m.On("GetGameEndFlag").Return(true)
 	m.On("GetActionLog").Return(entries)
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewCuckooPlayer(true)).Maybe()
 	assert.Contains(t, p.ActionLogOutput(m), "keep")
 }

--- a/internal/adapter/presenter/CucumberCuiPresenter.go
+++ b/internal/adapter/presenter/CucumberCuiPresenter.go
@@ -137,5 +137,5 @@ var cucumberHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *CucumberCuiPresenter) ActionLogOutput(s interfaces.CucumberGame) string {
-	return actionLogOutputText(s)
+	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/CucumberCuiPresenter.go
+++ b/internal/adapter/presenter/CucumberCuiPresenter.go
@@ -137,5 +137,5 @@ var cucumberHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *CucumberCuiPresenter) ActionLogOutput(s interfaces.CucumberGame) string {
-	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.CucumberPlayer](s)
 }

--- a/internal/adapter/presenter/DaifugoCuiPresenter.go
+++ b/internal/adapter/presenter/DaifugoCuiPresenter.go
@@ -178,5 +178,5 @@ func (p *DaifugoCuiPresenter) Output(dg interfaces.DaifugoGame, lastErr error) s
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *DaifugoCuiPresenter) ActionLogOutput(dg interfaces.DaifugoGame) string {
-	return actionLogOutputText(dg)
+	return actionLogOutputTextForSeats[*domain.DaifugoPlayer](dg)
 }

--- a/internal/adapter/presenter/DaifugoCuiPresenter_test.go
+++ b/internal/adapter/presenter/DaifugoCuiPresenter_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func makeDaifugoPlayersForPresenter() []*domain.DaifugoPlayer {
@@ -449,6 +450,8 @@ func TestDaifugoCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		mockGame.On("GetGameEndFlag").Return(true)
 		mockGame.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		mockGame.On("GetPlayer", mock.Anything).Return(domain.NewDaifugoPlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(mockGame)
 
@@ -462,6 +465,8 @@ func TestDaifugoCuiPresenter_ActionLogOutput(t *testing.T) {
 		mockGame := new(interfaces.MockDaifugoGame)
 		mockGame.On("GetGameEndFlag").Return(true)
 		mockGame.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		mockGame.On("GetPlayer", mock.Anything).Return(domain.NewDaifugoPlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(mockGame)
 

--- a/internal/adapter/presenter/DesmocheCuiPresenter.go
+++ b/internal/adapter/presenter/DesmocheCuiPresenter.go
@@ -167,5 +167,5 @@ var desmocheHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *DesmocheCuiPresenter) ActionLogOutput(c interfaces.DesmocheGame) string {
-	return actionLogOutputText(c)
+	return actionLogOutputTextForSeats[*domain.DesmochePlayer](c)
 }

--- a/internal/adapter/presenter/DeuceToSevenCuiPresenter.go
+++ b/internal/adapter/presenter/DeuceToSevenCuiPresenter.go
@@ -170,5 +170,5 @@ func (dcp *DeuceToSevenCuiPresenter) HintOutput(g interfaces.DeuceToSevenGame) s
 
 // ActionLogOutput renders the action log as plain text.
 func (dcp *DeuceToSevenCuiPresenter) ActionLogOutput(g interfaces.DeuceToSevenGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeatList(g, g.GetPlayers())
 }

--- a/internal/adapter/presenter/DoppelkopfCuiPresenter.go
+++ b/internal/adapter/presenter/DoppelkopfCuiPresenter.go
@@ -138,5 +138,5 @@ var doppelkopfHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *DoppelkopfCuiPresenter) ActionLogOutput(g interfaces.DoppelkopfGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/DoppelkopfCuiPresenter.go
+++ b/internal/adapter/presenter/DoppelkopfCuiPresenter.go
@@ -138,5 +138,5 @@ var doppelkopfHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *DoppelkopfCuiPresenter) ActionLogOutput(g interfaces.DoppelkopfGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.DoppelkopfPlayer](g)
 }

--- a/internal/adapter/presenter/DoppelkopfCuiPresenter_test.go
+++ b/internal/adapter/presenter/DoppelkopfCuiPresenter_test.go
@@ -159,6 +159,8 @@ func TestDoppelkopfCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "You plays ♠Q"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewDoppelkopfPlayer(true, 0)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "play")
 }

--- a/internal/adapter/presenter/DoubtCuiPresenter.go
+++ b/internal/adapter/presenter/DoubtCuiPresenter.go
@@ -153,5 +153,5 @@ func (p *DoubtCuiPresenter) Output(d interfaces.DoubtGame, lastErr error) string
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *DoubtCuiPresenter) ActionLogOutput(d interfaces.DoubtGame) string {
-	return actionLogOutputText(d)
+	return actionLogOutputTextForSeats[*domain.DoubtPlayer](d)
 }

--- a/internal/adapter/presenter/DoubtCuiPresenter_test.go
+++ b/internal/adapter/presenter/DoubtCuiPresenter_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -377,6 +378,8 @@ func TestDoubtCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		mockGame.On("GetGameEndFlag").Return(true)
 		mockGame.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		mockGame.On("GetPlayer", mock.Anything).Return(domain.NewDoubtPlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(mockGame)
 
@@ -390,6 +393,8 @@ func TestDoubtCuiPresenter_ActionLogOutput(t *testing.T) {
 		mockGame := new(interfaces.MockDoubtGame)
 		mockGame.On("GetGameEndFlag").Return(true)
 		mockGame.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		mockGame.On("GetPlayer", mock.Anything).Return(domain.NewDoubtPlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(mockGame)
 

--- a/internal/adapter/presenter/DoudizhuCuiPresenter.go
+++ b/internal/adapter/presenter/DoudizhuCuiPresenter.go
@@ -78,7 +78,7 @@ func (p *DoudizhuCuiPresenter) Output(dg interfaces.DoudizhuGame, lastErr error)
 
 // ActionLogOutput 棋譜をCUI出力
 func (p *DoudizhuCuiPresenter) ActionLogOutput(dg interfaces.DoudizhuGame) string {
-	return actionLogOutputText(dg)
+	return actionLogOutputTextForSeats[*domain.DoudizhuPlayer](dg)
 }
 
 func doudizhuPlayerStr(player *domain.DoudizhuPlayer, idx int) string {

--- a/internal/adapter/presenter/DurakCuiPresenter.go
+++ b/internal/adapter/presenter/DurakCuiPresenter.go
@@ -126,7 +126,7 @@ func (p *DurakCuiPresenter) Output(dg interfaces.DurakGame, lastErr error) strin
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *DurakCuiPresenter) ActionLogOutput(dg interfaces.DurakGame) string {
-	return actionLogOutputText(dg)
+	return actionLogOutputTextForSeats[*domain.DurakPlayer](dg)
 }
 
 // HintOutput emits the current Durak hint.

--- a/internal/adapter/presenter/EcarteCuiPresenter.go
+++ b/internal/adapter/presenter/EcarteCuiPresenter.go
@@ -213,5 +213,5 @@ var ecarteHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *EcarteCuiPresenter) ActionLogOutput(b interfaces.EcarteGame) string {
-	return actionLogOutputTextWithNames(b, func(idx int) string { return cuiPlayerName(b.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.EcartePlayer](b)
 }

--- a/internal/adapter/presenter/EcarteCuiPresenter.go
+++ b/internal/adapter/presenter/EcarteCuiPresenter.go
@@ -213,5 +213,5 @@ var ecarteHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *EcarteCuiPresenter) ActionLogOutput(b interfaces.EcarteGame) string {
-	return actionLogOutputText(b)
+	return actionLogOutputTextWithNames(b, func(idx int) string { return cuiPlayerName(b.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/EgyptianRatscrewCuiPresenter.go
+++ b/internal/adapter/presenter/EgyptianRatscrewCuiPresenter.go
@@ -109,5 +109,5 @@ func (p *EgyptianRatscrewCuiPresenter) Output(g interfaces.EgyptianRatscrewGame,
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *EgyptianRatscrewCuiPresenter) ActionLogOutput(g interfaces.EgyptianRatscrewGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.EgyptianRatscrewPlayer](g)
 }

--- a/internal/adapter/presenter/EscobaCuiPresenter.go
+++ b/internal/adapter/presenter/EscobaCuiPresenter.go
@@ -147,5 +147,5 @@ func (p *EscobaCuiPresenter) HintOutput(eg interfaces.EscobaGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *EscobaCuiPresenter) ActionLogOutput(eg interfaces.EscobaGame) string {
-	return actionLogOutputText(eg)
+	return actionLogOutputTextForSeats[*domain.ScopaPlayer](eg)
 }

--- a/internal/adapter/presenter/EstimationCuiPresenter.go
+++ b/internal/adapter/presenter/EstimationCuiPresenter.go
@@ -193,5 +193,5 @@ var estimationHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *EstimationCuiPresenter) ActionLogOutput(e interfaces.EstimationGame) string {
-	return actionLogOutputText(e)
+	return actionLogOutputTextWithNames(e, func(idx int) string { return cuiPlayerName(e.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/EstimationCuiPresenter.go
+++ b/internal/adapter/presenter/EstimationCuiPresenter.go
@@ -193,5 +193,5 @@ var estimationHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *EstimationCuiPresenter) ActionLogOutput(e interfaces.EstimationGame) string {
-	return actionLogOutputTextWithNames(e, func(idx int) string { return cuiPlayerName(e.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.EstimationPlayer](e)
 }

--- a/internal/adapter/presenter/EuchreCuiPresenter.go
+++ b/internal/adapter/presenter/EuchreCuiPresenter.go
@@ -241,5 +241,5 @@ var euchreHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *EuchreCuiPresenter) ActionLogOutput(e interfaces.EuchreGame) string {
-	return actionLogOutputText(e)
+	return actionLogOutputTextWithNames(e, func(idx int) string { return cuiPlayerName(e.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/EuchreCuiPresenter.go
+++ b/internal/adapter/presenter/EuchreCuiPresenter.go
@@ -241,5 +241,5 @@ var euchreHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *EuchreCuiPresenter) ActionLogOutput(e interfaces.EuchreGame) string {
-	return actionLogOutputTextWithNames(e, func(idx int) string { return cuiPlayerName(e.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.EuchrePlayer](e)
 }

--- a/internal/adapter/presenter/EuchreCuiPresenter_test.go
+++ b/internal/adapter/presenter/EuchreCuiPresenter_test.go
@@ -271,10 +271,13 @@ func TestEuchreCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewEuchrePlayer(true, 0)).Maybe()
 
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜")
 		assert.Contains(t, result, "play")
+		assert.Contains(t, result, "あなた", "棋譜の座席名が他の行と揃っていない")
 		assert.Contains(t, result, "played SPADE 5")
 		m.AssertExpectations(t)
 	})

--- a/internal/adapter/presenter/FiftyOneCuiPresenter.go
+++ b/internal/adapter/presenter/FiftyOneCuiPresenter.go
@@ -112,5 +112,5 @@ func fiftyOneSuitScoreLine(player *domain.FiftyOnePlayer) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *FiftyOneCuiPresenter) ActionLogOutput(fo interfaces.FiftyOneGame) string {
-	return actionLogOutputText(fo)
+	return actionLogOutputTextForSeats[*domain.FiftyOnePlayer](fo)
 }

--- a/internal/adapter/presenter/FiveCardStudCuiPresenter.go
+++ b/internal/adapter/presenter/FiveCardStudCuiPresenter.go
@@ -17,7 +17,7 @@ type FiveCardStudCuiPresenter struct{}
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *FiveCardStudCuiPresenter) ActionLogOutput(s interfaces.FiveCardStudGame) string {
-	return actionLogOutputText(s)
+	return actionLogOutputTextForSeats[*domain.FiveCardStudPlayer](s)
 }
 
 // Output renders the current game state for the active locale.

--- a/internal/adapter/presenter/FiveCardStudCuiPresenter_test.go
+++ b/internal/adapter/presenter/FiveCardStudCuiPresenter_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
@@ -419,6 +420,8 @@ func TestFiveCardStudCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		mockGame.On("GetGameEndFlag").Return(true)
 		mockGame.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		mockGame.On("GetPlayer", mock.Anything).Return(domain.NewFiveCardStudPlayer(true, domain.FiveCardStudPlayStyle(0))).Maybe()
 
 		result := p.ActionLogOutput(mockGame)
 		assert.Contains(t, result, "棋譜")

--- a/internal/adapter/presenter/FiveHundredCuiPresenter.go
+++ b/internal/adapter/presenter/FiveHundredCuiPresenter.go
@@ -180,7 +180,7 @@ func (p *FiveHundredCuiPresenter) HintOutput(g interfaces.FiveHundredGame) strin
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *FiveHundredCuiPresenter) ActionLogOutput(g interfaces.FiveHundredGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.FiveHundredPlayer](g)
 }
 
 // ptrOrZero returns *p or 0 when p is nil.

--- a/internal/adapter/presenter/FiveHundredCuiPresenter.go
+++ b/internal/adapter/presenter/FiveHundredCuiPresenter.go
@@ -180,7 +180,7 @@ func (p *FiveHundredCuiPresenter) HintOutput(g interfaces.FiveHundredGame) strin
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *FiveHundredCuiPresenter) ActionLogOutput(g interfaces.FiveHundredGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }
 
 // ptrOrZero returns *p or 0 when p is nil.

--- a/internal/adapter/presenter/FortyFivesCuiPresenter.go
+++ b/internal/adapter/presenter/FortyFivesCuiPresenter.go
@@ -240,5 +240,5 @@ var fortyFivesHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *FortyFivesCuiPresenter) ActionLogOutput(g interfaces.FortyFivesGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.FortyFivesPlayer](g)
 }

--- a/internal/adapter/presenter/FortyFivesCuiPresenter.go
+++ b/internal/adapter/presenter/FortyFivesCuiPresenter.go
@@ -240,5 +240,5 @@ var fortyFivesHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *FortyFivesCuiPresenter) ActionLogOutput(g interfaces.FortyFivesGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/FortyFivesCuiPresenter_test.go
+++ b/internal/adapter/presenter/FortyFivesCuiPresenter_test.go
@@ -155,6 +155,8 @@ func TestFortyFivesCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "You plays ♠K"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewFortyFivesPlayer(true)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "play")
 }

--- a/internal/adapter/presenter/FrenchTarotCuiPresenter.go
+++ b/internal/adapter/presenter/FrenchTarotCuiPresenter.go
@@ -233,5 +233,5 @@ var frenchTarotHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *FrenchTarotCuiPresenter) ActionLogOutput(g interfaces.FrenchTarotGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/FrenchTarotCuiPresenter.go
+++ b/internal/adapter/presenter/FrenchTarotCuiPresenter.go
@@ -233,5 +233,5 @@ var frenchTarotHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *FrenchTarotCuiPresenter) ActionLogOutput(g interfaces.FrenchTarotGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.FrenchTarotPlayer](g)
 }

--- a/internal/adapter/presenter/GaigelCuiPresenter.go
+++ b/internal/adapter/presenter/GaigelCuiPresenter.go
@@ -138,7 +138,7 @@ func (p *GaigelCuiPresenter) HintOutput(g interfaces.GaigelGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *GaigelCuiPresenter) ActionLogOutput(g interfaces.GaigelGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.GaigelPlayer](g)
 }
 
 // gaigelHintReasonKeys maps Gaigel-specific hint-reason identifiers to their

--- a/internal/adapter/presenter/GaigelCuiPresenter.go
+++ b/internal/adapter/presenter/GaigelCuiPresenter.go
@@ -138,7 +138,7 @@ func (p *GaigelCuiPresenter) HintOutput(g interfaces.GaigelGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *GaigelCuiPresenter) ActionLogOutput(g interfaces.GaigelGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }
 
 // gaigelHintReasonKeys maps Gaigel-specific hint-reason identifiers to their

--- a/internal/adapter/presenter/GanjifaCuiPresenter.go
+++ b/internal/adapter/presenter/GanjifaCuiPresenter.go
@@ -195,5 +195,5 @@ var ganjifaHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *GanjifaCuiPresenter) ActionLogOutput(g interfaces.GanjifaGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/GanjifaCuiPresenter.go
+++ b/internal/adapter/presenter/GanjifaCuiPresenter.go
@@ -195,5 +195,5 @@ var ganjifaHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *GanjifaCuiPresenter) ActionLogOutput(g interfaces.GanjifaGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.GanjifaPlayer](g)
 }

--- a/internal/adapter/presenter/GanjifaCuiPresenter_test.go
+++ b/internal/adapter/presenter/GanjifaCuiPresenter_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
@@ -200,6 +201,8 @@ func TestGanjifaCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "You plays Taj 12"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewGanjifaPlayer(true)).Maybe()
 	assert.Contains(t, p.ActionLogOutput(m), "play")
 }
 

--- a/internal/adapter/presenter/GermanWhistCuiPresenter.go
+++ b/internal/adapter/presenter/GermanWhistCuiPresenter.go
@@ -130,5 +130,5 @@ var germanWhistHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *GermanWhistCuiPresenter) ActionLogOutput(g interfaces.GermanWhistGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/GermanWhistCuiPresenter.go
+++ b/internal/adapter/presenter/GermanWhistCuiPresenter.go
@@ -130,5 +130,5 @@ var germanWhistHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *GermanWhistCuiPresenter) ActionLogOutput(g interfaces.GermanWhistGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.GermanWhistPlayer](g)
 }

--- a/internal/adapter/presenter/GinRummyCuiPresenter.go
+++ b/internal/adapter/presenter/GinRummyCuiPresenter.go
@@ -153,5 +153,5 @@ func writeGinRummyKnockerMelds(b *strings.Builder, melds [][]*domain.Card) {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *GinRummyCuiPresenter) ActionLogOutput(g interfaces.GinRummyGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.GinRummyPlayer](g)
 }

--- a/internal/adapter/presenter/GinRummyCuiPresenter_test.go
+++ b/internal/adapter/presenter/GinRummyCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -254,6 +255,8 @@ func TestGinRummyCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewGinRummyPlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜")
@@ -266,6 +269,8 @@ func TestGinRummyCuiPresenter_ActionLogOutput(t *testing.T) {
 		m := new(interfaces.MockGinRummyGame)
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewGinRummyPlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜はありません")

--- a/internal/adapter/presenter/GoFishCuiPresenter.go
+++ b/internal/adapter/presenter/GoFishCuiPresenter.go
@@ -154,5 +154,5 @@ func (p *GoFishCuiPresenter) Output(gf interfaces.GoFishGame, lastErr error) str
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *GoFishCuiPresenter) ActionLogOutput(gf interfaces.GoFishGame) string {
-	return actionLogOutputText(gf)
+	return actionLogOutputTextForSeats[*domain.GoFishPlayer](gf)
 }

--- a/internal/adapter/presenter/GoStopCuiPresenter.go
+++ b/internal/adapter/presenter/GoStopCuiPresenter.go
@@ -242,5 +242,5 @@ var gostopHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *GoStopCuiPresenter) ActionLogOutput(g interfaces.GoStopGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.GoStopPlayer](g)
 }

--- a/internal/adapter/presenter/GongZhuCuiPresenter.go
+++ b/internal/adapter/presenter/GongZhuCuiPresenter.go
@@ -216,5 +216,5 @@ var gongZhuHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *GongZhuCuiPresenter) ActionLogOutput(g interfaces.GongZhuGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.GongZhuPlayer](g)
 }

--- a/internal/adapter/presenter/GongZhuCuiPresenter.go
+++ b/internal/adapter/presenter/GongZhuCuiPresenter.go
@@ -216,5 +216,5 @@ var gongZhuHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *GongZhuCuiPresenter) ActionLogOutput(g interfaces.GongZhuGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/GongZhuCuiPresenter_test.go
+++ b/internal/adapter/presenter/GongZhuCuiPresenter_test.go
@@ -142,6 +142,8 @@ func TestGongZhuCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "plays ♠5"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewGongZhuPlayer(true)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.NotEmpty(t, result)
 }

--- a/internal/adapter/presenter/GoofspielCuiPresenter.go
+++ b/internal/adapter/presenter/GoofspielCuiPresenter.go
@@ -131,5 +131,5 @@ var goofspielHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *GoofspielCuiPresenter) ActionLogOutput(s interfaces.GoofspielGame) string {
-	return actionLogOutputText(s)
+	return actionLogOutputTextForSeats[*domain.GoofspielPlayer](s)
 }

--- a/internal/adapter/presenter/GuandanCuiPresenter.go
+++ b/internal/adapter/presenter/GuandanCuiPresenter.go
@@ -184,7 +184,7 @@ func (p *GuandanCuiPresenter) writeHandEnd(b *strings.Builder, g interfaces.Guan
 
 // ActionLogOutput は棋譜をテキストで出力する。
 func (p *GuandanCuiPresenter) ActionLogOutput(g interfaces.GuandanGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.GuandanPlayer](g)
 }
 
 // guandanHumanIdx は人間の席を返す (いなければ -1)。

--- a/internal/adapter/presenter/GutsCuiPresenter.go
+++ b/internal/adapter/presenter/GutsCuiPresenter.go
@@ -178,5 +178,5 @@ var gutsHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *GutsCuiPresenter) ActionLogOutput(g interfaces.GutsGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.GutsPlayer](g)
 }

--- a/internal/adapter/presenter/HachiHachiCuiPresenter.go
+++ b/internal/adapter/presenter/HachiHachiCuiPresenter.go
@@ -172,5 +172,5 @@ var hachihachiHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *HachiHachiCuiPresenter) ActionLogOutput(g interfaces.HachiHachiGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.HachiHachiPlayer](g)
 }

--- a/internal/adapter/presenter/HandAndFootCuiPresenter.go
+++ b/internal/adapter/presenter/HandAndFootCuiPresenter.go
@@ -189,5 +189,5 @@ func (p *HandAndFootCuiPresenter) HintOutput(g interfaces.HandAndFootGame) strin
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *HandAndFootCuiPresenter) ActionLogOutput(g interfaces.HandAndFootGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.HandAndFootPlayer](g)
 }

--- a/internal/adapter/presenter/HandAndFootCuiPresenter_test.go
+++ b/internal/adapter/presenter/HandAndFootCuiPresenter_test.go
@@ -258,6 +258,8 @@ func TestHandAndFootCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewHandAndFootPlayer(true)).Maybe()
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "draw_stock")
 		m.AssertExpectations(t)

--- a/internal/adapter/presenter/HasenpfefferCuiPresenter.go
+++ b/internal/adapter/presenter/HasenpfefferCuiPresenter.go
@@ -217,5 +217,5 @@ var hasenpfefferHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *HasenpfefferCuiPresenter) ActionLogOutput(h interfaces.HasenpfefferGame) string {
-	return actionLogOutputTextWithNames(h, func(idx int) string { return cuiPlayerName(h.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.HasenpfefferPlayer](h)
 }

--- a/internal/adapter/presenter/HasenpfefferCuiPresenter.go
+++ b/internal/adapter/presenter/HasenpfefferCuiPresenter.go
@@ -217,5 +217,5 @@ var hasenpfefferHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *HasenpfefferCuiPresenter) ActionLogOutput(h interfaces.HasenpfefferGame) string {
-	return actionLogOutputText(h)
+	return actionLogOutputTextWithNames(h, func(idx int) string { return cuiPlayerName(h.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/HeartsCuiPresenter.go
+++ b/internal/adapter/presenter/HeartsCuiPresenter.go
@@ -134,7 +134,7 @@ var heartsHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *HeartsCuiPresenter) ActionLogOutput(h interfaces.HeartsGame) string {
-	return actionLogOutputText(h)
+	return actionLogOutputTextWithNames(h, func(idx int) string { return cuiPlayerName(h.GetPlayer(idx), idx) })
 }
 
 // cuiPassDirectionStr returns the localized label for a Hearts pass direction.

--- a/internal/adapter/presenter/HeartsCuiPresenter.go
+++ b/internal/adapter/presenter/HeartsCuiPresenter.go
@@ -134,7 +134,7 @@ var heartsHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *HeartsCuiPresenter) ActionLogOutput(h interfaces.HeartsGame) string {
-	return actionLogOutputTextWithNames(h, func(idx int) string { return cuiPlayerName(h.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.HeartsPlayer](h)
 }
 
 // cuiPassDirectionStr returns the localized label for a Hearts pass direction.

--- a/internal/adapter/presenter/HeartsCuiPresenter_test.go
+++ b/internal/adapter/presenter/HeartsCuiPresenter_test.go
@@ -314,6 +314,8 @@ func TestHeartsCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewHeartsPlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜")
@@ -326,6 +328,8 @@ func TestHeartsCuiPresenter_ActionLogOutput(t *testing.T) {
 		m := new(interfaces.MockHeartsGame)
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewHeartsPlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜はありません")

--- a/internal/adapter/presenter/HokmCuiPresenter.go
+++ b/internal/adapter/presenter/HokmCuiPresenter.go
@@ -160,5 +160,5 @@ var hokmHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *HokmCuiPresenter) ActionLogOutput(h interfaces.HokmGame) string {
-	return actionLogOutputText(h)
+	return actionLogOutputTextWithNames(h, func(idx int) string { return cuiPlayerName(h.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/HokmCuiPresenter.go
+++ b/internal/adapter/presenter/HokmCuiPresenter.go
@@ -160,5 +160,5 @@ var hokmHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *HokmCuiPresenter) ActionLogOutput(h interfaces.HokmGame) string {
-	return actionLogOutputTextWithNames(h, func(idx int) string { return cuiPlayerName(h.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.HokmPlayer](h)
 }

--- a/internal/adapter/presenter/HoldemCuiPresenter.go
+++ b/internal/adapter/presenter/HoldemCuiPresenter.go
@@ -18,7 +18,7 @@ type HoldemCuiPresenter struct{}
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *HoldemCuiPresenter) ActionLogOutput(h interfaces.HoldemGame) string {
-	return actionLogOutputText(h)
+	return actionLogOutputTextForSeats[*domain.HoldemPlayer](h)
 }
 
 // Output renders the current game state for the active locale (#1699).

--- a/internal/adapter/presenter/HoldemCuiPresenter_test.go
+++ b/internal/adapter/presenter/HoldemCuiPresenter_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -755,6 +756,8 @@ func TestHoldemCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		mockGame.On("GetGameEndFlag").Return(true)
 		mockGame.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		mockGame.On("GetPlayer", mock.Anything).Return(domain.NewHoldemPlayer(true, domain.HoldemPlayStyle(0))).Maybe()
 
 		result := p.ActionLogOutput(mockGame)
 
@@ -768,6 +771,8 @@ func TestHoldemCuiPresenter_ActionLogOutput(t *testing.T) {
 		mockGame := new(interfaces.MockHoldemGame)
 		mockGame.On("GetGameEndFlag").Return(true)
 		mockGame.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		mockGame.On("GetPlayer", mock.Anything).Return(domain.NewHoldemPlayer(true, domain.HoldemPlayStyle(0))).Maybe()
 
 		result := p.ActionLogOutput(mockGame)
 

--- a/internal/adapter/presenter/HoneymoonBridgeCuiPresenter.go
+++ b/internal/adapter/presenter/HoneymoonBridgeCuiPresenter.go
@@ -188,5 +188,5 @@ var honeymoonBridgeHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *HoneymoonBridgeCuiPresenter) ActionLogOutput(s interfaces.HoneymoonBridgeGame) string {
-	return actionLogOutputText(s)
+	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/HoneymoonBridgeCuiPresenter.go
+++ b/internal/adapter/presenter/HoneymoonBridgeCuiPresenter.go
@@ -188,5 +188,5 @@ var honeymoonBridgeHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *HoneymoonBridgeCuiPresenter) ActionLogOutput(s interfaces.HoneymoonBridgeGame) string {
-	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.HoneymoonBridgePlayer](s)
 }

--- a/internal/adapter/presenter/IndianPokerCuiPresenter.go
+++ b/internal/adapter/presenter/IndianPokerCuiPresenter.go
@@ -17,7 +17,7 @@ type IndianPokerCuiPresenter struct{}
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *IndianPokerCuiPresenter) ActionLogOutput(ip interfaces.IndianPokerGame) string {
-	return actionLogOutputText(ip)
+	return actionLogOutputTextForSeats[*domain.IndianPokerPlayer](ip)
 }
 
 // Output renders the current game state for the active locale (#1699).

--- a/internal/adapter/presenter/IndianPokerCuiPresenter_test.go
+++ b/internal/adapter/presenter/IndianPokerCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
@@ -375,6 +376,8 @@ func TestIndianPokerCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		mockGame.On("GetGameEndFlag").Return(true)
 		mockGame.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		mockGame.On("GetPlayer", mock.Anything).Return(domain.NewIndianPokerPlayer(true, domain.HoldemPlayStyle(0))).Maybe()
 
 		result := p.ActionLogOutput(mockGame)
 
@@ -388,6 +391,8 @@ func TestIndianPokerCuiPresenter_ActionLogOutput(t *testing.T) {
 		mockGame := new(interfaces.MockIndianPokerGame)
 		mockGame.On("GetGameEndFlag").Return(true)
 		mockGame.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		mockGame.On("GetPlayer", mock.Anything).Return(domain.NewIndianPokerPlayer(true, domain.HoldemPlayStyle(0))).Maybe()
 
 		result := p.ActionLogOutput(mockGame)
 

--- a/internal/adapter/presenter/IndianRummyCuiPresenter.go
+++ b/internal/adapter/presenter/IndianRummyCuiPresenter.go
@@ -95,5 +95,5 @@ func (p *IndianRummyCuiPresenter) Output(g interfaces.IndianRummyGame, lastErr e
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *IndianRummyCuiPresenter) ActionLogOutput(g interfaces.IndianRummyGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.IndianRummyPlayer](g)
 }

--- a/internal/adapter/presenter/IsraeliWhistCuiPresenter.go
+++ b/internal/adapter/presenter/IsraeliWhistCuiPresenter.go
@@ -198,5 +198,5 @@ var israeliWhistHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *IsraeliWhistCuiPresenter) ActionLogOutput(w interfaces.IsraeliWhistGame) string {
-	return actionLogOutputText(w)
+	return actionLogOutputTextWithNames(w, func(idx int) string { return cuiPlayerName(w.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/IsraeliWhistCuiPresenter.go
+++ b/internal/adapter/presenter/IsraeliWhistCuiPresenter.go
@@ -198,5 +198,5 @@ var israeliWhistHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *IsraeliWhistCuiPresenter) ActionLogOutput(w interfaces.IsraeliWhistGame) string {
-	return actionLogOutputTextWithNames(w, func(idx int) string { return cuiPlayerName(w.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.IsraeliWhistPlayer](w)
 }

--- a/internal/adapter/presenter/JassCuiPresenter.go
+++ b/internal/adapter/presenter/JassCuiPresenter.go
@@ -155,5 +155,5 @@ func (p *JassCuiPresenter) HintOutput(g interfaces.JassGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *JassCuiPresenter) ActionLogOutput(g interfaces.JassGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/JassCuiPresenter.go
+++ b/internal/adapter/presenter/JassCuiPresenter.go
@@ -155,5 +155,5 @@ func (p *JassCuiPresenter) HintOutput(g interfaces.JassGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *JassCuiPresenter) ActionLogOutput(g interfaces.JassGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.JassPlayer](g)
 }

--- a/internal/adapter/presenter/KaiserCuiPresenter.go
+++ b/internal/adapter/presenter/KaiserCuiPresenter.go
@@ -167,7 +167,7 @@ func (p *KaiserCuiPresenter) Output(g interfaces.KaiserGame, lastErr error) stri
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *KaiserCuiPresenter) ActionLogOutput(g interfaces.KaiserGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.KaiserPlayer](g)
 }
 
 // kaiserHintKey は今の局面で出すべき助言の i18n キーと、必要なら添える手札

--- a/internal/adapter/presenter/KalookiCuiPresenter.go
+++ b/internal/adapter/presenter/KalookiCuiPresenter.go
@@ -101,5 +101,5 @@ func (p *KalookiCuiPresenter) Output(g interfaces.KalookiGame, lastErr error) st
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *KalookiCuiPresenter) ActionLogOutput(g interfaces.KalookiGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.KalookiPlayer](g)
 }

--- a/internal/adapter/presenter/KarnoffelCuiPresenter.go
+++ b/internal/adapter/presenter/KarnoffelCuiPresenter.go
@@ -152,5 +152,5 @@ func karnoffelLadderLine() string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *KarnoffelCuiPresenter) ActionLogOutput(g interfaces.KarnoffelGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.KarnoffelPlayer](g)
 }

--- a/internal/adapter/presenter/KempsCuiPresenter.go
+++ b/internal/adapter/presenter/KempsCuiPresenter.go
@@ -111,7 +111,7 @@ func (p *KempsCuiPresenter) Output(g interfaces.KempsGame, lastErr error) string
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *KempsCuiPresenter) ActionLogOutput(g interfaces.KempsGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.KempsPlayer](g)
 }
 
 // kempsCardSlice wraps []*Card to satisfy the cuiCardList interface.

--- a/internal/adapter/presenter/KilleCuiPresenter.go
+++ b/internal/adapter/presenter/KilleCuiPresenter.go
@@ -139,5 +139,5 @@ func (p *KilleCuiPresenter) Output(g interfaces.KilleGame, lastErr error) string
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *KilleCuiPresenter) ActionLogOutput(g interfaces.KilleGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.KillePlayer](g)
 }

--- a/internal/adapter/presenter/KingCuiPresenter.go
+++ b/internal/adapter/presenter/KingCuiPresenter.go
@@ -179,5 +179,5 @@ var kingHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *KingCuiPresenter) ActionLogOutput(kg interfaces.KingGame) string {
-	return actionLogOutputText(kg)
+	return actionLogOutputTextForSeats[*domain.KingPlayer](kg)
 }

--- a/internal/adapter/presenter/KlaberjassCuiPresenter.go
+++ b/internal/adapter/presenter/KlaberjassCuiPresenter.go
@@ -159,5 +159,5 @@ func (p *KlaberjassCuiPresenter) Output(g interfaces.KlaberjassGame, lastErr err
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *KlaberjassCuiPresenter) ActionLogOutput(g interfaces.KlaberjassGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.KlaberjassPlayer](g)
 }

--- a/internal/adapter/presenter/KlaverjasCuiPresenter.go
+++ b/internal/adapter/presenter/KlaverjasCuiPresenter.go
@@ -151,5 +151,5 @@ var klaverjasHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *KlaverjasCuiPresenter) ActionLogOutput(g interfaces.KlaverjasGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.KlaverjasPlayer](g)
 }

--- a/internal/adapter/presenter/KlaverjasCuiPresenter.go
+++ b/internal/adapter/presenter/KlaverjasCuiPresenter.go
@@ -151,5 +151,5 @@ var klaverjasHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *KlaverjasCuiPresenter) ActionLogOutput(g interfaces.KlaverjasGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/KlaverjasCuiPresenter_test.go
+++ b/internal/adapter/presenter/KlaverjasCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -141,6 +142,8 @@ func TestKlaverjasCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "You plays ♠K"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewKlaverjasPlayer(true)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "play")
 }

--- a/internal/adapter/presenter/KnockoutWhistCuiPresenter.go
+++ b/internal/adapter/presenter/KnockoutWhistCuiPresenter.go
@@ -165,5 +165,5 @@ var knockoutWhistHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *KnockoutWhistCuiPresenter) ActionLogOutput(g interfaces.KnockoutWhistGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/KnockoutWhistCuiPresenter.go
+++ b/internal/adapter/presenter/KnockoutWhistCuiPresenter.go
@@ -165,5 +165,5 @@ var knockoutWhistHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *KnockoutWhistCuiPresenter) ActionLogOutput(g interfaces.KnockoutWhistGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.KnockoutWhistPlayer](g)
 }

--- a/internal/adapter/presenter/KnockoutWhistCuiPresenter_test.go
+++ b/internal/adapter/presenter/KnockoutWhistCuiPresenter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
@@ -144,6 +145,8 @@ func TestKnockoutWhistCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "You plays ♠K"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewKnockoutWhistPlayer(true)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "play")
 }

--- a/internal/adapter/presenter/KoenigrufenCuiPresenter.go
+++ b/internal/adapter/presenter/KoenigrufenCuiPresenter.go
@@ -246,5 +246,5 @@ var koenigrufenHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *KoenigrufenCuiPresenter) ActionLogOutput(g interfaces.KoenigrufenGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/KoenigrufenCuiPresenter.go
+++ b/internal/adapter/presenter/KoenigrufenCuiPresenter.go
@@ -246,5 +246,5 @@ var koenigrufenHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *KoenigrufenCuiPresenter) ActionLogOutput(g interfaces.KoenigrufenGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.KoenigrufenPlayer](g)
 }

--- a/internal/adapter/presenter/KoiKoiCuiPresenter.go
+++ b/internal/adapter/presenter/KoiKoiCuiPresenter.go
@@ -201,5 +201,5 @@ var koikoiHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *KoiKoiCuiPresenter) ActionLogOutput(g interfaces.KoiKoiGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.KoiKoiPlayer](g)
 }

--- a/internal/adapter/presenter/LaughAndLieDownCuiPresenter.go
+++ b/internal/adapter/presenter/LaughAndLieDownCuiPresenter.go
@@ -125,5 +125,5 @@ var laughAndLieDownHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *LaughAndLieDownCuiPresenter) ActionLogOutput(c interfaces.LaughAndLieDownGame) string {
-	return actionLogOutputText(c)
+	return actionLogOutputTextForSeats[*domain.LaughAndLieDownPlayer](c)
 }

--- a/internal/adapter/presenter/LingerLongerCuiPresenter.go
+++ b/internal/adapter/presenter/LingerLongerCuiPresenter.go
@@ -115,7 +115,7 @@ var lingerLongerHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *LingerLongerCuiPresenter) ActionLogOutput(s interfaces.LingerLongerGame) string {
-	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.LingerLongerPlayer](s)
 }
 
 // lingerLongerEndBanner は決着の見出しを勝因に合わせて組み立てる。

--- a/internal/adapter/presenter/LingerLongerCuiPresenter.go
+++ b/internal/adapter/presenter/LingerLongerCuiPresenter.go
@@ -115,7 +115,7 @@ var lingerLongerHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *LingerLongerCuiPresenter) ActionLogOutput(s interfaces.LingerLongerGame) string {
-	return actionLogOutputText(s)
+	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
 }
 
 // lingerLongerEndBanner は決着の見出しを勝因に合わせて組み立てる。

--- a/internal/adapter/presenter/LiteratureCuiPresenter.go
+++ b/internal/adapter/presenter/LiteratureCuiPresenter.go
@@ -160,5 +160,5 @@ func (p *LiteratureCuiPresenter) Output(g interfaces.LiteratureGame, lastErr err
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *LiteratureCuiPresenter) ActionLogOutput(g interfaces.LiteratureGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.LiteraturePlayer](g)
 }

--- a/internal/adapter/presenter/LobaCuiPresenter.go
+++ b/internal/adapter/presenter/LobaCuiPresenter.go
@@ -161,5 +161,5 @@ var lobaHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *LobaCuiPresenter) ActionLogOutput(c interfaces.LobaGame) string {
-	return actionLogOutputText(c)
+	return actionLogOutputTextForSeats[*domain.LobaPlayer](c)
 }

--- a/internal/adapter/presenter/LooCuiPresenter.go
+++ b/internal/adapter/presenter/LooCuiPresenter.go
@@ -179,5 +179,5 @@ var looHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *LooCuiPresenter) ActionLogOutput(g interfaces.LooGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.LooPlayer](g)
 }

--- a/internal/adapter/presenter/LooCuiPresenter.go
+++ b/internal/adapter/presenter/LooCuiPresenter.go
@@ -179,5 +179,5 @@ var looHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *LooCuiPresenter) ActionLogOutput(g interfaces.LooGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/MacauCuiPresenter.go
+++ b/internal/adapter/presenter/MacauCuiPresenter.go
@@ -97,7 +97,7 @@ func (p *MacauCuiPresenter) Output(g interfaces.MacauGame, lastErr error) string
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *MacauCuiPresenter) ActionLogOutput(g interfaces.MacauGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.MacauPlayer](g)
 }
 
 // HintOutput lists the human's currently playable card indices. During a

--- a/internal/adapter/presenter/MacauCuiPresenter_test.go
+++ b/internal/adapter/presenter/MacauCuiPresenter_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -157,6 +158,8 @@ func TestMacauCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewMacauPlayer(true)).Maybe()
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜")
 		assert.Contains(t, result, "You plays SPADE 5")

--- a/internal/adapter/presenter/MachiavelliCuiPresenter.go
+++ b/internal/adapter/presenter/MachiavelliCuiPresenter.go
@@ -103,5 +103,5 @@ func (p *MachiavelliCuiPresenter) Output(g interfaces.MachiavelliGame, lastErr e
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *MachiavelliCuiPresenter) ActionLogOutput(g interfaces.MachiavelliGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.MachiavelliPlayer](g)
 }

--- a/internal/adapter/presenter/ManilleCuiPresenter.go
+++ b/internal/adapter/presenter/ManilleCuiPresenter.go
@@ -152,5 +152,5 @@ var manilleHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ManilleCuiPresenter) ActionLogOutput(g interfaces.ManilleGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.ManillePlayer](g)
 }

--- a/internal/adapter/presenter/ManilleCuiPresenter.go
+++ b/internal/adapter/presenter/ManilleCuiPresenter.go
@@ -152,5 +152,5 @@ var manilleHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ManilleCuiPresenter) ActionLogOutput(g interfaces.ManilleGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/ManilleCuiPresenter_test.go
+++ b/internal/adapter/presenter/ManilleCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -136,6 +137,8 @@ func TestManilleCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "You plays ♠K"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewManillePlayer(true)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "play")
 }

--- a/internal/adapter/presenter/MaoCuiPresenter.go
+++ b/internal/adapter/presenter/MaoCuiPresenter.go
@@ -118,5 +118,5 @@ func (p *MaoCuiPresenter) Output(g interfaces.MaoGame, lastErr error) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *MaoCuiPresenter) ActionLogOutput(g interfaces.MaoGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.MaoPlayer](g)
 }

--- a/internal/adapter/presenter/MaoCuiPresenter_test.go
+++ b/internal/adapter/presenter/MaoCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -159,6 +160,8 @@ func TestMaoCuiPresenter_ActionLogOutput(t *testing.T) {
 	}
 	m.On("GetGameEndFlag").Return(true)
 	m.On("GetActionLog").Return(entries)
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewMaoPlayer(true)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "You plays SPADE 5")
 }

--- a/internal/adapter/presenter/MariasCuiPresenter.go
+++ b/internal/adapter/presenter/MariasCuiPresenter.go
@@ -162,5 +162,5 @@ var mariasHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *MariasCuiPresenter) ActionLogOutput(g interfaces.MariasGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.MariasPlayer](g)
 }

--- a/internal/adapter/presenter/MariasCuiPresenter.go
+++ b/internal/adapter/presenter/MariasCuiPresenter.go
@@ -162,5 +162,5 @@ var mariasHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *MariasCuiPresenter) ActionLogOutput(g interfaces.MariasGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/MariasCuiPresenter_test.go
+++ b/internal/adapter/presenter/MariasCuiPresenter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
@@ -141,6 +142,8 @@ func TestMariasCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "You plays ♠K"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewMariasPlayer(true)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "play")
 }

--- a/internal/adapter/presenter/MemoryCuiPresenter.go
+++ b/internal/adapter/presenter/MemoryCuiPresenter.go
@@ -127,5 +127,5 @@ func (p *MemoryCuiPresenter) Output(m interfaces.MemoryGame, lastErr error) stri
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *MemoryCuiPresenter) ActionLogOutput(m interfaces.MemoryGame) string {
-	return actionLogOutputText(m)
+	return actionLogOutputTextForSeats[*domain.MemoryPlayer](m)
 }

--- a/internal/adapter/presenter/MemoryCuiPresenter_test.go
+++ b/internal/adapter/presenter/MemoryCuiPresenter_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
@@ -328,6 +329,8 @@ func TestMemoryCuiPresenterActionLog(t *testing.T) {
 		mg.On("GetActionLog").Return([]*domain.ActionLogEntry{
 			{TurnNumber: 1, PlayerIdx: 0, ActionType: "match", Detail: "ペア獲得"},
 		})
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		mg.On("GetPlayer", mock.Anything).Return(domain.NewMemoryPlayer(true)).Maybe()
 
 		p := new(MemoryCuiPresenter)
 		result := p.ActionLogOutput(mg)
@@ -339,6 +342,8 @@ func TestMemoryCuiPresenterActionLog(t *testing.T) {
 		mg.On("GetGameEndFlag").Return(true)
 		var nilLog []*domain.ActionLogEntry
 		mg.On("GetActionLog").Return(nilLog)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		mg.On("GetPlayer", mock.Anything).Return(domain.NewMemoryPlayer(true)).Maybe()
 
 		p := new(MemoryCuiPresenter)
 		result := p.ActionLogOutput(mg)

--- a/internal/adapter/presenter/MendikotCuiPresenter.go
+++ b/internal/adapter/presenter/MendikotCuiPresenter.go
@@ -152,5 +152,5 @@ var mendikotHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *MendikotCuiPresenter) ActionLogOutput(m interfaces.MendikotGame) string {
-	return actionLogOutputTextWithNames(m, func(idx int) string { return cuiPlayerName(m.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.MendikotPlayer](m)
 }

--- a/internal/adapter/presenter/MendikotCuiPresenter.go
+++ b/internal/adapter/presenter/MendikotCuiPresenter.go
@@ -152,5 +152,5 @@ var mendikotHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *MendikotCuiPresenter) ActionLogOutput(m interfaces.MendikotGame) string {
-	return actionLogOutputText(m)
+	return actionLogOutputTextWithNames(m, func(idx int) string { return cuiPlayerName(m.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/MichiganCuiPresenter.go
+++ b/internal/adapter/presenter/MichiganCuiPresenter.go
@@ -211,5 +211,5 @@ func (p *MichiganCuiPresenter) HintOutput(g interfaces.MichiganGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *MichiganCuiPresenter) ActionLogOutput(g interfaces.MichiganGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.MichiganPlayer](g)
 }

--- a/internal/adapter/presenter/MightyCuiPresenter.go
+++ b/internal/adapter/presenter/MightyCuiPresenter.go
@@ -261,5 +261,5 @@ var mightyHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *MightyCuiPresenter) ActionLogOutput(m interfaces.MightyGame) string {
-	return actionLogOutputText(m)
+	return actionLogOutputTextWithNames(m, func(idx int) string { return cuiPlayerName(m.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/MightyCuiPresenter.go
+++ b/internal/adapter/presenter/MightyCuiPresenter.go
@@ -261,5 +261,5 @@ var mightyHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *MightyCuiPresenter) ActionLogOutput(m interfaces.MightyGame) string {
-	return actionLogOutputTextWithNames(m, func(idx int) string { return cuiPlayerName(m.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.MightyPlayer](m)
 }

--- a/internal/adapter/presenter/MightyCuiPresenter_test.go
+++ b/internal/adapter/presenter/MightyCuiPresenter_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -360,9 +361,12 @@ func TestMightyCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewMightyPlayer(true)).Maybe()
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜")
 		assert.Contains(t, result, "play")
+		assert.Contains(t, result, "あなた", "棋譜の座席名が他の行と揃っていない")
 	})
 
 	t.Run("game not ended", func(t *testing.T) {

--- a/internal/adapter/presenter/MinchiateCuiPresenter.go
+++ b/internal/adapter/presenter/MinchiateCuiPresenter.go
@@ -195,5 +195,5 @@ var minchiateHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *MinchiateCuiPresenter) ActionLogOutput(g interfaces.MinchiateGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/MinchiateCuiPresenter.go
+++ b/internal/adapter/presenter/MinchiateCuiPresenter.go
@@ -195,5 +195,5 @@ var minchiateHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *MinchiateCuiPresenter) ActionLogOutput(g interfaces.MinchiateGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.MinchiatePlayer](g)
 }

--- a/internal/adapter/presenter/MinchiateCuiPresenter_test.go
+++ b/internal/adapter/presenter/MinchiateCuiPresenter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -191,6 +192,8 @@ func TestMinchiateCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "You play Angelo"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewMinchiatePlayer(true)).Maybe()
 	assert.Contains(t, p.ActionLogOutput(m), "play")
 }
 

--- a/internal/adapter/presenter/MinibridgeCuiPresenter.go
+++ b/internal/adapter/presenter/MinibridgeCuiPresenter.go
@@ -183,5 +183,5 @@ var minibridgeHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *MinibridgeCuiPresenter) ActionLogOutput(s interfaces.MinibridgeGame) string {
-	return actionLogOutputText(s)
+	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/MinibridgeCuiPresenter.go
+++ b/internal/adapter/presenter/MinibridgeCuiPresenter.go
@@ -183,5 +183,5 @@ var minibridgeHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *MinibridgeCuiPresenter) ActionLogOutput(s interfaces.MinibridgeGame) string {
-	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.MinibridgePlayer](s)
 }

--- a/internal/adapter/presenter/MusCuiPresenter.go
+++ b/internal/adapter/presenter/MusCuiPresenter.go
@@ -243,5 +243,5 @@ var musHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *MusCuiPresenter) ActionLogOutput(g interfaces.MusGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.MusPlayer](g)
 }

--- a/internal/adapter/presenter/MusCuiPresenter_test.go
+++ b/internal/adapter/presenter/MusCuiPresenter_test.go
@@ -227,6 +227,8 @@ func TestMusCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "mus", Detail: "You wants mus"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewMusPlayer(true)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "mus")
 }

--- a/internal/adapter/presenter/MushiCuiPresenter.go
+++ b/internal/adapter/presenter/MushiCuiPresenter.go
@@ -151,5 +151,5 @@ var mushiHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *MushiCuiPresenter) ActionLogOutput(m interfaces.MushiGame) string {
-	return actionLogOutputText(m)
+	return actionLogOutputTextForSeats[*domain.MushiPlayer](m)
 }

--- a/internal/adapter/presenter/NainJauneCuiPresenter.go
+++ b/internal/adapter/presenter/NainJauneCuiPresenter.go
@@ -155,5 +155,5 @@ var nainJauneHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *NainJauneCuiPresenter) ActionLogOutput(c interfaces.NainJauneGame) string {
-	return actionLogOutputText(c)
+	return actionLogOutputTextForSeats[*domain.NainJaunePlayer](c)
 }

--- a/internal/adapter/presenter/NapCuiPresenter.go
+++ b/internal/adapter/presenter/NapCuiPresenter.go
@@ -198,5 +198,5 @@ var napHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *NapCuiPresenter) ActionLogOutput(g interfaces.NapGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.NapPlayer](g)
 }

--- a/internal/adapter/presenter/NapCuiPresenter.go
+++ b/internal/adapter/presenter/NapCuiPresenter.go
@@ -198,5 +198,5 @@ var napHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *NapCuiPresenter) ActionLogOutput(g interfaces.NapGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/NapCuiPresenter_test.go
+++ b/internal/adapter/presenter/NapCuiPresenter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -171,6 +172,8 @@ func TestNapCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "You plays ♠K"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewNapPlayer(true)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "play")
 }

--- a/internal/adapter/presenter/NapoleonCuiPresenter.go
+++ b/internal/adapter/presenter/NapoleonCuiPresenter.go
@@ -237,5 +237,5 @@ var napoleonHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *NapoleonCuiPresenter) ActionLogOutput(n interfaces.NapoleonGame) string {
-	return actionLogOutputText(n)
+	return actionLogOutputTextWithNames(n, func(idx int) string { return cuiPlayerName(n.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/NapoleonCuiPresenter.go
+++ b/internal/adapter/presenter/NapoleonCuiPresenter.go
@@ -237,5 +237,5 @@ var napoleonHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *NapoleonCuiPresenter) ActionLogOutput(n interfaces.NapoleonGame) string {
-	return actionLogOutputTextWithNames(n, func(idx int) string { return cuiPlayerName(n.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.NapoleonPlayer](n)
 }

--- a/internal/adapter/presenter/NapoleonCuiPresenter_test.go
+++ b/internal/adapter/presenter/NapoleonCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -365,10 +366,13 @@ func TestNapoleonCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewNapoleonPlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜")
 		assert.Contains(t, result, "play")
+		assert.Contains(t, result, "あなた", "棋譜の座席名が他の行と揃っていない")
 		assert.Contains(t, result, "played SPADE 5")
 		m.AssertExpectations(t)
 	})

--- a/internal/adapter/presenter/NinetyNineCuiPresenter.go
+++ b/internal/adapter/presenter/NinetyNineCuiPresenter.go
@@ -131,5 +131,5 @@ func (p *NinetyNineCuiPresenter) HintOutput(o interfaces.NinetyNineGame) string 
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *NinetyNineCuiPresenter) ActionLogOutput(o interfaces.NinetyNineGame) string {
-	return actionLogOutputTextWithNames(o, func(idx int) string { return cuiPlayerName(o.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.NinetyNinePlayer](o)
 }

--- a/internal/adapter/presenter/NinetyNineCuiPresenter.go
+++ b/internal/adapter/presenter/NinetyNineCuiPresenter.go
@@ -131,5 +131,5 @@ func (p *NinetyNineCuiPresenter) HintOutput(o interfaces.NinetyNineGame) string 
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *NinetyNineCuiPresenter) ActionLogOutput(o interfaces.NinetyNineGame) string {
-	return actionLogOutputText(o)
+	return actionLogOutputTextWithNames(o, func(idx int) string { return cuiPlayerName(o.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/OhHellCuiPresenter.go
+++ b/internal/adapter/presenter/OhHellCuiPresenter.go
@@ -162,5 +162,5 @@ func (p *OhHellCuiPresenter) HintOutput(o interfaces.OhHellGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *OhHellCuiPresenter) ActionLogOutput(o interfaces.OhHellGame) string {
-	return actionLogOutputText(o)
+	return actionLogOutputTextWithNames(o, func(idx int) string { return cuiPlayerName(o.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/OhHellCuiPresenter.go
+++ b/internal/adapter/presenter/OhHellCuiPresenter.go
@@ -162,5 +162,5 @@ func (p *OhHellCuiPresenter) HintOutput(o interfaces.OhHellGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *OhHellCuiPresenter) ActionLogOutput(o interfaces.OhHellGame) string {
-	return actionLogOutputTextWithNames(o, func(idx int) string { return cuiPlayerName(o.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.OhHellPlayer](o)
 }

--- a/internal/adapter/presenter/OldMaidCuiPresenter.go
+++ b/internal/adapter/presenter/OldMaidCuiPresenter.go
@@ -160,5 +160,5 @@ func (p *OldMaidCuiPresenter) Output(om interfaces.OldMaidGame, lastErr error) s
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *OldMaidCuiPresenter) ActionLogOutput(om interfaces.OldMaidGame) string {
-	return actionLogOutputText(om)
+	return actionLogOutputTextForSeats[*domain.OldMaidPlayer](om)
 }

--- a/internal/adapter/presenter/OldMaidCuiPresenter_test.go
+++ b/internal/adapter/presenter/OldMaidCuiPresenter_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 // setupOldMaidCuiTest creates an OldMaid game with standard CPU card setup (player[1] has HEART 5, players[2,3] finished).
@@ -492,6 +493,8 @@ func TestOldMaidCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		mockGame.On("GetGameEndFlag").Return(true)
 		mockGame.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		mockGame.On("GetPlayer", mock.Anything).Return(domain.NewOldMaidPlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(mockGame)
 
@@ -505,6 +508,8 @@ func TestOldMaidCuiPresenter_ActionLogOutput(t *testing.T) {
 		mockGame := new(interfaces.MockOldMaidGame)
 		mockGame.On("GetGameEndFlag").Return(true)
 		mockGame.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		mockGame.On("GetPlayer", mock.Anything).Return(domain.NewOldMaidPlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(mockGame)
 

--- a/internal/adapter/presenter/OmahaCuiPresenter.go
+++ b/internal/adapter/presenter/OmahaCuiPresenter.go
@@ -18,7 +18,7 @@ type OmahaCuiPresenter struct{}
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *OmahaCuiPresenter) ActionLogOutput(o interfaces.OmahaGame) string {
-	return actionLogOutputText(o)
+	return actionLogOutputTextForSeats[*domain.OmahaPlayer](o)
 }
 
 // omahaTitleKey は、ホールカード枚数 (4=オマハ, 5=Big O) と Hi-Lo フラグから

--- a/internal/adapter/presenter/OmahaCuiPresenter_test.go
+++ b/internal/adapter/presenter/OmahaCuiPresenter_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
@@ -714,6 +715,8 @@ func TestOmahaCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		mockGame.On("GetGameEndFlag").Return(true)
 		mockGame.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		mockGame.On("GetPlayer", mock.Anything).Return(domain.NewOmahaPlayer(true, domain.HoldemPlayStyle(0))).Maybe()
 
 		result := p.ActionLogOutput(mockGame)
 
@@ -727,6 +730,8 @@ func TestOmahaCuiPresenter_ActionLogOutput(t *testing.T) {
 		mockGame := new(interfaces.MockOmahaGame)
 		mockGame.On("GetGameEndFlag").Return(true)
 		mockGame.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		mockGame.On("GetPlayer", mock.Anything).Return(domain.NewOmahaPlayer(true, domain.HoldemPlayStyle(0))).Maybe()
 
 		result := p.ActionLogOutput(mockGame)
 

--- a/internal/adapter/presenter/OmbreCuiPresenter.go
+++ b/internal/adapter/presenter/OmbreCuiPresenter.go
@@ -221,5 +221,5 @@ var ombreHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *OmbreCuiPresenter) ActionLogOutput(g interfaces.OmbreGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/OmbreCuiPresenter.go
+++ b/internal/adapter/presenter/OmbreCuiPresenter.go
@@ -221,5 +221,5 @@ var ombreHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *OmbreCuiPresenter) ActionLogOutput(g interfaces.OmbreGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.OmbrePlayer](g)
 }

--- a/internal/adapter/presenter/OmbreCuiPresenter_test.go
+++ b/internal/adapter/presenter/OmbreCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -212,6 +213,8 @@ func TestOmbreCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "You plays ♠K"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewOmbrePlayer(true)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "play")
 }

--- a/internal/adapter/presenter/OpenFaceChineseCuiPresenter.go
+++ b/internal/adapter/presenter/OpenFaceChineseCuiPresenter.go
@@ -170,5 +170,5 @@ var openFaceChineseHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *OpenFaceChineseCuiPresenter) ActionLogOutput(g interfaces.OpenFaceChineseGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.OpenFaceChinesePlayer](g)
 }

--- a/internal/adapter/presenter/PageOneCuiPresenter.go
+++ b/internal/adapter/presenter/PageOneCuiPresenter.go
@@ -99,7 +99,7 @@ func (p *PageOneCuiPresenter) Output(g interfaces.PageOneGame, lastErr error) st
 
 // ActionLogOutput 棋譜をテキスト出力
 func (p *PageOneCuiPresenter) ActionLogOutput(g interfaces.PageOneGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.PageOnePlayer](g)
 }
 
 // HintOutput lists the human's playable card indices during the play phase, or

--- a/internal/adapter/presenter/PageOneCuiPresenter_test.go
+++ b/internal/adapter/presenter/PageOneCuiPresenter_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -159,6 +160,8 @@ func TestPageOneCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewPageOnePlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜")

--- a/internal/adapter/presenter/PanCuiPresenter.go
+++ b/internal/adapter/presenter/PanCuiPresenter.go
@@ -106,5 +106,5 @@ func (p *PanCuiPresenter) Output(g interfaces.PanGame, lastErr error) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *PanCuiPresenter) ActionLogOutput(g interfaces.PanGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.PanPlayer](g)
 }

--- a/internal/adapter/presenter/PasurCuiPresenter.go
+++ b/internal/adapter/presenter/PasurCuiPresenter.go
@@ -143,5 +143,5 @@ var pasurHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *PasurCuiPresenter) ActionLogOutput(s interfaces.PasurGame) string {
-	return actionLogOutputText(s)
+	return actionLogOutputTextForSeats[*domain.PasurPlayer](s)
 }

--- a/internal/adapter/presenter/PigCuiPresenter.go
+++ b/internal/adapter/presenter/PigCuiPresenter.go
@@ -139,5 +139,5 @@ var pigHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *PigCuiPresenter) ActionLogOutput(s interfaces.PigGame) string {
-	return actionLogOutputText(s)
+	return actionLogOutputTextForSeats[*domain.PigPlayer](s)
 }

--- a/internal/adapter/presenter/PigsTailCuiPresenter.go
+++ b/internal/adapter/presenter/PigsTailCuiPresenter.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain/interfaces"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
@@ -84,5 +85,5 @@ func (p *PigsTailCuiPresenter) Output(pt interfaces.PigsTailGame, lastErr error)
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *PigsTailCuiPresenter) ActionLogOutput(pt interfaces.PigsTailGame) string {
-	return actionLogOutputText(pt)
+	return actionLogOutputTextForSeats[*domain.PigsTailPlayer](pt)
 }

--- a/internal/adapter/presenter/PineappleCuiPresenter.go
+++ b/internal/adapter/presenter/PineappleCuiPresenter.go
@@ -31,7 +31,7 @@ type PineappleCuiPresenter struct{}
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (pp *PineappleCuiPresenter) ActionLogOutput(p interfaces.PineappleGame) string {
-	return actionLogOutputText(p)
+	return actionLogOutputTextForSeats[*domain.PineapplePlayer](p)
 }
 
 // Output renders the current game state for the active locale (#1699).

--- a/internal/adapter/presenter/PineappleCuiPresenter_test.go
+++ b/internal/adapter/presenter/PineappleCuiPresenter_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -425,6 +426,8 @@ func TestPineappleCuiPresenter_ActionLogOutput(t *testing.T) {
 		m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 			{TurnNumber: 1, PlayerIdx: 0, ActionType: "raise", Detail: "raise 30"},
 		})
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewPineapplePlayer(true, domain.HoldemPlayStyle(0))).Maybe()
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜")
 		assert.Contains(t, result, "raise")

--- a/internal/adapter/presenter/PinochleCuiPresenter.go
+++ b/internal/adapter/presenter/PinochleCuiPresenter.go
@@ -217,7 +217,7 @@ func (p *PinochleCuiPresenter) HintOutput(g interfaces.PinochleGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *PinochleCuiPresenter) ActionLogOutput(g interfaces.PinochleGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.PinochlePlayer](g)
 }
 
 // buildCuiMessage writes the per-phase prompt or end-of-game banner.

--- a/internal/adapter/presenter/PinochleCuiPresenter_test.go
+++ b/internal/adapter/presenter/PinochleCuiPresenter_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
@@ -296,6 +297,8 @@ func TestPinochleCuiPresenter_ActionLogOutput(t *testing.T) {
 		m := new(interfaces.MockPinochleGame)
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewPinochlePlayer(true, 0)).Maybe()
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜はありません")
 	})
@@ -307,6 +310,8 @@ func TestPinochleCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewPinochlePlayer(true, 0)).Maybe()
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜")
 		assert.Contains(t, result, "bid")

--- a/internal/adapter/presenter/PishtiCuiPresenter.go
+++ b/internal/adapter/presenter/PishtiCuiPresenter.go
@@ -119,5 +119,5 @@ func pishtiPlayerStr(pg interfaces.PishtiGame, player *domain.PishtiPlayer, i in
 
 // ActionLogOutput は棋譜をテキストとして出力する。
 func (p *PishtiCuiPresenter) ActionLogOutput(pg interfaces.PishtiGame) string {
-	return actionLogOutputText(pg)
+	return actionLogOutputTextForSeats[*domain.PishtiPlayer](pg)
 }

--- a/internal/adapter/presenter/PitchCuiPresenter.go
+++ b/internal/adapter/presenter/PitchCuiPresenter.go
@@ -190,7 +190,7 @@ var pitchHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *PitchCuiPresenter) ActionLogOutput(s interfaces.PitchGame) string {
-	return actionLogOutputText(s)
+	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
 }
 
 // writePitchHandPips は人間の手札のゲームピップ合計と内訳を書く。

--- a/internal/adapter/presenter/PitchCuiPresenter.go
+++ b/internal/adapter/presenter/PitchCuiPresenter.go
@@ -190,7 +190,7 @@ var pitchHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *PitchCuiPresenter) ActionLogOutput(s interfaces.PitchGame) string {
-	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.PitchPlayer](s)
 }
 
 // writePitchHandPips は人間の手札のゲームピップ合計と内訳を書く。

--- a/internal/adapter/presenter/PitchCuiPresenter_test.go
+++ b/internal/adapter/presenter/PitchCuiPresenter_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -161,6 +162,8 @@ func TestPitchCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "bid", Detail: "You bid 3"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewPitchPlayer(true)).Maybe()
 	out := p.ActionLogOutput(m)
 	assert.Contains(t, out, "You bid 3")
 }

--- a/internal/adapter/presenter/PochCuiPresenter.go
+++ b/internal/adapter/presenter/PochCuiPresenter.go
@@ -188,5 +188,5 @@ var pochHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *PochCuiPresenter) ActionLogOutput(c interfaces.PochGame) string {
-	return actionLogOutputText(c)
+	return actionLogOutputTextForSeats[*domain.PochPlayer](c)
 }

--- a/internal/adapter/presenter/PokerCuiPresenter.go
+++ b/internal/adapter/presenter/PokerCuiPresenter.go
@@ -172,7 +172,7 @@ func pokerPhaseName(phase int) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (pcp *PokerCuiPresenter) ActionLogOutput(p interfaces.PokerGame) string {
-	return actionLogOutputText(p)
+	return actionLogOutputTextForSeatList(p, p.GetPlayers())
 }
 
 // OutputWithOdds appends the draw-odds table to the standard Output.

--- a/internal/adapter/presenter/PokerCuiPresenter_test.go
+++ b/internal/adapter/presenter/PokerCuiPresenter_test.go
@@ -677,11 +677,15 @@ func TestPokerCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		mockGame.On("GetGameEndFlag").Return(true)
 		mockGame.On("GetActionLog").Return(entries)
+		mockGame.On("GetPlayers").Return([]*domain.PokerPlayer{domain.NewPokerPlayer(true, domain.PokerPlayStyle(0))}).Maybe()
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		mockGame.On("GetPlayers").Return([]*domain.PokerPlayer{domain.NewPokerPlayer(true, domain.PokerPlayStyle(0))}).Maybe()
 
 		result := p.ActionLogOutput(mockGame)
 
 		assert.Contains(t, result, "棋譜")
 		assert.Contains(t, result, "exchange")
+		assert.Contains(t, result, "あなた", "棋譜の座席名が他の行と揃っていない")
 		assert.Contains(t, result, "exchanged 2 cards")
 		mockGame.AssertExpectations(t)
 	})
@@ -690,6 +694,7 @@ func TestPokerCuiPresenter_ActionLogOutput(t *testing.T) {
 		mockGame := new(interfaces.MockPokerGame)
 		mockGame.On("GetGameEndFlag").Return(true)
 		mockGame.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+		mockGame.On("GetPlayers").Return([]*domain.PokerPlayer{domain.NewPokerPlayer(true, domain.PokerPlayStyle(0))}).Maybe()
 
 		result := p.ActionLogOutput(mockGame)
 
@@ -700,6 +705,7 @@ func TestPokerCuiPresenter_ActionLogOutput(t *testing.T) {
 	t.Run("game_not_ended", func(t *testing.T) {
 		mockGame := new(interfaces.MockPokerGame)
 		mockGame.On("GetGameEndFlag").Return(false)
+		mockGame.On("GetPlayers").Return([]*domain.PokerPlayer{domain.NewPokerPlayer(true, domain.PokerPlayStyle(0))}).Maybe()
 
 		result := p.ActionLogOutput(mockGame)
 

--- a/internal/adapter/presenter/PolignacCuiPresenter.go
+++ b/internal/adapter/presenter/PolignacCuiPresenter.go
@@ -134,5 +134,5 @@ var polignacHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *PolignacCuiPresenter) ActionLogOutput(g interfaces.PolignacGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.PolignacPlayer](g)
 }

--- a/internal/adapter/presenter/PolignacCuiPresenter.go
+++ b/internal/adapter/presenter/PolignacCuiPresenter.go
@@ -134,5 +134,5 @@ var polignacHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *PolignacCuiPresenter) ActionLogOutput(g interfaces.PolignacGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/PopeJoanCuiPresenter.go
+++ b/internal/adapter/presenter/PopeJoanCuiPresenter.go
@@ -163,5 +163,5 @@ var popeJoanHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *PopeJoanCuiPresenter) ActionLogOutput(c interfaces.PopeJoanGame) string {
-	return actionLogOutputText(c)
+	return actionLogOutputTextForSeats[*domain.PopeJoanPlayer](c)
 }

--- a/internal/adapter/presenter/PreferenceCuiPresenter.go
+++ b/internal/adapter/presenter/PreferenceCuiPresenter.go
@@ -227,5 +227,5 @@ var preferenceHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *PreferenceCuiPresenter) ActionLogOutput(g interfaces.PreferenceGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/PreferenceCuiPresenter.go
+++ b/internal/adapter/presenter/PreferenceCuiPresenter.go
@@ -227,5 +227,5 @@ var preferenceHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *PreferenceCuiPresenter) ActionLogOutput(g interfaces.PreferenceGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.PreferencePlayer](g)
 }

--- a/internal/adapter/presenter/PreferenceCuiPresenter_test.go
+++ b/internal/adapter/presenter/PreferenceCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -245,6 +246,8 @@ func TestPreferenceCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "You plays ♠K"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewPreferencePlayer(true)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "play")
 }

--- a/internal/adapter/presenter/PresidentCuiPresenter.go
+++ b/internal/adapter/presenter/PresidentCuiPresenter.go
@@ -139,5 +139,5 @@ func (p *PresidentCuiPresenter) HintOutput(pg interfaces.PresidentGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *PresidentCuiPresenter) ActionLogOutput(pg interfaces.PresidentGame) string {
-	return actionLogOutputText(pg)
+	return actionLogOutputTextForSeats[*domain.PresidentPlayer](pg)
 }

--- a/internal/adapter/presenter/PrimeroCuiPresenter.go
+++ b/internal/adapter/presenter/PrimeroCuiPresenter.go
@@ -159,5 +159,5 @@ func (p *PrimeroCuiPresenter) HintOutput(g interfaces.PrimeroGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *PrimeroCuiPresenter) ActionLogOutput(g interfaces.PrimeroGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.PrimeroPlayer](g)
 }

--- a/internal/adapter/presenter/PrsiCuiPresenter.go
+++ b/internal/adapter/presenter/PrsiCuiPresenter.go
@@ -113,5 +113,5 @@ func (p *PrsiCuiPresenter) Output(g interfaces.PrsiGame, lastErr error) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *PrsiCuiPresenter) ActionLogOutput(g interfaces.PrsiGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.PrsiPlayer](g)
 }

--- a/internal/adapter/presenter/PrsiCuiPresenter_test.go
+++ b/internal/adapter/presenter/PrsiCuiPresenter_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -164,6 +165,8 @@ func TestPrsiCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "plays SPADE 7"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewPrsiPlayer(true)).Maybe()
 	out := p.ActionLogOutput(m)
 	assert.Contains(t, out, "play")
 }

--- a/internal/adapter/presenter/RamsCuiPresenter.go
+++ b/internal/adapter/presenter/RamsCuiPresenter.go
@@ -145,5 +145,5 @@ var ramsHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *RamsCuiPresenter) ActionLogOutput(r interfaces.RamsGame) string {
-	return actionLogOutputTextWithNames(r, func(idx int) string { return cuiPlayerName(r.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.RamsPlayer](r)
 }

--- a/internal/adapter/presenter/RamsCuiPresenter.go
+++ b/internal/adapter/presenter/RamsCuiPresenter.go
@@ -145,5 +145,5 @@ var ramsHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *RamsCuiPresenter) ActionLogOutput(r interfaces.RamsGame) string {
-	return actionLogOutputText(r)
+	return actionLogOutputTextWithNames(r, func(idx int) string { return cuiPlayerName(r.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/ReversisCuiPresenter.go
+++ b/internal/adapter/presenter/ReversisCuiPresenter.go
@@ -139,5 +139,5 @@ var reversisHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ReversisCuiPresenter) ActionLogOutput(r interfaces.ReversisGame) string {
-	return actionLogOutputText(r)
+	return actionLogOutputTextWithNames(r, func(idx int) string { return cuiPlayerName(r.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/ReversisCuiPresenter.go
+++ b/internal/adapter/presenter/ReversisCuiPresenter.go
@@ -139,5 +139,5 @@ var reversisHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ReversisCuiPresenter) ActionLogOutput(r interfaces.ReversisGame) string {
-	return actionLogOutputTextWithNames(r, func(idx int) string { return cuiPlayerName(r.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.ReversisPlayer](r)
 }

--- a/internal/adapter/presenter/RollingStoneCuiPresenter.go
+++ b/internal/adapter/presenter/RollingStoneCuiPresenter.go
@@ -126,5 +126,5 @@ var rollingStoneHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *RollingStoneCuiPresenter) ActionLogOutput(s interfaces.RollingStoneGame) string {
-	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.RollingStonePlayer](s)
 }

--- a/internal/adapter/presenter/RollingStoneCuiPresenter.go
+++ b/internal/adapter/presenter/RollingStoneCuiPresenter.go
@@ -126,5 +126,5 @@ var rollingStoneHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *RollingStoneCuiPresenter) ActionLogOutput(s interfaces.RollingStoneGame) string {
-	return actionLogOutputText(s)
+	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/RookCuiPresenter.go
+++ b/internal/adapter/presenter/RookCuiPresenter.go
@@ -221,7 +221,7 @@ func (p *RookCuiPresenter) HintOutput(g interfaces.RookGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *RookCuiPresenter) ActionLogOutput(g interfaces.RookGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.RookPlayer](g)
 }
 
 // rookJoinInts formats an int slice as a space-separated string.

--- a/internal/adapter/presenter/RookCuiPresenter.go
+++ b/internal/adapter/presenter/RookCuiPresenter.go
@@ -221,7 +221,7 @@ func (p *RookCuiPresenter) HintOutput(g interfaces.RookGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *RookCuiPresenter) ActionLogOutput(g interfaces.RookGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }
 
 // rookJoinInts formats an int slice as a space-separated string.

--- a/internal/adapter/presenter/Rummy500CuiPresenter.go
+++ b/internal/adapter/presenter/Rummy500CuiPresenter.go
@@ -101,7 +101,7 @@ func (p *Rummy500CuiPresenter) Output(g interfaces.Rummy500Game, lastErr error) 
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *Rummy500CuiPresenter) ActionLogOutput(g interfaces.Rummy500Game) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.Rummy500Player](g)
 }
 
 // rummy500MeldCandidates returns up to `limit` index triples of the player's

--- a/internal/adapter/presenter/RussianBankCuiPresenter.go
+++ b/internal/adapter/presenter/RussianBankCuiPresenter.go
@@ -155,5 +155,5 @@ func rbHintSourceName(h *domain.RussianBankHint) string {
 
 // ActionLogOutput 棋譜をテキスト出力する。
 func (p *RussianBankCuiPresenter) ActionLogOutput(g interfaces.RussianBankGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.RussianBankPlayer](g)
 }

--- a/internal/adapter/presenter/SakuraCuiPresenter.go
+++ b/internal/adapter/presenter/SakuraCuiPresenter.go
@@ -164,5 +164,5 @@ var sakuraHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SakuraCuiPresenter) ActionLogOutput(g interfaces.SakuraGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.SakuraPlayer](g)
 }

--- a/internal/adapter/presenter/SambaCuiPresenter.go
+++ b/internal/adapter/presenter/SambaCuiPresenter.go
@@ -150,5 +150,5 @@ func (p *SambaCuiPresenter) Output(g interfaces.SambaGame, lastErr error) string
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SambaCuiPresenter) ActionLogOutput(g interfaces.SambaGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.SambaPlayer](g)
 }

--- a/internal/adapter/presenter/SambaCuiPresenter_test.go
+++ b/internal/adapter/presenter/SambaCuiPresenter_test.go
@@ -181,6 +181,8 @@ func TestSambaCuiPresenter_ActionLogOutput(t *testing.T) {
 		m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 			{TurnNumber: 1, PlayerIdx: 0, ActionType: "draw_stock", Detail: "drew"},
 		})
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewSambaPlayer(true, 0)).Maybe()
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "draw_stock")
 		m.AssertExpectations(t)

--- a/internal/adapter/presenter/ScartoCuiPresenter.go
+++ b/internal/adapter/presenter/ScartoCuiPresenter.go
@@ -260,5 +260,5 @@ var scartoHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ScartoCuiPresenter) ActionLogOutput(g interfaces.ScartoGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/ScartoCuiPresenter.go
+++ b/internal/adapter/presenter/ScartoCuiPresenter.go
@@ -260,5 +260,5 @@ var scartoHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ScartoCuiPresenter) ActionLogOutput(g interfaces.ScartoGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.ScartoPlayer](g)
 }

--- a/internal/adapter/presenter/SchnapsenCuiPresenter.go
+++ b/internal/adapter/presenter/SchnapsenCuiPresenter.go
@@ -167,5 +167,5 @@ var schnapsenHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SchnapsenCuiPresenter) ActionLogOutput(s interfaces.SchnapsenGame) string {
-	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.SchnapsenPlayer](s)
 }

--- a/internal/adapter/presenter/SchnapsenCuiPresenter.go
+++ b/internal/adapter/presenter/SchnapsenCuiPresenter.go
@@ -167,5 +167,5 @@ var schnapsenHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SchnapsenCuiPresenter) ActionLogOutput(s interfaces.SchnapsenGame) string {
-	return actionLogOutputText(s)
+	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/ScopaCuiPresenter.go
+++ b/internal/adapter/presenter/ScopaCuiPresenter.go
@@ -156,7 +156,7 @@ func (p *ScopaCuiPresenter) HintOutput(sg interfaces.ScopaGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ScopaCuiPresenter) ActionLogOutput(sg interfaces.ScopaGame) string {
-	return actionLogOutputText(sg)
+	return actionLogOutputTextForSeats[*domain.ScopaPlayer](sg)
 }
 
 // writeScopaBreakdown は直前ラウンドの得点内訳を書く。まだ1ラウンドも

--- a/internal/adapter/presenter/ScoponeCuiPresenter.go
+++ b/internal/adapter/presenter/ScoponeCuiPresenter.go
@@ -139,5 +139,5 @@ func (p *ScoponeCuiPresenter) HintOutput(sg interfaces.ScoponeGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ScoponeCuiPresenter) ActionLogOutput(sg interfaces.ScoponeGame) string {
-	return actionLogOutputText(sg)
+	return actionLogOutputTextForSeats[*domain.ScopaPlayer](sg)
 }

--- a/internal/adapter/presenter/SedmaCuiPresenter.go
+++ b/internal/adapter/presenter/SedmaCuiPresenter.go
@@ -135,5 +135,5 @@ var sedmaHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SedmaCuiPresenter) ActionLogOutput(g interfaces.SedmaGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/SedmaCuiPresenter.go
+++ b/internal/adapter/presenter/SedmaCuiPresenter.go
@@ -135,5 +135,5 @@ var sedmaHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SedmaCuiPresenter) ActionLogOutput(g interfaces.SedmaGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.SedmaPlayer](g)
 }

--- a/internal/adapter/presenter/SedmaCuiPresenter_test.go
+++ b/internal/adapter/presenter/SedmaCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -141,6 +142,8 @@ func TestSedmaCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "You plays ♠K"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewSedmaPlayer(true)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "play")
 }

--- a/internal/adapter/presenter/SergeantMajorCuiPresenter.go
+++ b/internal/adapter/presenter/SergeantMajorCuiPresenter.go
@@ -202,5 +202,5 @@ var sergeantMajorHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SergeantMajorCuiPresenter) ActionLogOutput(s interfaces.SergeantMajorGame) string {
-	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.SergeantMajorPlayer](s)
 }

--- a/internal/adapter/presenter/SergeantMajorCuiPresenter.go
+++ b/internal/adapter/presenter/SergeantMajorCuiPresenter.go
@@ -202,5 +202,5 @@ var sergeantMajorHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SergeantMajorCuiPresenter) ActionLogOutput(s interfaces.SergeantMajorGame) string {
-	return actionLogOutputText(s)
+	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/SevenBridgeCuiPresenter.go
+++ b/internal/adapter/presenter/SevenBridgeCuiPresenter.go
@@ -132,7 +132,7 @@ func (p *SevenBridgeCuiPresenter) HintOutput(g interfaces.SevenBridgeGame) strin
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SevenBridgeCuiPresenter) ActionLogOutput(g interfaces.SevenBridgeGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.SevenBridgePlayer](g)
 }
 
 // sevenBridgeDrawHint はドローフェーズの助言を返す。

--- a/internal/adapter/presenter/SevenBridgeCuiPresenter_test.go
+++ b/internal/adapter/presenter/SevenBridgeCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -233,6 +234,8 @@ func TestSevenBridgeCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewSevenBridgePlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "draw_stock")
@@ -243,6 +246,8 @@ func TestSevenBridgeCuiPresenter_ActionLogOutput(t *testing.T) {
 		m := new(interfaces.MockSevenBridgeGame)
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewSevenBridgePlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜はありません")

--- a/internal/adapter/presenter/SevenCardStudCuiPresenter.go
+++ b/internal/adapter/presenter/SevenCardStudCuiPresenter.go
@@ -18,7 +18,7 @@ type SevenCardStudCuiPresenter struct{}
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SevenCardStudCuiPresenter) ActionLogOutput(s interfaces.SevenCardStudGame) string {
-	return actionLogOutputText(s)
+	return actionLogOutputTextForSeats[*domain.SevenCardStudPlayer](s)
 }
 
 // Output renders the current game state for the active locale (#1699).

--- a/internal/adapter/presenter/SevenCardStudCuiPresenter_test.go
+++ b/internal/adapter/presenter/SevenCardStudCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -548,6 +549,8 @@ func TestSevenCardStudCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		mockGame.On("GetGameEndFlag").Return(true)
 		mockGame.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		mockGame.On("GetPlayer", mock.Anything).Return(domain.NewSevenCardStudPlayer(true, domain.SevenCardStudPlayStyle(0))).Maybe()
 
 		result := p.ActionLogOutput(mockGame)
 		assert.Contains(t, result, "棋譜")

--- a/internal/adapter/presenter/SevensCuiPresenter.go
+++ b/internal/adapter/presenter/SevensCuiPresenter.go
@@ -125,7 +125,7 @@ type SevensCuiPresenter struct{}
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SevensCuiPresenter) ActionLogOutput(s interfaces.SevensGame) string {
-	return actionLogOutputText(s)
+	return actionLogOutputTextForSeats[*domain.SevensPlayer](s)
 }
 
 // Output renders the current game state for the active locale (#1699).

--- a/internal/adapter/presenter/SevensCuiPresenter_test.go
+++ b/internal/adapter/presenter/SevensCuiPresenter_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func makeSevensPlayersForPresenter() []*domain.SevensPlayer {
@@ -569,6 +570,8 @@ func TestSevensCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		mockGame.On("GetGameEndFlag").Return(true)
 		mockGame.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		mockGame.On("GetPlayer", mock.Anything).Return(domain.NewSevensPlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(mockGame)
 
@@ -582,6 +585,8 @@ func TestSevensCuiPresenter_ActionLogOutput(t *testing.T) {
 		mockGame := new(interfaces.MockSevensGame)
 		mockGame.On("GetGameEndFlag").Return(true)
 		mockGame.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		mockGame.On("GetPlayer", mock.Anything).Return(domain.NewSevensPlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(mockGame)
 

--- a/internal/adapter/presenter/SheepsheadCuiPresenter.go
+++ b/internal/adapter/presenter/SheepsheadCuiPresenter.go
@@ -224,5 +224,5 @@ var sheepsheadHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SheepsheadCuiPresenter) ActionLogOutput(g interfaces.SheepsheadGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/SheepsheadCuiPresenter.go
+++ b/internal/adapter/presenter/SheepsheadCuiPresenter.go
@@ -224,5 +224,5 @@ var sheepsheadHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SheepsheadCuiPresenter) ActionLogOutput(g interfaces.SheepsheadGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.SheepsheadPlayer](g)
 }

--- a/internal/adapter/presenter/SheepsheadCuiPresenter_test.go
+++ b/internal/adapter/presenter/SheepsheadCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -255,6 +256,8 @@ func TestSheepsheadCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "pick", Detail: "You picks up the blind"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewSheepsheadPlayer(true, 0)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "pick")
 }

--- a/internal/adapter/presenter/ShelemCuiPresenter.go
+++ b/internal/adapter/presenter/ShelemCuiPresenter.go
@@ -202,5 +202,5 @@ var shelemHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ShelemCuiPresenter) ActionLogOutput(s interfaces.ShelemGame) string {
-	return actionLogOutputText(s)
+	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/ShelemCuiPresenter.go
+++ b/internal/adapter/presenter/ShelemCuiPresenter.go
@@ -202,5 +202,5 @@ var shelemHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ShelemCuiPresenter) ActionLogOutput(s interfaces.ShelemGame) string {
-	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.ShelemPlayer](s)
 }

--- a/internal/adapter/presenter/ShengJiCuiPresenter.go
+++ b/internal/adapter/presenter/ShengJiCuiPresenter.go
@@ -224,5 +224,5 @@ func (p *ShengJiCuiPresenter) writeHandEnd(b *strings.Builder, g interfaces.Shen
 
 // ActionLogOutput は棋譜をテキストで出力する。
 func (p *ShengJiCuiPresenter) ActionLogOutput(g interfaces.ShengJiGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.ShengJiPlayer](g)
 }

--- a/internal/adapter/presenter/ShitheadCuiPresenter.go
+++ b/internal/adapter/presenter/ShitheadCuiPresenter.go
@@ -193,5 +193,5 @@ func formatShitheadAction(sg interfaces.ShitheadGame, action *domain.ShitheadCpu
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ShitheadCuiPresenter) ActionLogOutput(sg interfaces.ShitheadGame) string {
-	return actionLogOutputText(sg)
+	return actionLogOutputTextForSeats[*domain.ShitheadPlayer](sg)
 }

--- a/internal/adapter/presenter/ShortDeckCuiPresenter.go
+++ b/internal/adapter/presenter/ShortDeckCuiPresenter.go
@@ -30,7 +30,7 @@ type ShortDeckCuiPresenter struct{}
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ShortDeckCuiPresenter) ActionLogOutput(o interfaces.ShortDeckGame) string {
-	return actionLogOutputText(o)
+	return actionLogOutputTextForSeats[*domain.ShortDeckPlayer](o)
 }
 
 // Output renders the current game state for the active locale (#1699).

--- a/internal/adapter/presenter/ShortDeckCuiPresenter_test.go
+++ b/internal/adapter/presenter/ShortDeckCuiPresenter_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -635,6 +636,8 @@ func TestShortDeckCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		mockGame.On("GetGameEndFlag").Return(true)
 		mockGame.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		mockGame.On("GetPlayer", mock.Anything).Return(domain.NewShortDeckPlayer(true, domain.HoldemPlayStyle(0))).Maybe()
 
 		result := p.ActionLogOutput(mockGame)
 
@@ -648,6 +651,8 @@ func TestShortDeckCuiPresenter_ActionLogOutput(t *testing.T) {
 		mockGame := new(interfaces.MockShortDeckGame)
 		mockGame.On("GetGameEndFlag").Return(true)
 		mockGame.On("GetActionLog").Return(([]*domain.ActionLogEntry)(nil))
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		mockGame.On("GetPlayer", mock.Anything).Return(domain.NewShortDeckPlayer(true, domain.HoldemPlayStyle(0))).Maybe()
 
 		result := p.ActionLogOutput(mockGame)
 

--- a/internal/adapter/presenter/SixBidSoloCuiPresenter.go
+++ b/internal/adapter/presenter/SixBidSoloCuiPresenter.go
@@ -235,5 +235,5 @@ func sixBidSoloLadderTarget(k domain.SixBidSoloBidKind) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SixBidSoloCuiPresenter) ActionLogOutput(g interfaces.SixBidSoloGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.SixBidSoloPlayer](g)
 }

--- a/internal/adapter/presenter/SixCardGolfCuiPresenter.go
+++ b/internal/adapter/presenter/SixCardGolfCuiPresenter.go
@@ -122,7 +122,9 @@ func scgPlayerName(player *domain.SixCardGolfPlayer, idx int) string {
 
 // ActionLogOutput 棋譜
 func (p *SixCardGolfCuiPresenter) ActionLogOutput(g interfaces.SixCardGolfGame) string {
-	return actionLogOutputText(g)
+	// 席は IsCpu しか持たないので cuiPlayerName は使えない。この画面の他の行と
+	// 同じ scgPlayerName を通す (#5977)。
+	return actionLogOutputTextNamedBy(g, func(idx int) string { return scgPlayerName(g.GetPlayer(idx), idx) })
 }
 
 // HintOutput recommends a draw source (PlayerTurn) or a swap/discard for the

--- a/internal/adapter/presenter/SjavsCuiPresenter.go
+++ b/internal/adapter/presenter/SjavsCuiPresenter.go
@@ -170,5 +170,5 @@ var sjavsHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SjavsCuiPresenter) ActionLogOutput(c interfaces.SjavsGame) string {
-	return actionLogOutputText(c)
+	return actionLogOutputTextForSeats[*domain.SjavsPlayer](c)
 }

--- a/internal/adapter/presenter/SkatCuiPresenter.go
+++ b/internal/adapter/presenter/SkatCuiPresenter.go
@@ -233,7 +233,7 @@ func (p *SkatCuiPresenter) HintOutput(s interfaces.SkatGame) string {
 
 // ActionLogOutput returns the round's action log as text.
 func (p *SkatCuiPresenter) ActionLogOutput(s interfaces.SkatGame) string {
-	return actionLogOutputText(s)
+	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
 }
 
 // skatGameTypeLabel returns the localized label for a Skat game type.

--- a/internal/adapter/presenter/SkatCuiPresenter.go
+++ b/internal/adapter/presenter/SkatCuiPresenter.go
@@ -233,7 +233,7 @@ func (p *SkatCuiPresenter) HintOutput(s interfaces.SkatGame) string {
 
 // ActionLogOutput returns the round's action log as text.
 func (p *SkatCuiPresenter) ActionLogOutput(s interfaces.SkatGame) string {
-	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.SkatPlayer](s)
 }
 
 // skatGameTypeLabel returns the localized label for a Skat game type.

--- a/internal/adapter/presenter/SkitgubbeCuiPresenter.go
+++ b/internal/adapter/presenter/SkitgubbeCuiPresenter.go
@@ -128,5 +128,5 @@ var skitgubbeHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SkitgubbeCuiPresenter) ActionLogOutput(c interfaces.SkitgubbeGame) string {
-	return actionLogOutputText(c)
+	return actionLogOutputTextForSeats[*domain.SkitgubbePlayer](c)
 }

--- a/internal/adapter/presenter/SlapjackCuiPresenter.go
+++ b/internal/adapter/presenter/SlapjackCuiPresenter.go
@@ -93,5 +93,5 @@ func (p *SlapjackCuiPresenter) Output(g interfaces.SlapjackGame, lastErr error) 
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SlapjackCuiPresenter) ActionLogOutput(g interfaces.SlapjackGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.SlapjackPlayer](g)
 }

--- a/internal/adapter/presenter/SlobberhannesCuiPresenter.go
+++ b/internal/adapter/presenter/SlobberhannesCuiPresenter.go
@@ -137,5 +137,5 @@ var slobberhannesHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SlobberhannesCuiPresenter) ActionLogOutput(s interfaces.SlobberhannesGame) string {
-	return actionLogOutputText(s)
+	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/SlobberhannesCuiPresenter.go
+++ b/internal/adapter/presenter/SlobberhannesCuiPresenter.go
@@ -137,5 +137,5 @@ var slobberhannesHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SlobberhannesCuiPresenter) ActionLogOutput(s interfaces.SlobberhannesGame) string {
-	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.SlobberhannesPlayer](s)
 }

--- a/internal/adapter/presenter/SnapCuiPresenter.go
+++ b/internal/adapter/presenter/SnapCuiPresenter.go
@@ -116,5 +116,5 @@ var snapHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SnapCuiPresenter) ActionLogOutput(s interfaces.SnapGame) string {
-	return actionLogOutputText(s)
+	return actionLogOutputTextForSeats[*domain.SnapPlayer](s)
 }

--- a/internal/adapter/presenter/SoloWhistCuiPresenter.go
+++ b/internal/adapter/presenter/SoloWhistCuiPresenter.go
@@ -214,5 +214,5 @@ var soloWhistHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SoloWhistCuiPresenter) ActionLogOutput(g interfaces.SoloWhistGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.SoloWhistPlayer](g)
 }

--- a/internal/adapter/presenter/SoloWhistCuiPresenter.go
+++ b/internal/adapter/presenter/SoloWhistCuiPresenter.go
@@ -214,5 +214,5 @@ var soloWhistHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SoloWhistCuiPresenter) ActionLogOutput(g interfaces.SoloWhistGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/SoloWhistCuiPresenter_test.go
+++ b/internal/adapter/presenter/SoloWhistCuiPresenter_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
@@ -161,6 +162,8 @@ func TestSoloWhistCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "You plays ♠K"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewSoloWhistPlayer(true)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "play")
 }

--- a/internal/adapter/presenter/SpadesCuiPresenter.go
+++ b/internal/adapter/presenter/SpadesCuiPresenter.go
@@ -150,5 +150,5 @@ var spadesHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SpadesCuiPresenter) ActionLogOutput(s interfaces.SpadesGame) string {
-	return actionLogOutputText(s)
+	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/SpadesCuiPresenter.go
+++ b/internal/adapter/presenter/SpadesCuiPresenter.go
@@ -150,5 +150,5 @@ var spadesHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SpadesCuiPresenter) ActionLogOutput(s interfaces.SpadesGame) string {
-	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.SpadesPlayer](s)
 }

--- a/internal/adapter/presenter/SpadesCuiPresenter_test.go
+++ b/internal/adapter/presenter/SpadesCuiPresenter_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -264,10 +265,13 @@ func TestSpadesCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewSpadesPlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜")
 		assert.Contains(t, result, "play")
+		assert.Contains(t, result, "あなた", "棋譜の座席名が他の行と揃っていない")
 		assert.Contains(t, result, "played SPADE 5")
 		m.AssertExpectations(t)
 	})

--- a/internal/adapter/presenter/SpeedCuiPresenter.go
+++ b/internal/adapter/presenter/SpeedCuiPresenter.go
@@ -101,5 +101,5 @@ func (p *SpeedCuiPresenter) Output(s interfaces.SpeedGame, lastErr error) string
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SpeedCuiPresenter) ActionLogOutput(s interfaces.SpeedGame) string {
-	return actionLogOutputText(s)
+	return actionLogOutputTextForSeats[*domain.SpeedPlayer](s)
 }

--- a/internal/adapter/presenter/SpoilFiveCuiPresenter.go
+++ b/internal/adapter/presenter/SpoilFiveCuiPresenter.go
@@ -150,7 +150,7 @@ var spoilFiveHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SpoilFiveCuiPresenter) ActionLogOutput(g interfaces.SpoilFiveGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }
 
 // writeSpoilFiveTopTrumps は固定序列を強い順に1行で書く。

--- a/internal/adapter/presenter/SpoilFiveCuiPresenter.go
+++ b/internal/adapter/presenter/SpoilFiveCuiPresenter.go
@@ -150,7 +150,7 @@ var spoilFiveHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SpoilFiveCuiPresenter) ActionLogOutput(g interfaces.SpoilFiveGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.SpoilFivePlayer](g)
 }
 
 // writeSpoilFiveTopTrumps は固定序列を強い順に1行で書く。

--- a/internal/adapter/presenter/SpoilFiveCuiPresenter_test.go
+++ b/internal/adapter/presenter/SpoilFiveCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -150,6 +151,8 @@ func TestSpoilFiveCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "You plays ♠K"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewSpoilFivePlayer(true)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "play")
 }

--- a/internal/adapter/presenter/SpoonsCuiPresenter.go
+++ b/internal/adapter/presenter/SpoonsCuiPresenter.go
@@ -93,7 +93,7 @@ func (p *SpoonsCuiPresenter) Output(g interfaces.SpoonsGame, lastErr error) stri
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SpoonsCuiPresenter) ActionLogOutput(g interfaces.SpoonsGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.SpoonsPlayer](g)
 }
 
 // spoonsLetters は文字数を "S-P-O-O-N-S" の取得済み接頭辞として表示する。

--- a/internal/adapter/presenter/StealingBundlesCuiPresenter.go
+++ b/internal/adapter/presenter/StealingBundlesCuiPresenter.go
@@ -161,5 +161,5 @@ var stealingBundlesHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *StealingBundlesCuiPresenter) ActionLogOutput(s interfaces.StealingBundlesGame) string {
-	return actionLogOutputText(s)
+	return actionLogOutputTextForSeats[*domain.StealingBundlesPlayer](s)
 }

--- a/internal/adapter/presenter/SuecaCuiPresenter.go
+++ b/internal/adapter/presenter/SuecaCuiPresenter.go
@@ -153,5 +153,5 @@ var suecaHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SuecaCuiPresenter) ActionLogOutput(g interfaces.SuecaGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/SuecaCuiPresenter.go
+++ b/internal/adapter/presenter/SuecaCuiPresenter.go
@@ -153,5 +153,5 @@ var suecaHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *SuecaCuiPresenter) ActionLogOutput(g interfaces.SuecaGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.SuecaPlayer](g)
 }

--- a/internal/adapter/presenter/SuecaCuiPresenter_test.go
+++ b/internal/adapter/presenter/SuecaCuiPresenter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -190,6 +191,8 @@ func TestSuecaCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "You plays ♠K"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewSuecaPlayer(true)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "play")
 }

--- a/internal/adapter/presenter/TablanetCuiPresenter.go
+++ b/internal/adapter/presenter/TablanetCuiPresenter.go
@@ -111,5 +111,5 @@ var tablanetHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TablanetCuiPresenter) ActionLogOutput(g interfaces.TablanetGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.TablanetPlayer](g)
 }

--- a/internal/adapter/presenter/TarabishCuiPresenter.go
+++ b/internal/adapter/presenter/TarabishCuiPresenter.go
@@ -186,5 +186,5 @@ var tarabishHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TarabishCuiPresenter) ActionLogOutput(t interfaces.TarabishGame) string {
-	return actionLogOutputText(t)
+	return actionLogOutputTextWithNames(t, func(idx int) string { return cuiPlayerName(t.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/TarabishCuiPresenter.go
+++ b/internal/adapter/presenter/TarabishCuiPresenter.go
@@ -186,5 +186,5 @@ var tarabishHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TarabishCuiPresenter) ActionLogOutput(t interfaces.TarabishGame) string {
-	return actionLogOutputTextWithNames(t, func(idx int) string { return cuiPlayerName(t.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.TarabishPlayer](t)
 }

--- a/internal/adapter/presenter/TarneebCuiPresenter.go
+++ b/internal/adapter/presenter/TarneebCuiPresenter.go
@@ -167,5 +167,5 @@ var tarneebHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TarneebCuiPresenter) ActionLogOutput(t interfaces.TarneebGame) string {
-	return actionLogOutputText(t)
+	return actionLogOutputTextWithNames(t, func(idx int) string { return cuiPlayerName(t.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/TarneebCuiPresenter.go
+++ b/internal/adapter/presenter/TarneebCuiPresenter.go
@@ -167,5 +167,5 @@ var tarneebHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TarneebCuiPresenter) ActionLogOutput(t interfaces.TarneebGame) string {
-	return actionLogOutputTextWithNames(t, func(idx int) string { return cuiPlayerName(t.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.TarneebPlayer](t)
 }

--- a/internal/adapter/presenter/TarocchiniCuiPresenter.go
+++ b/internal/adapter/presenter/TarocchiniCuiPresenter.go
@@ -206,5 +206,5 @@ var tarocchiniHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TarocchiniCuiPresenter) ActionLogOutput(g interfaces.TarocchiniGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.TarocchiniPlayer](g)
 }

--- a/internal/adapter/presenter/TarocchiniCuiPresenter.go
+++ b/internal/adapter/presenter/TarocchiniCuiPresenter.go
@@ -206,5 +206,5 @@ var tarocchiniHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TarocchiniCuiPresenter) ActionLogOutput(g interfaces.TarocchiniGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/TarocchiniCuiPresenter_test.go
+++ b/internal/adapter/presenter/TarocchiniCuiPresenter_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -193,6 +194,8 @@ func TestTarocchiniCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "You play Papa"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewTarocchiniPlayer(true)).Maybe()
 	assert.Contains(t, p.ActionLogOutput(m), "play")
 }
 

--- a/internal/adapter/presenter/TeenDoPaanchCuiPresenter.go
+++ b/internal/adapter/presenter/TeenDoPaanchCuiPresenter.go
@@ -175,5 +175,5 @@ var teenDoPaanchHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TeenDoPaanchCuiPresenter) ActionLogOutput(g interfaces.TeenDoPaanchGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.TeenDoPaanchPlayer](g)
 }

--- a/internal/adapter/presenter/TeenDoPaanchCuiPresenter.go
+++ b/internal/adapter/presenter/TeenDoPaanchCuiPresenter.go
@@ -175,5 +175,5 @@ var teenDoPaanchHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TeenDoPaanchCuiPresenter) ActionLogOutput(g interfaces.TeenDoPaanchGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/TeenPattiCuiPresenter.go
+++ b/internal/adapter/presenter/TeenPattiCuiPresenter.go
@@ -158,5 +158,5 @@ var teenPattiHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TeenPattiCuiPresenter) ActionLogOutput(g interfaces.TeenPattiGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.TeenPattiPlayer](g)
 }

--- a/internal/adapter/presenter/TeenPattiCuiPresenter_test.go
+++ b/internal/adapter/presenter/TeenPattiCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -240,6 +241,8 @@ func TestTeenPattiCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "bet", Detail: "You bets 1"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewTeenPattiPlayer(true, 0)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "bet")
 }

--- a/internal/adapter/presenter/ThirtyOneCuiPresenter.go
+++ b/internal/adapter/presenter/ThirtyOneCuiPresenter.go
@@ -131,7 +131,7 @@ func (p *ThirtyOneCuiPresenter) Output(g interfaces.ThirtyOneGame, lastErr error
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ThirtyOneCuiPresenter) ActionLogOutput(g interfaces.ThirtyOneGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.ThirtyOnePlayer](g)
 }
 
 // HintOutput emits the recommended move for the human player.

--- a/internal/adapter/presenter/ThirtyOneCuiPresenter_test.go
+++ b/internal/adapter/presenter/ThirtyOneCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -148,6 +149,8 @@ func TestThirtyOneCuiPresenter_ActionLogOutput(t *testing.T) {
 	}
 	m.On("GetGameEndFlag").Return(true)
 	m.On("GetActionLog").Return(entries)
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewThirtyOnePlayer(true)).Maybe()
 	assert.Contains(t, p.ActionLogOutput(m), "knock")
 }
 

--- a/internal/adapter/presenter/ThreeCardBragCuiPresenter.go
+++ b/internal/adapter/presenter/ThreeCardBragCuiPresenter.go
@@ -151,5 +151,5 @@ var threeCardBragHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ThreeCardBragCuiPresenter) ActionLogOutput(g interfaces.ThreeCardBragGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.ThreeCardBragPlayer](g)
 }

--- a/internal/adapter/presenter/ThreeCardBragCuiPresenter_test.go
+++ b/internal/adapter/presenter/ThreeCardBragCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -185,6 +186,8 @@ func TestThreeCardBragCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "bet", Detail: "You bets 1"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewThreeCardBragPlayer(true, 0)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "bet")
 }

--- a/internal/adapter/presenter/ThreeThirteenCuiPresenter.go
+++ b/internal/adapter/presenter/ThreeThirteenCuiPresenter.go
@@ -122,5 +122,5 @@ func (p *ThreeThirteenCuiPresenter) Output(g interfaces.ThreeThirteenGame, lastE
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ThreeThirteenCuiPresenter) ActionLogOutput(g interfaces.ThreeThirteenGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.ThreeThirteenPlayer](g)
 }

--- a/internal/adapter/presenter/TichuCuiPresenter.go
+++ b/internal/adapter/presenter/TichuCuiPresenter.go
@@ -80,7 +80,7 @@ func (p *TichuCuiPresenter) Output(tg interfaces.TichuGame, lastErr error) strin
 
 // ActionLogOutput 棋譜をCUI出力
 func (p *TichuCuiPresenter) ActionLogOutput(tg interfaces.TichuGame) string {
-	return actionLogOutputText(tg)
+	return actionLogOutputTextForSeats[*domain.TichuPlayer](tg)
 }
 
 func tichuPlayerStr(player *domain.TichuPlayer, idx int, bomb []int) string {

--- a/internal/adapter/presenter/TienLenCuiPresenter.go
+++ b/internal/adapter/presenter/TienLenCuiPresenter.go
@@ -107,7 +107,7 @@ func (p *TienLenCuiPresenter) Output(tg interfaces.TienLenGame, lastErr error) s
 
 // ActionLogOutput 棋譜を出力
 func (p *TienLenCuiPresenter) ActionLogOutput(tg interfaces.TienLenGame) string {
-	return actionLogOutputText(tg)
+	return actionLogOutputTextForSeats[*domain.TienLenPlayer](tg)
 }
 
 // HintOutput emits the recommended play for the human player.

--- a/internal/adapter/presenter/TienLenCuiPresenter_test.go
+++ b/internal/adapter/presenter/TienLenCuiPresenter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -141,6 +142,8 @@ func TestTienLenCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "played 1 card(s)"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewTienLenPlayer(true)).Maybe()
 	assert.Contains(t, p.ActionLogOutput(m), "play")
 }
 

--- a/internal/adapter/presenter/ToepenCuiPresenter.go
+++ b/internal/adapter/presenter/ToepenCuiPresenter.go
@@ -115,5 +115,5 @@ var toepenHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ToepenCuiPresenter) ActionLogOutput(t interfaces.ToepenGame) string {
-	return actionLogOutputText(t)
+	return actionLogOutputTextWithNames(t, func(idx int) string { return cuiPlayerName(t.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/ToepenCuiPresenter.go
+++ b/internal/adapter/presenter/ToepenCuiPresenter.go
@@ -115,5 +115,5 @@ var toepenHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ToepenCuiPresenter) ActionLogOutput(t interfaces.ToepenGame) string {
-	return actionLogOutputTextWithNames(t, func(idx int) string { return cuiPlayerName(t.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.ToepenPlayer](t)
 }

--- a/internal/adapter/presenter/TonkCuiPresenter.go
+++ b/internal/adapter/presenter/TonkCuiPresenter.go
@@ -169,5 +169,5 @@ func (p *TonkCuiPresenter) Output(g interfaces.TonkGame, lastErr error) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TonkCuiPresenter) ActionLogOutput(g interfaces.TonkGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.TonkPlayer](g)
 }

--- a/internal/adapter/presenter/TonkCuiPresenter_test.go
+++ b/internal/adapter/presenter/TonkCuiPresenter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -236,6 +237,8 @@ func TestTonkCuiPresenter_ActionLogOutput(t *testing.T) {
 		}
 		m.On("GetGameEndFlag").Return(true)
 		m.On("GetActionLog").Return(entries)
+		// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+		m.On("GetPlayer", mock.Anything).Return(domain.NewTonkPlayer(true)).Maybe()
 
 		result := p.ActionLogOutput(m)
 		assert.Contains(t, result, "棋譜")

--- a/internal/adapter/presenter/TressetteCuiPresenter.go
+++ b/internal/adapter/presenter/TressetteCuiPresenter.go
@@ -137,5 +137,5 @@ var tressetteHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TressetteCuiPresenter) ActionLogOutput(g interfaces.TressetteGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.TressettePlayer](g)
 }

--- a/internal/adapter/presenter/TressetteCuiPresenter.go
+++ b/internal/adapter/presenter/TressetteCuiPresenter.go
@@ -137,5 +137,5 @@ var tressetteHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TressetteCuiPresenter) ActionLogOutput(g interfaces.TressetteGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/TressetteCuiPresenter_test.go
+++ b/internal/adapter/presenter/TressetteCuiPresenter_test.go
@@ -130,6 +130,8 @@ func TestTressetteCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "plays ♠3"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewTressettePlayer(true)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "play")
 }

--- a/internal/adapter/presenter/TrexCuiPresenter.go
+++ b/internal/adapter/presenter/TrexCuiPresenter.go
@@ -204,5 +204,5 @@ var trexHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TrexCuiPresenter) ActionLogOutput(c interfaces.TrexGame) string {
-	return actionLogOutputText(c)
+	return actionLogOutputTextForSeats[*domain.TrexPlayer](c)
 }

--- a/internal/adapter/presenter/TrogguCuiPresenter.go
+++ b/internal/adapter/presenter/TrogguCuiPresenter.go
@@ -183,5 +183,5 @@ var trogguHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TrogguCuiPresenter) ActionLogOutput(g interfaces.TrogguGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/TrogguCuiPresenter.go
+++ b/internal/adapter/presenter/TrogguCuiPresenter.go
@@ -183,5 +183,5 @@ var trogguHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TrogguCuiPresenter) ActionLogOutput(g interfaces.TrogguGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.TrogguPlayer](g)
 }

--- a/internal/adapter/presenter/TrucoCuiPresenter.go
+++ b/internal/adapter/presenter/TrucoCuiPresenter.go
@@ -143,5 +143,5 @@ var trucoHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TrucoCuiPresenter) ActionLogOutput(g interfaces.TrucoGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/TrucoCuiPresenter.go
+++ b/internal/adapter/presenter/TrucoCuiPresenter.go
@@ -143,5 +143,5 @@ var trucoHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TrucoCuiPresenter) ActionLogOutput(g interfaces.TrucoGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.TrucoPlayer](g)
 }

--- a/internal/adapter/presenter/TuteCuiPresenter.go
+++ b/internal/adapter/presenter/TuteCuiPresenter.go
@@ -172,5 +172,5 @@ var tuteHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TuteCuiPresenter) ActionLogOutput(g interfaces.TuteGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/TuteCuiPresenter.go
+++ b/internal/adapter/presenter/TuteCuiPresenter.go
@@ -172,5 +172,5 @@ var tuteHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TuteCuiPresenter) ActionLogOutput(g interfaces.TuteGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.TutePlayer](g)
 }

--- a/internal/adapter/presenter/TuteCuiPresenter_test.go
+++ b/internal/adapter/presenter/TuteCuiPresenter_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -182,6 +183,8 @@ func TestTuteCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "You plays ♠K"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewTutePlayer(true)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "play")
 }

--- a/internal/adapter/presenter/TwentyNineCuiPresenter.go
+++ b/internal/adapter/presenter/TwentyNineCuiPresenter.go
@@ -237,5 +237,5 @@ var twentyNineHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TwentyNineCuiPresenter) ActionLogOutput(g interfaces.TwentyNineGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.TwentyNinePlayer](g)
 }

--- a/internal/adapter/presenter/TwentyNineCuiPresenter.go
+++ b/internal/adapter/presenter/TwentyNineCuiPresenter.go
@@ -237,5 +237,5 @@ var twentyNineHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TwentyNineCuiPresenter) ActionLogOutput(g interfaces.TwentyNineGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/TwentyNineCuiPresenter_test.go
+++ b/internal/adapter/presenter/TwentyNineCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -211,6 +212,8 @@ func TestTwentyNineCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "You plays ♠K"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewTwentyNinePlayer(true)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "play")
 }

--- a/internal/adapter/presenter/TwoTenJackCuiPresenter.go
+++ b/internal/adapter/presenter/TwoTenJackCuiPresenter.go
@@ -135,5 +135,5 @@ var twoTenJackHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TwoTenJackCuiPresenter) ActionLogOutput(s interfaces.TwoTenJackGame) string {
-	return actionLogOutputText(s)
+	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/TwoTenJackCuiPresenter.go
+++ b/internal/adapter/presenter/TwoTenJackCuiPresenter.go
@@ -135,5 +135,5 @@ var twoTenJackHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TwoTenJackCuiPresenter) ActionLogOutput(s interfaces.TwoTenJackGame) string {
-	return actionLogOutputTextWithNames(s, func(idx int) string { return cuiPlayerName(s.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.TwoTenJackPlayer](s)
 }

--- a/internal/adapter/presenter/TysiacCuiPresenter.go
+++ b/internal/adapter/presenter/TysiacCuiPresenter.go
@@ -187,5 +187,5 @@ var tysiacHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TysiacCuiPresenter) ActionLogOutput(g interfaces.TysiacGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/TysiacCuiPresenter.go
+++ b/internal/adapter/presenter/TysiacCuiPresenter.go
@@ -187,5 +187,5 @@ var tysiacHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *TysiacCuiPresenter) ActionLogOutput(g interfaces.TysiacGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.TysiacPlayer](g)
 }

--- a/internal/adapter/presenter/TysiacCuiPresenter_test.go
+++ b/internal/adapter/presenter/TysiacCuiPresenter_test.go
@@ -172,6 +172,8 @@ func TestTysiacCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "You plays ♠K"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewTysiacPlayer(true)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "play")
 }

--- a/internal/adapter/presenter/UltiCuiPresenter.go
+++ b/internal/adapter/presenter/UltiCuiPresenter.go
@@ -215,5 +215,5 @@ var ultiHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *UltiCuiPresenter) ActionLogOutput(g interfaces.UltiGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.UltiPlayer](g)
 }

--- a/internal/adapter/presenter/UltiCuiPresenter.go
+++ b/internal/adapter/presenter/UltiCuiPresenter.go
@@ -215,5 +215,5 @@ var ultiHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *UltiCuiPresenter) ActionLogOutput(g interfaces.UltiGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/UltiCuiPresenter_test.go
+++ b/internal/adapter/presenter/UltiCuiPresenter_test.go
@@ -162,6 +162,8 @@ func TestUltiCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "You plays ♠K"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewUltiPlayer(true)).Maybe()
 	result := p.ActionLogOutput(m)
 	assert.Contains(t, result, "play")
 }

--- a/internal/adapter/presenter/VintCuiPresenter.go
+++ b/internal/adapter/presenter/VintCuiPresenter.go
@@ -173,5 +173,5 @@ func vintLadderLine() string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *VintCuiPresenter) ActionLogOutput(g interfaces.VintGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.VintPlayer](g)
 }

--- a/internal/adapter/presenter/ViraCuiPresenter.go
+++ b/internal/adapter/presenter/ViraCuiPresenter.go
@@ -227,5 +227,5 @@ var viraHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ViraCuiPresenter) ActionLogOutput(g interfaces.ViraGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/ViraCuiPresenter.go
+++ b/internal/adapter/presenter/ViraCuiPresenter.go
@@ -227,5 +227,5 @@ var viraHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ViraCuiPresenter) ActionLogOutput(g interfaces.ViraGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.ViraPlayer](g)
 }

--- a/internal/adapter/presenter/ViraCuiPresenter_test.go
+++ b/internal/adapter/presenter/ViraCuiPresenter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -238,5 +239,7 @@ func TestViraCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "You plays ♠K"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewViraPlayer(true)).Maybe()
 	assert.Contains(t, p.ActionLogOutput(m), "play")
 }

--- a/internal/adapter/presenter/WarCuiPresenter.go
+++ b/internal/adapter/presenter/WarCuiPresenter.go
@@ -84,5 +84,5 @@ func (p *WarCuiPresenter) Output(w interfaces.WarGame, lastErr error) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *WarCuiPresenter) ActionLogOutput(w interfaces.WarGame) string {
-	return actionLogOutputText(w)
+	return actionLogOutputTextForSeats[*domain.WarPlayer](w)
 }

--- a/internal/adapter/presenter/WattenCuiPresenter.go
+++ b/internal/adapter/presenter/WattenCuiPresenter.go
@@ -195,5 +195,5 @@ func (p *WattenCuiPresenter) HintOutput(g interfaces.WattenGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *WattenCuiPresenter) ActionLogOutput(g interfaces.WattenGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.WattenPlayer](g)
 }

--- a/internal/adapter/presenter/WattenCuiPresenter.go
+++ b/internal/adapter/presenter/WattenCuiPresenter.go
@@ -195,5 +195,5 @@ func (p *WattenCuiPresenter) HintOutput(g interfaces.WattenGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *WattenCuiPresenter) ActionLogOutput(g interfaces.WattenGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/WhistCuiPresenter.go
+++ b/internal/adapter/presenter/WhistCuiPresenter.go
@@ -104,5 +104,5 @@ var whistHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *WhistCuiPresenter) ActionLogOutput(w interfaces.WhistGame) string {
-	return actionLogOutputText(w)
+	return actionLogOutputTextWithNames(w, func(idx int) string { return cuiPlayerName(w.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/WhistCuiPresenter.go
+++ b/internal/adapter/presenter/WhistCuiPresenter.go
@@ -104,5 +104,5 @@ var whistHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *WhistCuiPresenter) ActionLogOutput(w interfaces.WhistGame) string {
-	return actionLogOutputTextWithNames(w, func(idx int) string { return cuiPlayerName(w.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.WhistPlayer](w)
 }

--- a/internal/adapter/presenter/WizardCuiPresenter.go
+++ b/internal/adapter/presenter/WizardCuiPresenter.go
@@ -265,5 +265,5 @@ func (p *WizardCuiPresenter) HintOutput(o interfaces.WizardGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *WizardCuiPresenter) ActionLogOutput(o interfaces.WizardGame) string {
-	return actionLogOutputTextWithNames(o, func(idx int) string { return cuiPlayerName(o.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.WizardPlayer](o)
 }

--- a/internal/adapter/presenter/WizardCuiPresenter.go
+++ b/internal/adapter/presenter/WizardCuiPresenter.go
@@ -265,5 +265,5 @@ func (p *WizardCuiPresenter) HintOutput(o interfaces.WizardGame) string {
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *WizardCuiPresenter) ActionLogOutput(o interfaces.WizardGame) string {
-	return actionLogOutputText(o)
+	return actionLogOutputTextWithNames(o, func(idx int) string { return cuiPlayerName(o.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/YanivCuiPresenter.go
+++ b/internal/adapter/presenter/YanivCuiPresenter.go
@@ -107,5 +107,5 @@ func (p *YanivCuiPresenter) Output(g interfaces.YanivGame, lastErr error) string
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *YanivCuiPresenter) ActionLogOutput(g interfaces.YanivGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextForSeats[*domain.YanivPlayer](g)
 }

--- a/internal/adapter/presenter/YanivCuiPresenter_test.go
+++ b/internal/adapter/presenter/YanivCuiPresenter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -148,5 +149,7 @@ func TestYanivCuiPresenter_ActionLogOutput(t *testing.T) {
 	}
 	m.On("GetGameEndFlag").Return(true)
 	m.On("GetActionLog").Return(entries)
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewYanivPlayer(true)).Maybe()
 	assert.Contains(t, p.ActionLogOutput(m), "yaniv")
 }

--- a/internal/adapter/presenter/ZhengCuiPresenter.go
+++ b/internal/adapter/presenter/ZhengCuiPresenter.go
@@ -88,5 +88,5 @@ func (p *ZhengCuiPresenter) Output(zg interfaces.ZhengGame, lastErr error) strin
 
 // ActionLogOutput 棋譜を出力
 func (p *ZhengCuiPresenter) ActionLogOutput(zg interfaces.ZhengGame) string {
-	return actionLogOutputText(zg)
+	return actionLogOutputTextForSeats[*domain.ZhengPlayer](zg)
 }

--- a/internal/adapter/presenter/ZhengCuiPresenter_test.go
+++ b/internal/adapter/presenter/ZhengCuiPresenter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/presenter"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/color"
@@ -108,6 +109,8 @@ func TestZhengCuiPresenter_ActionLogOutput(t *testing.T) {
 	m.On("GetActionLog").Return([]*domain.ActionLogEntry{
 		{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "played 1 card(s)"},
 	})
+	// 棋譜の座席名は同じ画面の他の行と同じ解決を通る (#5977)。
+	m.On("GetPlayer", mock.Anything).Return(domain.NewZhengPlayer(true)).Maybe()
 	assert.Contains(t, p.ActionLogOutput(m), "play")
 }
 

--- a/internal/adapter/presenter/ZwanzigerrufenCuiPresenter.go
+++ b/internal/adapter/presenter/ZwanzigerrufenCuiPresenter.go
@@ -212,5 +212,5 @@ var zwanzigerrufenHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ZwanzigerrufenCuiPresenter) ActionLogOutput(g interfaces.ZwanzigerrufenGame) string {
-	return actionLogOutputText(g)
+	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
 }

--- a/internal/adapter/presenter/ZwanzigerrufenCuiPresenter.go
+++ b/internal/adapter/presenter/ZwanzigerrufenCuiPresenter.go
@@ -212,5 +212,5 @@ var zwanzigerrufenHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ZwanzigerrufenCuiPresenter) ActionLogOutput(g interfaces.ZwanzigerrufenGame) string {
-	return actionLogOutputTextWithNames(g, func(idx int) string { return cuiPlayerName(g.GetPlayer(idx), idx) })
+	return actionLogOutputTextForSeats[*domain.ZwanzigerrufenPlayer](g)
 }

--- a/internal/adapter/presenter/ZwickerCuiPresenter.go
+++ b/internal/adapter/presenter/ZwickerCuiPresenter.go
@@ -167,5 +167,5 @@ var zwickerHintReasonKeys = map[string]string{
 
 // ActionLogOutput emits the action-log transcript as plain text.
 func (p *ZwickerCuiPresenter) ActionLogOutput(c interfaces.ZwickerGame) string {
-	return actionLogOutputText(c)
+	return actionLogOutputTextForSeats[*domain.ZwickerPlayer](c)
 }

--- a/internal/adapter/presenter/action_log_helper.go
+++ b/internal/adapter/presenter/action_log_helper.go
@@ -34,6 +34,25 @@ func actionLogOutputTextWithNames(game gameEndLogger, nameOf func(idx int) strin
 	return actionLogToTextWithNames(game.GetActionLog(), nameOf)
 }
 
+// seatedGame is a game that can name the seat behind a log entry's PlayerIdx.
+type seatedGame[P cuiPlayer] interface {
+	gameEndLogger
+	GetPlayer(int) P
+}
+
+// actionLogOutputTextForSeats renders the transcript naming seats the way the
+// rest of the screen names them.
+//
+// **クロージャはここに 1 つだけ置く。**呼び出し側 86 ファイルにインラインで
+// 書くと、席名を引く行が「棋譜が空の局面しか見ていないテスト」では通らず、
+// 全ファイルが部分的に未到達として並ぶ。
+//
+// P は明示する (`actionLogOutputTextForSeats[*domain.XPlayer](g)`)。
+// メソッドの戻り値からの型推論は Go には無い。
+func actionLogOutputTextForSeats[P cuiPlayer, G seatedGame[P]](game G) string {
+	return actionLogOutputTextWithNames(game, func(idx int) string { return cuiPlayerName(game.GetPlayer(idx), idx) })
+}
+
 // actionLogOutputJSON returns the action log as JSON, or an empty log if the game is not finished.
 func actionLogOutputJSON(game gameEndLogger) string {
 	if !game.GetGameEndFlag() {

--- a/internal/adapter/presenter/action_log_helper.go
+++ b/internal/adapter/presenter/action_log_helper.go
@@ -2,10 +2,12 @@ package presenter
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/adapter/controller"
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 // gameEndLogger is a minimal interface satisfied by all game types that support action logs.
@@ -20,6 +22,16 @@ func actionLogOutputText(game gameEndLogger) string {
 		return actionLogToText(nil)
 	}
 	return actionLogToText(game.GetActionLog())
+}
+
+// actionLogOutputTextWithNames is actionLogOutputText with seat names resolved
+// by the caller, so the transcript calls the seats what the rest of the screen
+// calls them (#5977).
+func actionLogOutputTextWithNames(game gameEndLogger, nameOf func(idx int) string) string {
+	if !game.GetGameEndFlag() {
+		return actionLogToTextWithNames(nil, nameOf)
+	}
+	return actionLogToTextWithNames(game.GetActionLog(), nameOf)
 }
 
 // actionLogOutputJSON returns the action log as JSON, or an empty log if the game is not finished.
@@ -47,17 +59,35 @@ func actionLogToJSON(entries []*domain.ActionLogEntry) string {
 	return marshalOrError(out)
 }
 
-// actionLogToText 棋譜をテキスト形式に変換する
+// actionLogToText 棋譜をテキスト形式に変換する。
+//
+// 座席名は既定で "Player 0" 相当（Web GUI と同じ表記）。ゲーム側が席の一覧を
+// 持っているなら actionLogToTextWithNames で cuiPlayerName に寄せられる。
 func actionLogToText(entries []*domain.ActionLogEntry) string {
+	return actionLogToTextWithNames(entries, nil)
+}
+
+// actionLogToTextWithNames は座席名の解決を呼び出し側に委ねる版。
+//
+// **棋譜だけ呼称が食い違っていた。**同じ画面の他の行は cuiPlayerName 経由で
+// 「あなた」「CPU 1」と出すのに、棋譜は英語固定の "Player 0" だった (#5977)。
+// nameOf が nil か空文字を返した席は既定表記に落とす。
+func actionLogToTextWithNames(entries []*domain.ActionLogEntry, nameOf func(idx int) string) string {
 	if len(entries) == 0 {
-		return "棋譜はありません。\n"
+		return i18n.T("cuiActionLogEmpty") + "\n"
 	}
 	var sb strings.Builder
-	sb.WriteString("========== 棋譜 ==========\n")
+	sb.WriteString(i18n.T("cuiActionLogHeader") + "\n")
 	for _, e := range entries {
-		player := "SYSTEM"
+		player := i18n.T("cuiActionLogSystem")
 		if e.PlayerIdx >= 0 {
-			player = fmt.Sprintf("Player %d", e.PlayerIdx)
+			player = ""
+			if nameOf != nil {
+				player = nameOf(e.PlayerIdx)
+			}
+			if player == "" {
+				player = i18n.Tf("cuiActionLogPlayer", "idx", strconv.Itoa(e.PlayerIdx))
+			}
 		}
 		fmt.Fprintf(&sb, "T%d [%s] %s: %s", e.TurnNumber, player, e.ActionType, e.Detail)
 		if len(e.Cards) > 0 {

--- a/internal/adapter/presenter/action_log_helper.go
+++ b/internal/adapter/presenter/action_log_helper.go
@@ -53,6 +53,24 @@ func actionLogOutputTextForSeats[P cuiPlayer, G seatedGame[P]](game G) string {
 	return actionLogOutputTextWithNames(game, func(idx int) string { return cuiPlayerName(game.GetPlayer(idx), idx) })
 }
 
+// actionLogOutputTextForSeatList is actionLogOutputTextForSeats for the games
+// whose interface exposes the seats as a slice rather than by index.
+func actionLogOutputTextForSeatList[P cuiPlayer](game gameEndLogger, players []P) string {
+	return actionLogOutputTextWithNames(game, func(idx int) string {
+		if idx < 0 || idx >= len(players) {
+			return ""
+		}
+		return cuiPlayerName(players[idx], idx)
+	})
+}
+
+// actionLogOutputTextNamedBy is the escape hatch for the games whose seats do
+// not satisfy cuiPlayer (SixCardGolf's player carries IsCpu rather than
+// GetIsHuman) but that still have their own naming function.
+func actionLogOutputTextNamedBy(game gameEndLogger, nameOf func(idx int) string) string {
+	return actionLogOutputTextWithNames(game, nameOf)
+}
+
 // actionLogOutputJSON returns the action log as JSON, or an empty log if the game is not finished.
 func actionLogOutputJSON(game gameEndLogger) string {
 	if !game.GetGameEndFlag() {

--- a/internal/adapter/presenter/action_log_helper_test.go
+++ b/internal/adapter/presenter/action_log_helper_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yuta-yoshinaga/go_trumpcards/internal/domain"
+	"github.com/yuta-yoshinaga/go_trumpcards/internal/i18n"
 )
 
 // stubGameEndLogger is a test double for gameEndLogger.
@@ -24,7 +25,7 @@ func TestActionLogOutputText(t *testing.T) {
 	t.Run("game not ended returns empty log", func(t *testing.T) {
 		g := &stubGameEndLogger{ended: false}
 		result := actionLogOutputText(g)
-		assert.Equal(t, "棋譜はありません。\n", result)
+		assert.Equal(t, i18n.T("cuiActionLogEmpty")+"\n", result)
 	})
 
 	t.Run("game ended returns log", func(t *testing.T) {
@@ -36,7 +37,7 @@ func TestActionLogOutputText(t *testing.T) {
 		}
 		result := actionLogOutputText(g)
 		assert.Contains(t, result, "T1")
-		assert.Contains(t, result, "Player 0")
+		assert.Contains(t, result, i18n.Tf("cuiActionLogPlayer", "idx", "0"))
 	})
 }
 
@@ -109,12 +110,12 @@ func TestActionLogToJSON(t *testing.T) {
 func TestActionLogToText(t *testing.T) {
 	t.Run("empty entries", func(t *testing.T) {
 		result := actionLogToText([]*domain.ActionLogEntry{})
-		assert.Equal(t, "棋譜はありません。\n", result)
+		assert.Equal(t, i18n.T("cuiActionLogEmpty")+"\n", result)
 	})
 
 	t.Run("nil entries", func(t *testing.T) {
 		result := actionLogToText(nil)
-		assert.Equal(t, "棋譜はありません。\n", result)
+		assert.Equal(t, i18n.T("cuiActionLogEmpty")+"\n", result)
 	})
 
 	t.Run("entries with cards", func(t *testing.T) {
@@ -128,9 +129,9 @@ func TestActionLogToText(t *testing.T) {
 			},
 		}
 		result := actionLogToText(entries)
-		assert.Contains(t, result, "棋譜")
+		assert.Contains(t, result, i18n.T("cuiActionLogHeader"))
 		assert.Contains(t, result, "T1")
-		assert.Contains(t, result, "Player 0")
+		assert.Contains(t, result, i18n.Tf("cuiActionLogPlayer", "idx", "0"))
 		assert.Contains(t, result, "play")
 		assert.Contains(t, result, "played a card")
 		assert.Contains(t, result, "SPADE 5")
@@ -146,7 +147,7 @@ func TestActionLogToText(t *testing.T) {
 			},
 		}
 		result := actionLogToText(entries)
-		assert.Contains(t, result, "SYSTEM")
+		assert.Contains(t, result, i18n.T("cuiActionLogSystem"))
 		assert.Contains(t, result, "deal")
 		assert.Contains(t, result, "dealt cards")
 	})
@@ -161,10 +162,56 @@ func TestActionLogToText(t *testing.T) {
 			},
 		}
 		result := actionLogToText(entries)
-		assert.Contains(t, result, "Player 1")
+		assert.Contains(t, result, i18n.Tf("cuiActionLogPlayer", "idx", "1"))
 		assert.Contains(t, result, "pass: passed")
 		// No card bracket appended (only [Player X] and header brackets exist)
 		assert.NotContains(t, result, "SPADE")
 		assert.NotContains(t, result, "HEART")
+	})
+}
+
+// #5977: 棋譜だけ文字列が直書きで、`--lang en` でも日本語の見出しと
+// 「棋譜はありません。」が出ていた。座席名も他の行 (cuiPlayerName) が
+// 「あなた」「CPU 1」と出すのに対し、ここだけ英語固定の "Player 0" だった。
+func TestActionLogTextIsTranslated(t *testing.T) {
+	defer i18n.SetLang("ja")
+
+	t.Run("empty log and header follow the language", func(t *testing.T) {
+		i18n.SetLang("ja")
+		ja := actionLogToText(nil)
+		jaHeader := actionLogToText([]*domain.ActionLogEntry{{TurnNumber: 1, PlayerIdx: -1, ActionType: "deal"}})
+
+		i18n.SetLang("en")
+		en := actionLogToText(nil)
+		enHeader := actionLogToText([]*domain.ActionLogEntry{{TurnNumber: 1, PlayerIdx: -1, ActionType: "deal"}})
+
+		assert.NotEqual(t, ja, en, "空の棋譜が言語で変わらない")
+		assert.NotEqual(t, jaHeader, enHeader, "見出しが言語で変わらない")
+		// **キーがそのまま出ていないこと。**未定義キーは i18n.T がキー名を返す。
+		assert.NotContains(t, en, "cuiActionLog")
+		assert.NotContains(t, ja, "cuiActionLog")
+	})
+
+	t.Run("seat names match the rest of the screen", func(t *testing.T) {
+		i18n.SetLang("ja")
+		entries := []*domain.ActionLogEntry{
+			{TurnNumber: 1, PlayerIdx: 0, ActionType: "play", Detail: "出した"},
+			{TurnNumber: 2, PlayerIdx: 1, ActionType: "play", Detail: "出した"},
+		}
+		players := []*domain.AluettePlayer{domain.NewAluettePlayer(true), domain.NewAluettePlayer(false)}
+
+		result := actionLogToTextWithNames(entries, func(idx int) string {
+			return cuiPlayerName(players[idx], idx)
+		})
+		assert.Contains(t, result, i18n.T("cuiPlayerYou"))
+		assert.Contains(t, result, "CPU 1")
+		assert.NotContains(t, result, i18n.Tf("cuiActionLogPlayer", "idx", "0"))
+	})
+
+	t.Run("a seat the resolver does not know still renders", func(t *testing.T) {
+		i18n.SetLang("ja")
+		entries := []*domain.ActionLogEntry{{TurnNumber: 1, PlayerIdx: 9, ActionType: "play", Detail: "出した"}}
+		result := actionLogToTextWithNames(entries, func(int) string { return "" })
+		assert.Contains(t, result, "T1", "名前が引けなくても行そのものは出る")
 	})
 }

--- a/internal/i18n/locales/en/cui_common.json
+++ b/internal/i18n/locales/en/cui_common.json
@@ -52,5 +52,9 @@
   "sokoHandRank10": "Straight Flush",
   "sokoHandRank11": "Royal Flush",
   "cuiSolitaireUndoAvailable": "(u undoes one move)",
-  "cuiSolitaireUndoUnavailable": "(nothing to undo)"
+  "cuiSolitaireUndoUnavailable": "(nothing to undo)",
+  "cuiActionLogEmpty": "No actions recorded.",
+  "cuiActionLogHeader": "========== Action Log ==========",
+  "cuiActionLogSystem": "SYSTEM",
+  "cuiActionLogPlayer": "Player {{idx}}"
 }

--- a/internal/i18n/locales/ja/cui_common.json
+++ b/internal/i18n/locales/ja/cui_common.json
@@ -52,5 +52,9 @@
   "sokoHandRank10": "ストレートフラッシュ",
   "sokoHandRank11": "ロイヤルフラッシュ",
   "cuiSolitaireUndoAvailable": "（u で 1 手戻せます）",
-  "cuiSolitaireUndoUnavailable": "（戻せる手はありません）"
+  "cuiSolitaireUndoUnavailable": "（戻せる手はありません）",
+  "cuiActionLogEmpty": "棋譜はありません。",
+  "cuiActionLogHeader": "========== 棋譜 ==========",
+  "cuiActionLogSystem": "システム",
+  "cuiActionLogPlayer": "座席{{idx}}"
 }


### PR DESCRIPTION
Closes #5977

## 何が起きていたか

`internal/adapter/presenter/action_log_helper.go` は文字列を全部直書きしていた:

- `"棋譜はありません。\n"` / `"========== 棋譜 ==========\n"` — **日本語固定**。`--lang en` でも日本語が出る
- `fmt.Sprintf("Player %d", e.PlayerIdx)` / `"SYSTEM"` — **英語固定**。同じ画面の他の行は `cuiPlayerName` 経由で「あなた」「CPU 1」と出すので、**棋譜だけ呼称が食い違っていた**

`log` / `l` は全ゲームにあるので、影響はゲーム数ぶん。

## 変更点

1. `internal/i18n/locales/{ja,en}/cui_common.json` に 4 キー (`cuiActionLogEmpty` / `cuiActionLogHeader` / `cuiActionLogSystem` / `cuiActionLogPlayer`)。ja/en とも 58 キーで一致
2. `actionLogToTextWithNames(entries, nameOf)` / `actionLogOutputTextWithNames(game, nameOf)` を追加し、**座席名の解決を呼び出し側に委ねる**。`nameOf` が nil か空を返した席は翻訳済みの既定表記に落ちる
3. **席の一覧を持つ 86 presenter** を `cuiPlayerName(g.GetPlayer(idx), idx)` に寄せた。ソリティアなど席を持たないゲームは既定表記のまま

## テスト

**`action_log_helper_test.go`**（新規 3 本）
- 見出しと空メッセージが `SetLang("ja"/"en")` で**別の文字列になる**。さらに未定義キー由来の `cuiActionLog...` がそのまま出ていないことも見る（`i18n.T` は未定義キーでキー名を返すので、これが無いと「翻訳された」ことにならない）
- 座席名が `cuiPlayerName` と一致する（`あなた` / `CPU 1` が出て、`Player 0` は出ない）
- 解決関数が名前を返せない席でも行そのものは出る

既存の直値アサーション（`"棋譜はありません。"` / `"Player 0"` / `"SYSTEM"` / `"棋譜"`）は i18n 経由に置き換えた。

**presenter テスト 25 本**にモックの `GetPlayer` スタブを追加。うち 8 本は「あなた」と出ることまで見る（受け入れ条件 2 そのもの）。

### ミューテーション確認

| ミューテーション | 結果 |
|---|---|
| 解決関数を無視して常に既定表記にする | **14 failed** |
| 空メッセージを直書きに戻す | 2 failed |

## 検証

- `go test -tags test ./internal/...` 全パッケージ ok
- `golangci-lint run ./internal/...` 0 issues
- ja/en の `cui_common.json` はキー数・キー名とも一致