### PR TITLE
fix(ramsch): resolve the hint reason instead of printing its identifier

### DIFF
--- a/frontend/src/i18n/locales/en/ramsch.json
+++ b/frontend/src/i18n/locales/en/ramsch.json
@@ -34,7 +34,9 @@
   "skatLabel": "Skat (goes to whoever wins the last trick)",
   "loserBadge": "most points — loses",
   "durchmarschBadge": "Durchmarsch",
-  "hintReasonAvoidPoints": "duck with a card worth nothing and take no points",
-  "hintReasonLeadLow": "lead something cheap so you do not put points on the table",
-  "hintReasonForcedDiscard": "only point cards are legal here, so give up the cheapest"
+  "hint": {
+    "avoid_points": "duck with a card worth nothing and take no points",
+    "lead_low": "lead something cheap so you do not put points on the table",
+    "forced_discard": "only point cards are legal here, so give up the cheapest"
+  }
 }

--- a/frontend/src/i18n/locales/ja/ramsch.json
+++ b/frontend/src/i18n/locales/ja/ramsch.json
@@ -34,7 +34,9 @@
   "skatLabel": "伏せ札（最終トリックの獲得者が受け取ります）",
   "loserBadge": "最多・失点",
   "durchmarschBadge": "Durchmarsch",
-  "hintReasonAvoidPoints": "点の無い札で降りて、失点を避けます",
-  "hintReasonLeadLow": "自分から点を出さないよう、安い札でリードします",
-  "hintReasonForcedDiscard": "点札しか出せないので、いちばん安く済ませます"
+  "hint": {
+    "avoid_points": "点の無い札で降りて、失点を避けます",
+    "lead_low": "自分から点を出さないよう、安い札でリードします",
+    "forced_discard": "点札しか出せないので、いちばん安く済ませます"
+  }
 }

--- a/frontend/src/utils/hints/ramschHint.test.ts
+++ b/frontend/src/utils/hints/ramschHint.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import i18n from '../../i18n';
+import type { RamschResponse } from '../../types/card';
+import { RamschPhase } from '../../types/phases';
+import { getRamschHint } from './ramschHint';
+
+const state = (overrides: Partial<RamschResponse> = {}): RamschResponse =>
+  ({
+    players: [],
+    phase: RamschPhase.PLAY,
+    gameEndFlag: false,
+    hint: { cardIndex: 2, reason: 'avoid_points' },
+    ...overrides,
+  }) as RamschResponse;
+
+describe('getRamschHint', () => {
+  it('points at the card the backend chose', () => {
+    const hint = getRamschHint(state());
+    expect(hint?.targetPos).toBe(2);
+    expect(hint?.targetAction).toBe('play');
+  });
+
+  // **理由キーが実際に翻訳へ解決すること。**
+  //
+  // `ramsch:avoid_points` と書いていたときは、i18next の nsSeparator (既定 ':')
+  // が効いて「名前空間 ramsch のキー avoid_points」を探しに行き、そんなキーは
+  // 無いので**生の識別子がそのままツールチップに出ていた**。
+  // 「文字列が返る」ことだけを見るテストでは通ってしまう。
+  it.each(['avoid_points', 'lead_low', 'forced_discard'])('resolves the reason %s to real text', (reason) => {
+    const hint = getRamschHint(state({ hint: { cardIndex: 0, reason } }));
+    const key = hint?.reason ?? '';
+    const text = i18n.t(key, { ns: 'ramsch' });
+
+    expect(text).not.toBe(key);
+    expect(text).not.toContain(reason);
+    expect(text.length).toBeGreaterThan(4);
+  });
+
+  // **負のコントロール**: 存在しない理由なら解決せず、キーがそのまま返る。
+  // 上の assert が「何でも通る」わけではないことを示す。
+  it('leaves an unknown reason unresolved', () => {
+    const hint = getRamschHint(state({ hint: { cardIndex: 0, reason: 'no_such_reason' } }));
+    const key = hint?.reason ?? '';
+    expect(i18n.t(key, { ns: 'ramsch' })).toBe(key);
+  });
+
+  it('stays quiet once the hand is over or with no hint', () => {
+    expect(getRamschHint(state({ gameEndFlag: true }))).toBeNull();
+    expect(getRamschHint(state({ hint: undefined }))).toBeNull();
+    expect(getRamschHint(state({ phase: RamschPhase.ROUND_END }))).toBeNull();
+    expect(getRamschHint(state({ hint: { reason: 'avoid_points' } }))).toBeNull();
+  });
+});

--- a/frontend/src/utils/hints/ramschHint.ts
+++ b/frontend/src/utils/hints/ramschHint.ts
@@ -20,7 +20,10 @@ export function getRamschHint(state: RamschResponse): HintResult | null {
 
   return {
     targetAction: 'play',
-    reason: state.hint.reason ? `ramsch:${state.hint.reason}` : 'ramsch:hintReasonAvoidPoints',
+    // **`hint.<reason>` の形にする。** `ns:key` と書くと i18next の
+    // nsSeparator (既定 ':') が効いて名前空間解決になり、キーが見つからず
+    // 生の識別子 (`avoid_points`) がそのままツールチップに出る。
+    reason: `hint.${state.hint.reason || 'avoid_points'}`,
     confidence: 'moderate',
     targetPos: state.hint.cardIndex,
   };


### PR DESCRIPTION
Ramsch's hint tooltip has been printing `avoid_points` at the user since #6202 merged.

## What happened

The hint factory built its reason as `` `ramsch:${reason}` ``. i18next's default `nsSeparator` is `:`, so that is parsed as **namespace `ramsch`, key `avoid_points`** — and no such key exists, because the locale file spells them `hintReasonAvoidPoints`.

| | |
|---|---|
| Go emits | `avoid_points`, `lead_low`, `forced_discard` |
| Frontend asked for | `ramsch:avoid_points` → ns `ramsch`, key `avoid_points` |
| Locale file had | `hintReasonAvoidPoints`, `hintReasonLeadLow`, `hintReasonForcedDiscard` |

So the tooltip showed the raw identifier and all three reason strings were dead.

## How it was found

While fixing the **identical** mistake in Seven Twenty-Seven (#6203) — I made it twice in a row. A sweep of every hint factory shows those two were the only ones using the `ns:key` form; the other ~120 call sites use `hint.${...}` or `hintReason.${...}`.

## The fix

`` `hint.${reason}` `` with a nested `hint` object keyed by the snake_case reason the backend actually emits, matching Guts and the rest of the repo.

## Why the test is shaped the way it is

**Asserting that a string comes back passes against this bug** — a raw identifier is a perfectly good string. The test asserts the reason **resolves to real text**:

```ts
const text = i18n.t(hint.reason, { ns: 'ramsch' });
expect(text).not.toBe(key);       // i18next returns the key on a miss
expect(text).not.toContain(reason); // and the raw identifier is not the answer
```

with a **negative control** showing an unknown reason still comes back unresolved, so the assertion is not vacuous.

Reinstating the `ns:key` form fails **4 of its 6 cases**.

## Test plan

- [x] `bun run typecheck` / `bun run check`
- [x] Vitest — 6 tests, mutation-verified against the shipped bug
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)