### PR TITLE
test(e2e): give the deal-time waits a budget a loaded runner can meet

### DIFF
--- a/frontend/e2e/blackjack.spec.ts
+++ b/frontend/e2e/blackjack.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, waitForLoaded } from './helpers';
+import { isVisibleWithin, navigateTo, TIMEOUT_ACTION, TIMEOUT_GAME_LOOP, waitForLoaded } from './helpers';
 
 test.describe('BlackJack E2E', () => {
   test('plays a round: bet → stand → result', async ({ page }) => {
@@ -25,7 +25,10 @@ test.describe('BlackJack E2E', () => {
     // one (#6063).
     const standButton = page.getByRole('button', { name: 'スタンド' });
     const resetButton = page.getByRole('button', { name: '次のゲーム' });
-    await expect(standButton.or(resetButton).first()).toBeVisible({ timeout: 5_000 });
+    // **配り直後の遷移にはサーバー往復が乗る。**5 秒は負荷の高いランナーでは
+    // 足りず、Blackjack と無関係な PR で 2 回落ちている (#6181)。どちらの回も
+    // 同じシャードの別 spec も一緒に落ちていた。
+    await expect(standButton.or(resetButton).first()).toBeVisible({ timeout: TIMEOUT_GAME_LOOP });
 
     if (await standButton.isVisible()) {
       await standButton.click();
@@ -33,6 +36,6 @@ test.describe('BlackJack E2E', () => {
     }
 
     // END phase: 次のゲーム button should be visible either way
-    await expect(resetButton).toBeVisible({ timeout: 10_000 });
+    await expect(resetButton).toBeVisible({ timeout: TIMEOUT_GAME_LOOP });
   });
 });

--- a/frontend/e2e/crazyeights.spec.ts
+++ b/frontend/e2e/crazyeights.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { isVisibleWithin, navigateTo, waitForLoaded } from './helpers';
+import { isVisibleWithin, navigateTo, TIMEOUT_GAME_LOOP, TIMEOUT_LOADED, waitForLoaded } from './helpers';
 
 test.describe('Crazy Eights E2E', () => {
   test('navigates, resets, and plays through phase transitions', async ({ page }) => {
@@ -37,9 +37,13 @@ test.describe('Crazy Eights E2E', () => {
       // リクエストの中で完結するので、保留中の更新が無ければ画面はもう変わらない。
       // 出なければ待ち続けずに切り上げる。最後の「1 回は操作した」と
       // 「リセットでラウンドが始まり直す」が、この test の本来の主張。
+      // **最初の 1 回だけ予算を長く取る。**ここには盤面の初回描画とリセット直後の
+      // 往復が乗るので、負荷の高いランナーでは 10 秒では足りず、1 度も操作しない
+      // まま抜けて `interactions > 0` が落ちていた (#6031 の続き。4 回とも
+      // Crazy Eights と無関係な PR で、同じシャードの別 spec も一緒に落ちている)。
       const actionAppeared = await isVisibleWithin(
         playButton.or(drawButton).or(nextRoundButton).or(suitSpade).or(endResetButton).first(),
-        10_000,
+        turn === 0 ? TIMEOUT_LOADED : TIMEOUT_GAME_LOOP,
       );
       if (!actionAppeared) break;
 


### PR DESCRIPTION
Closes #6181

`.claude/.flake-ledger.jsonl` で確認した 2 件のフレークです。**6 回とも当該ゲームと無関係な PR**で、うち 3 回は同じシャードの別 spec も一緒に落ちています ── つまり配りではなく**ランナーの詰まり**が引き金です。

| spec | 回数 | 落ちる行 |
|---|---|---|
| `crazyeights.spec.ts` | 4 | `expect(interactions).toBeGreaterThan(0)` |
| `blackjack.spec.ts` | 2 | 配り直後の「スタンド か 次のゲーム」の `toBeVisible` |

## Crazy Eights

`interactions > 0` が落ちるのは、**ループの 1 周目で操作ボタンが 1 つも現れなかったとき**だけです（2 周目以降で break してもテストは通る）。1 周目は「リセット直後の往復 + 盤面の初回描画」を含むのに、予算が 2 周目以降と同じ 10 秒でした。`Reset` は `currentPlayerIdx = 0`（人間の席）にするので、本来はすぐ「出す / 引く」が出る場面です。

→ **1 周目だけ** `TIMEOUT_LOADED` (30 秒)、2 周目以降は従来どおり `TIMEOUT_GAME_LOOP` (10 秒)。

## Blackjack

配り直後の「スタンドか次のゲームのどちらかが出る」にサーバー往復が乗るのに、予算が 5 秒でした。→ `TIMEOUT_GAME_LOOP` (10 秒)。ついでに裸の `5_000` / `10_000` を名前付き定数に寄せています。

## 無条件には伸ばしていません

伸ばしたのは **初回 / 配り直後の 1 箇所ずつ**だけです。ループの 2 周目以降の break は元から想定された終了条件で、30 秒待っても操作できない状態は本物の不具合として落ちてほしいためです。

## 検証

- `bun run typecheck` / biome clean
- E2E は CI で回ります（このシャードの他の spec も含めて）